### PR TITLE
Add latest tag to docker images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -48,4 +48,5 @@ steps:
         from_secret: DOCKER_PASSWORD
       repo: xbapps/xbvr
       auto_tag: true
+      tags: latest
       build_args: DRONE_TAG=${DRONE_TAG}


### PR DESCRIPTION
Drone will merge the auto-generated tags and tags. Since we aren't using event:push to push a new image and we are using event:tag to push new images auto_tag doesn't apply the :latest tag automatically.