### PR TITLE
Several changes and fixes for NAVR, VRHush, RealJamVR, TmwVRnet scrapers

### DIFF
--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -70,11 +70,11 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 			base := strings.Split(strings.Replace(e.Attr("src"), "//", "", -1), "/")
 
 			base[8] = "horizontal"
-			base[9] = "1252x708c.jpg"
+			base[9] = "1182x777c.jpg"
 			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
 
 			base[8] = "vertical"
-			base[9] = "400x605c.jpg"
+			base[9] = "1182x1788c.jpg"
 			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
 		})
 

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -45,9 +45,15 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 		// Released
 		sc.Released = strings.TrimSuffix(strings.TrimSpace(e.ChildText(`.date`)), ",")
 
-		// Title, Cover URL
-		sc.Title = strings.TrimSpace(e.ChildAttr(`deo-video`, "title"))
-		sc.Covers = append(sc.Covers, strings.TrimSpace(e.ChildAttr(`deo-video`, "cover-image")))
+		// Title
+		sc.Title = strings.TrimSpace(e.ChildText(`h1`))
+		
+		// Cover URL
+		re := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
+		coverURL := re.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`.splash-screen`, "style")))[1]
+		if len(coverURL) > 0 {
+			sc.Covers = append(sc.Covers, coverURL)
+		}
 
 		// Gallery
 		e.ForEach(`.scene-previews-container a`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -1,20 +1,20 @@
 package scrape
 
 import (
-  "strconv"
+	"strconv"
 	"strings"
 	"sync"
-  "regexp"
-  "html"
+	"regexp"
+	"html"
 
 	"github.com/gocolly/colly"
 	"github.com/mozillazg/go-slugify"
 	"github.com/thoas/go-funk"
 	"github.com/xbapps/xbvr/pkg/models"
-  "github.com/tidwall/gjson"
+	"github.com/tidwall/gjson"
 )
 
-func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string) error {
+func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -24,7 +24,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
 		sc.SceneType = "VR"
-		sc.Studio = "SLR Originals"
+		sc.Studio = company
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 
@@ -52,21 +52,21 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Extract from JSON meta data
 		// NOTE: SLR only provides certain information like duration as json metadata inside a script element
-    // The page code also changes often and is difficult to traverse, best to get as much as possible from metadata
-    e.ForEach(`script[type="application/ld+json"]`, func(id int, e *colly.HTMLElement) {
-      JsonMetadata := strings.TrimSpace(e.Text)
+		// The page code also changes often and is difficult to traverse, best to get as much as possible from metadata
+		e.ForEach(`script[type="application/ld+json"]`, func(id int, e *colly.HTMLElement) {
+			JsonMetadata := strings.TrimSpace(e.Text)
 
 			// skip Studio name as tag (also used for determining filenames)
 			var studioName string
-			studio := gjson.Get(JsonMetadata, "video.author.name")
-			if studio.Exists() {
-				studioName = studio.String()
-				skiptags[strings.TrimSpace(studio.String())] = true
+			author := gjson.Get(JsonMetadata, "video.author.name")
+			if author.Exists() {
+				studioName = author.String()
+				skiptags[strings.TrimSpace(author.String())] = true
 			}
 
-      // Cover
-      // NOTE: SLR sadly doesn't provide large covers yet, only thumbnail-sized
-      if gjson.Get(JsonMetadata, "video.thumbnailUrl").Exists() {
+			// Cover
+			// NOTE: SLR sadly doesn't provide large covers yet, only thumbnail-sized
+			if gjson.Get(JsonMetadata, "video.thumbnailUrl").Exists() {
 				sc.Covers = append(sc.Covers, gjson.Get(JsonMetadata, "video.thumbnailUrl").String())
 			}
 
@@ -88,32 +88,32 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			}
 
 			// Duration
-      // NOTE: SLR fails to include hours (1h55m30s shows up as T55M30S)
+			// NOTE: SLR fails to include hours (1h55m30s shows up as T55M30S)
 			// ...but this is ready for the format of T01H55M30S should SLR fix that
-      reGetDuration := regexp.MustCompile(`^T(\d{0,2})H?(\d{2})M(\d{2})S$`)
-      duration := 0
-      if gjson.Get(JsonMetadata, "video.datePublished").Exists() {
-        tmpParts := reGetDuration.FindStringSubmatch(gjson.Get(JsonMetadata, "video.duration").String())
-        if len(tmpParts[1]) > 0 {
-          if h, err := strconv.Atoi(tmpParts[1]); err == nil {
-            hrs := h
-            if m, err := strconv.Atoi(tmpParts[2]); err == nil {
-              mins := m
-              duration = (hrs*60)+mins
-            }
-          }
-        }else{
-          if m, err := strconv.Atoi(tmpParts[2]); err == nil {
-            duration = m
-          }
-        }
-        sc.Duration = duration
-      }
+			reGetDuration := regexp.MustCompile(`^T(\d{0,2})H?(\d{2})M(\d{2})S$`)
+			duration := 0
+			if gjson.Get(JsonMetadata, "video.datePublished").Exists() {
+				tmpParts := reGetDuration.FindStringSubmatch(gjson.Get(JsonMetadata, "video.duration").String())
+				if len(tmpParts[1]) > 0 {
+					if h, err := strconv.Atoi(tmpParts[1]); err == nil {
+						hrs := h
+						if m, err := strconv.Atoi(tmpParts[2]); err == nil {
+							mins := m
+							duration = (hrs*60)+mins
+						}
+					}
+				}else{
+					if m, err := strconv.Atoi(tmpParts[2]); err == nil {
+						duration = m
+					}
+				}
+				sc.Duration = duration
+			}
 
 			// Tags
-      // Note: known issue with SLR, they use a lot of combining tags like "cheerleader / college / school"
-      // ...a lot of these are shared with RealJamVR which uses the same tags though.
-      // Could split by / but would run into issues with "f/f/m" and "shorts / skirts"
+			// Note: known issue with SLR, they use a lot of combined tags like "cheerleader / college / school"
+			// ...a lot of these are shared with RealJamVR which uses the same tags though.
+			// Could split by / but would run into issues with "f/f/m" and "shorts / skirts"
 			var videotype string
 			keywords := gjson.Get(JsonMetadata, "video.keywords")
 			keywords.ForEach(func(key, tag gjson.Result) bool {
@@ -131,22 +131,22 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 			// Filenames
 			// Only shown for logged in users so need to generate them
-	    // Format: SLR_StudioName_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
+			// Format: SLR_StudioName_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
 			resolutions := []string{"_6400p_", "_2880p_", "_2700p_", "_1440p_", "_1080p_", "_original_"}
 			baseName := "SLR_" + studioName + "_" + sc.Title
 			if (videotype == "360°") {	// Sadly can't determine if TB or MONO so have to add both
-        filenames := make([]string, 0, 2*len(resolutions))
+				filenames := make([]string, 0, 2*len(resolutions))
 				for i := range resolutions {
-          filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_MONO_360.mp4")
-          filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_TB_360.mp4")
-          sc.Filenames = filenames
+					filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_MONO_360.mp4")
+					filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_TB_360.mp4")
+					sc.Filenames = filenames
 				}
 			}else{	// Assuming everything else is 180 and LR, yet to find a TB_180
-        filenames := make([]string, 0, len(resolutions))
+				filenames := make([]string, 0, len(resolutions))
 				for i := range resolutions {
-          filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_LR_180.mp4")
+					filenames = append(filenames, baseName + resolutions[i] + sc.SiteID + "_LR_180.mp4")
 				}
-        sc.Filenames = filenames
+				sc.Filenames = filenames
 			}
 
 		})
@@ -156,7 +156,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 	siteCollector.OnHTML(`div.c-pagination ul li a`, func(e *colly.HTMLElement) {
 		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
-    siteCollector.Visit(pageURL)
+		siteCollector.Visit(pageURL)
 	})
 
 	siteCollector.OnHTML(`div.c-grid--scenes article a`, func(e *colly.HTMLElement) {
@@ -180,72 +180,72 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 // SLR Originals - SexLikeReal own productions
 func SLROriginals(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "slr-originals", "SLR Originals")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "slr-originals", "SLR Originals", "SexLikeReal")
 }
 
 // iStripper - Has a site for 2D desktop app, but doesn't even mention they do VR scenes: https://www.istripper.com/
 func iStripper(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "istripper", "iStripper")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "istripper", "iStripper", "TotemCore Ltd")
 }
 
 // EmilyBloom - does have vertical covers on her site but no scene info to scrape: https://theemilybloom.com/virtual-reality/
 func EmilyBloom(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "emilybloom", "EmilyBloom")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "emilybloom", "EmilyBloom", "Emily Bloom")
 }
 
 // VRSexperts - does have large covers on their blog but they appear very delayed: http://www.vrsexperts.com/
 func VRSexperts(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsexperts", "VRSexperts")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsexperts", "VRSexperts", "VRSexperts")
 }
 
 // VReXtasy - Can't find a site/twitter at all
 func VReXtasy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrextasy", "VReXtasy")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "vrextasy", "VReXtasy", "VReXtasy")
 }
 
 // VRSolos - https://twitter.com/VRsolos/
 func VRSolos(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsolos", "VRSolos")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsolos", "VRSolos", "VRSolos")
 }
 
 // Jimmy Draws - https://twitter.com/ukpornmaker
 func JimmyDraws(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "jimmydraws", "JimmyDraws")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "jimmydraws", "JimmyDraws", "Jimmy Draws")
 }
 
 // POVcentralVR - Has a site with mixed 2D/VR content, doesn't seem very scrapable: http://povcentral.com/home.html
 // Does have a blog for VR scenes but no useful covers: http://blog.povcentralmembers.com/category/3d/
 func POVcentralVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "povcentralvr", "POVcentralVR")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "povcentralvr", "POVcentralVR", "POV Central")
 }
 
 // OnlyTease - Has a site for their 2D scenes, only started doing VR since Oct 2019: https://www.onlytease.com/
 func OnlyTease(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "onlytease", "OnlyTease")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "onlytease", "OnlyTease", "OT Publishing Ltd")
 }
 
 // perVRt/Terrible - Likely to change to Terrible brand, is working on their own website here: http://terrible.porn/
 // Publishes on SLR as perVRt, includes brands: Juggs, Babygirl, Sappho
 // https://twitter.com/terribledotporn & https://twitter.com/perVRtPORN
 func perVRt(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "pervrt", "perVRt/Terrible")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "pervrt", "perVRt", "Terrible"")
 }
 
 // LeninaCrowne - Wife of https://twitter.com/DickTerrible from the perVRt/Terrible Studio.
 func LeninaCrowne(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "leninacrowne", "LeninaCrowne")
+	return SexLikeReal(wg, updateSite, knownScenes, out, "leninacrowne", "LeninaCrowne", "Terrible")
 }
 
 func init() {
-  registerScraper("slr-originals", "SLR Originals", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png", SLROriginals)
-  registerScraper("istripper", "iStripper (SLR)", "https://www.istripper.com/favicons/istripper/apple-icon-120x120.png", iStripper)
-  registerScraper("emilybloom", "EmilyBloom (SLR)", "https://theemilybloom.com/wp-content/uploads/2017/05/FlowerHeaderLogo.png", EmilyBloom)
-  registerScraper("vrsexperts", "VRSexperts (SLR)", "https://mcdn.vrporn.com/files/20190812141431/vrsexpertslogo2.jpg", VRSexperts)
-  registerScraper("vrextasy", "VReXtasy (SLR)", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png", VReXtasy)
-  registerScraper("vrsolos", "VRSolos (SLR)", "https://mcdn.vrporn.com/files/20191226092954/VRSolos_Logo.jpg", VRSolos)
-  registerScraper("jimmydraws", "JimmyDraws (SLR)", "https://mcdn.vrporn.com/files/20190821145930/iLPJW6J7_400x400.png", JimmyDraws)
-  registerScraper("povcentralvr", "POVcentralVR (SLR)", "https://mcdn.vrporn.com/files/20191125091909/POVCentralLogo.jpg", POVcentralVR)
-  registerScraper("onlytease", "OnlyTease (SLR)", "https://www.onlytease.com/assets/img/favicons/ot/apple-touch-icon.png", OnlyTease)
-  registerScraper("pervrt", "perVRt/Terrible (SLR)", "https://mcdn.vrporn.com/files/20181218151630/pervrt-logo.jpg", perVRt)
-  registerScraper("leninacrowne", "LeninaCrowne (SLR)", "https://mcdn.vrporn.com/files/20190711135807/terrible_logo-e1562878668857_400x400_acf_cropped.jpg", LeninaCrowne)
+	registerScraper("slr-originals", "SLR Originals", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png", SLROriginals)
+	registerScraper("istripper", "iStripper (SLR)", "https://www.istripper.com/favicons/istripper/apple-icon-120x120.png", iStripper)
+	registerScraper("emilybloom", "EmilyBloom (SLR)", "https://theemilybloom.com/wp-content/uploads/2017/05/FlowerHeaderLogo.png", EmilyBloom)
+	registerScraper("vrsexperts", "VRSexperts (SLR)", "https://mcdn.vrporn.com/files/20190812141431/vrsexpertslogo2.jpg", VRSexperts)
+	registerScraper("vrextasy", "VReXtasy (SLR)", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png", VReXtasy)
+	registerScraper("vrsolos", "VRSolos (SLR)", "https://mcdn.vrporn.com/files/20191226092954/VRSolos_Logo.jpg", VRSolos)
+	registerScraper("jimmydraws", "JimmyDraws (SLR)", "https://mcdn.vrporn.com/files/20190821145930/iLPJW6J7_400x400.png", JimmyDraws)
+	registerScraper("povcentralvr", "POVcentralVR (SLR)", "https://mcdn.vrporn.com/files/20191125091909/POVCentralLogo.jpg", POVcentralVR)
+	registerScraper("onlytease", "OnlyTease (SLR)", "https://www.onlytease.com/assets/img/favicons/ot/apple-touch-icon.png", OnlyTease)
+	registerScraper("pervrt", "perVRt/Terrible (SLR)", "https://mcdn.vrporn.com/files/20181218151630/pervrt-logo.jpg", perVRt)
+	registerScraper("leninacrowne", "LeninaCrowne (SLR)", "https://mcdn.vrporn.com/files/20190711135807/terrible_logo-e1562878668857_400x400_acf_cropped.jpg", LeninaCrowne)
 }

--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -36,12 +36,13 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		})
 
 		// Title / Cover / ID
-		e.ForEach(`deo-video`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
 			sc.Title = strings.TrimSpace(e.Attr("title"))
 
-			sc.Covers = append(sc.Covers, e.Attr("cover-image"))
+			tmpCover := "https://tmwvrnet.com/content/"+e.Attr("poster")
+			sc.Covers = append(sc.Covers, tmpCover)
 
-			tmp := strings.Split(e.Attr("cover-image"), "/")
+			tmp := strings.Split(tmpCover, "/")
 			sc.SiteID = tmp[5]
 			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID + "-" + sc.Released
 		})

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -96,8 +96,9 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc := e.Request.Ctx.GetAny("scene").(*models.ScrapedScene)
 
 		var name string
+		reDoubleWhitespace := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 		e.ForEach(`h1#model-name`, func(id int, e *colly.HTMLElement) {
-			name = strings.TrimSpace(e.Text)
+			name = strings.TrimSpace(reDoubleWhitespace.ReplaceAllString(e.Text, " "))
 		})
 
 		var gender string

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -41,14 +41,21 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 			sc.Title = strings.TrimSpace(e.Text)
 		})
 
+		// Regex for original resolution of both covers and gallery
+		reGetOriginal := regexp.MustCompile(`^(https?:\/\/k3y8c8f9\.ssl\.hwcdn\.net\/vrh\/)(?:largethumbs|hugethumbs|rollover_large)(\/.+)-c\d{3,4}x\d{3,4}(\.\w{3,4})$`)
+
 		// Cover URLs
+		// note 'largethumbs' could be changed to 'hugethumbs' for HQ original but those are easily 5Mb+
 		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
-			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("poster")))
+			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("poster")))
+			sc.Covers = append(sc.Covers, tmpParts[1]+"largethumbs"+tmpParts[2]+tmpParts[3])
 		})
 
 		// Gallery
+		// note 'rollover_large' could be changed to 'rollover_huge' for HQ original but those are easily 5Mb+
 		e.ForEach(`div.owl-carousel img.img-responsive`, func(id int, e *colly.HTMLElement) {
-			sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("src")))
+			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("src")))
+			sc.Gallery = append(sc.Gallery, tmpParts[1]+"rollover_large"+tmpParts[2]+tmpParts[3])
 		})
 
 		// Synopsis

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"regexp"
 
 	"github.com/gocolly/colly"
 	"github.com/mozillazg/go-slugify"


### PR DESCRIPTION
Minor changes and fixes, but please do check if it's all working well. I did test it in gitpod and it all worked fine there but wasn't able to get it to commit my changes, so had to manually edit the changes in my fork on github. No idea how to compile to an .exe with gitpod, I'm assuming that's just not possible. So I couldn't test it locally.

- Changed NaughtyAmericaVR horizontal and vertical covers to use a larger size.
- Fixed title and cover scraping for RealJamVR which wasn't working any more.
- Fixed TmwVRnet scraper, same issue as RealJamVR because deo player element changed.
- Changed VRHush cover and gallery images to use better, larger images.
- Added a fix for double white spaces in model names in VRHush scraper.

About the last point, it was adding duplicate model names to the database (see Adriana Chechik). But I wonder if basic trimming/sanitizing of model names shouldn't be done at a higher level. Like just before adding to the database so it would do that for all scrapers.