### PR TITLE
Fix r18

### DIFF
--- a/pkg/scrape/r18.go
+++ b/pkg/scrape/r18.go
@@ -80,10 +80,23 @@ func ScrapeR18(knownScenes []string, out *[]models.ScrapedScene, queryString str
 		})
 
 		// Scene ID
+    var contentID string
+		e.ForEach(`div.product-details dt:contains("Content ID")+dd`, func(id int, e *colly.HTMLElement) {
+			contentID = strings.TrimSpace(e.Text)
+    })
+
+    var dvdID string
 		e.ForEach(`div.product-details dt:contains("DVD ID")+dd`, func(id int, e *colly.HTMLElement) {
-			sc.SceneID = strings.TrimSpace(e.Text)
-			sc.SiteID = strings.TrimSpace(e.Text)
+      dvdID = strings.TrimSpace(e.Text)
 		})
+
+  	if dvdID == "----" {
+      sc.SceneID = contentID
+  	  sc.SiteID = contentID
+    } else {
+      sc.SceneID = dvdID
+      sc.SiteID = dvdID
+    }
 
 		sc.Tags = append(sc.Tags, "JAVR")
 		*out = append(*out, sc)
@@ -92,7 +105,7 @@ func ScrapeR18(knownScenes []string, out *[]models.ScrapedScene, queryString str
 	siteCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sceneURL := ""
 
-		e.ForEach(`ul.cmn-list-product01 li a`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`li.item-list a:not([class])`, func(id int, e *colly.HTMLElement) {
 			if id == 0 {
 				sceneURL = strings.Split(e.Attr("href"), "?")[0]
 			} else {

--- a/pkg/scrape/r18.go
+++ b/pkg/scrape/r18.go
@@ -80,23 +80,23 @@ func ScrapeR18(knownScenes []string, out *[]models.ScrapedScene, queryString str
 		})
 
 		// Scene ID
-    var contentID string
+		var contentID string
 		e.ForEach(`div.product-details dt:contains("Content ID")+dd`, func(id int, e *colly.HTMLElement) {
 			contentID = strings.TrimSpace(e.Text)
-    })
-
-    var dvdID string
-		e.ForEach(`div.product-details dt:contains("DVD ID")+dd`, func(id int, e *colly.HTMLElement) {
-      dvdID = strings.TrimSpace(e.Text)
 		})
 
-  	if dvdID == "----" {
-      sc.SceneID = contentID
-  	  sc.SiteID = contentID
-    } else {
-      sc.SceneID = dvdID
-      sc.SiteID = dvdID
-    }
+		var dvdID string
+		e.ForEach(`div.product-details dt:contains("DVD ID")+dd`, func(id int, e *colly.HTMLElement) {
+			dvdID = strings.TrimSpace(e.Text)
+		})
+
+		if dvdID == "----" {
+			sc.SceneID = contentID
+			sc.SiteID = contentID
+		} else {
+			sc.SceneID = dvdID
+			sc.SiteID = dvdID
+		}
 
 		sc.Tags = append(sc.Tags, "JAVR")
 		*out = append(*out, sc)


### PR DESCRIPTION
This fixes the selector used when searching for a "dvd id", as well as handling the rare edge case when a scene has no "dvd id", and only a "content id". It also allows for searching on the "content id".