### PR TITLE
VirtualRealPorn(/Trans) scraper: fix scraped filenames

### DIFF
--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -102,20 +102,53 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 				fragmentName := strings.Split(origURL, "/")
 
 				fpName := strings.Split(fragmentName[len(fragmentName)-1], "?")[0]
-				fpName = strings.Replace(fpName, ".webm", "", -1)
-				fpName = strings.Replace(fpName, ".mp4", "", -1)
-				fpName = strings.Replace(fpName, "_-_Trailer", "", -1)
-				fpName = strings.Replace(fpName, "_-_Smartphone", "", -1)
+				prefix := siteID + ".com_-_"
+				if strings.HasPrefix(fpName, prefix) {
+					fpName = strings.Split(fpName, prefix)[1]
+					fpName = strings.SplitN(fpName, "_-_Trailer", 2)[0]
+					siteIDAcronym := "VRP"
+					if siteID == "VirtualRealTrans" {
+						siteIDAcronym = "VRT"
+					}
 
-				var outFilenames []string
-				postfix := []string{"-_180x180_3dh"}
+					var outFilenames []string
 
-				for i := range postfix {
-					outFilenames = append(outFilenames, fpName+"_"+postfix[i]+".mp4")
-					outFilenames = append(outFilenames, strings.Replace(fpName, ".com", "", -1)+"_"+postfix[i]+".mp4")
+					// Playstation VR
+					outFilenames = append(outFilenames, siteIDAcronym+"_"+fpName+"_Trailer_PS4_180_sbs.mp4") // Trailer
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_3K_180_sbs.mp4")                 // PS4
+					outFilenames = append(outFilenames, siteIDAcronym+"_"+fpName+"_180_sbs.mp4")             // PS4 (older videos)
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_180_sbs.mp4")            // PS4 (oldest videos)
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_4096x2040_180_sbs.mp4")          // PS4 Pro
+					outFilenames = append(outFilenames, siteIDAcronym+"_"+fpName+"_Pro_180_sbs.mp4")         // PS4 Pro (older videos)
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_Pro_180_sbs.mp4")        // PS4 Pro (oldest videos)
+
+					// Oculus Go / Quest
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_Trailer.mp4")       // Trailer (same for Oculus Rift (S) / Vive / Windows MR)
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_4864_180x180_3dh.mp4")      // 4K+
+					outFilenames = append(outFilenames, siteID+"_-_"+fpName+"_-_h264P_180x180_3dh.mp4") // 4K+ (older videos)
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_4K_30M_180x180_3dh.mp4")    // 4K HQ (same for Gear VR / Daydream and Oculus Rift (S) / Vive / Windows MR)
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_4K_h265_180x180_3dh.mp4")   // 4K h265 (same for Oculus Rift (S) / Vive / Windows MR)
+					outFilenames = append(outFilenames, siteID+"_-_"+fpName+"_-_vp9_180x180_3dh.mp4")   // 4K VP9 (older videos; same for Gear VR / Daydream and Oculus Rift (S) / Vive / Windows MR)
+					outFilenames = append(outFilenames, siteID+"_-_"+fpName+"_-_180x180_3dh.mp4")       // 4K h264 (older videos; same for Gear VR / Daydream)
+
+					// Gear VR / Daydream
+					outFilenames = append(outFilenames, siteID+"_-_"+fpName+"_-_Trailer_Streaming_3dh.mp4") // Trailer
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_4K_180x180_3dh.mp4")            // 4K (same for Smartphone)
+
+					// Smartphone
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_Trailer_-_Smartphone.mp4") // Trailer
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_1920_180x180_3dh.mp4")             // Full HD (same for Oculus Rift (S) / Vive / Windows MR)
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_1920.mp4")                 // Full HD (older videos; same for Oculus Rift (S) / Vive / Windows MR)
+
+					// Oculus Rift (S) / Vive / Windows MR
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_5K_30M_180x180_3dh.mp4")     // 5K HQ
+					outFilenames = append(outFilenames, siteID+"_"+fpName+"_5K_180x180_3dh.mp4")         // 5K
+					outFilenames = append(outFilenames, siteID+"_-_"+fpName+"_-_5K_180x180_3dh.mp4")     // 5K (older videos)
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_5K_180x180_3dh.mp4") // 5K (before site update)
+					outFilenames = append(outFilenames, siteID+".com_-_"+fpName+"_-_h264.mp4")           // 4K 264 (older videos)
+
+					sc.Filenames = outFilenames
 				}
-
-				sc.Filenames = outFilenames
 			}
 		})
 


### PR DESCRIPTION
VirtualRealPorn seems to employ a myriad of filename patterns, which to some extent have changed over time. Please let me know if I have forgotten a pattern.

Since I do not have an account and cannot verify the actual naming of the files, I made an educated guess for the filenames of VirtualRealTrans.