### PR TITLE
Various fixes and changes to multiple scrapers.

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -40,9 +40,9 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		})
 
 		// Cover URLs
-		e.ForEach(`div#videoPreviewContainer picture source`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div#videoPreviewContainer picture img`, func(id int, e *colly.HTMLElement) {
 			if id == 0 {
-				sc.Covers = append(sc.Covers, strings.Split(e.Request.AbsoluteURL(e.Attr("srcset")), "?")[0])
+				sc.Covers = append(sc.Covers, strings.Split(e.Attr("src"), "?")[0])
 			}
 		})
 
@@ -60,6 +60,9 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		e.ForEach(`a.video-tag`, func(id int, e *colly.HTMLElement) {
 			sc.Tags = append(sc.Tags, strings.TrimSpace(e.Text))
 		})
+		if scraperID == "vrcosplayx" {
+			sc.Tags = append(sc.Tags, "Cosplay", "Parody")
+		}
 
 		// Cast
 		e.ForEach(`a.video-actor-link`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/lethalhardcorevr.go
+++ b/pkg/scrape/lethalhardcorevr.go
@@ -85,10 +85,9 @@ func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 		})
 
 		// Cast
-		r := strings.NewReplacer("(", "",
-			")", "")
+		r := strings.NewReplacer("(", "", ")", "")
 		e.ForEach(`div.item-page-details .overlay small`, func(id int, e *colly.HTMLElement) {
-			if id == 0 {
+			if id <= 1 {
 				sc.Cast = append(sc.Cast, strings.TrimSpace(r.Replace(e.Text)))
 			}
 		})
@@ -97,7 +96,7 @@ func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 		e.ForEach(`meta[name=Keywords]`, func(id int, e *colly.HTMLElement) {
 			k := strings.Split(e.Attr("content"), ",")
 			for i, tag := range k {
-				if i == len(k)-1 {
+				if i >= len(k)-2 {
 					for _, actor := range sc.Cast {
 						if funk.Contains(tag, actor) {
 							tag = strings.Replace(tag, actor, "", -1)

--- a/pkg/scrape/milfvr.go
+++ b/pkg/scrape/milfvr.go
@@ -53,7 +53,7 @@ func MilfVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 		// Gallery
 		for _, x := range []string{"1", "2", "3", "4", "5", "6"} {
-			tmpGallery := "https://cdns-i.milfvr.com/" + sc.SiteID[0:1] + "/" + sc.SiteID[0:4] + "/" + sc.SiteID + "/thumbs/700_" + x + ".jpg"
+			tmpGallery := "https://cdns-i.milfvr.com/" + sc.SiteID[0:1] + "/" + sc.SiteID[0:4] + "/" + sc.SiteID + "/thumbs/1280_" + x + ".jpg"
 			sc.Gallery = append(sc.Gallery, tmpGallery)
 		}
 

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"html"
 	"strconv"
 	"strings"
 	"sync"
@@ -109,7 +110,7 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 				out, _ := vm.Get("out")
 				outs, _ := out.ToString()
 
-				sc.Cast = strings.Split(outs, ",")
+				sc.Cast = strings.Split(html.UnescapeString(outs), ",")
 			}
 		})
 

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -33,7 +33,7 @@ func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 
 		// Cover
-		sc.Covers = append(sc.Covers, e.Request.Ctx.Get("cover"))
+		sc.Covers = append(sc.Covers, strings.Replace(e.Request.Ctx.Get("cover"), "-Small", "-Large", 1))
 
 		// Title
 		sc.Title = e.Request.Ctx.Get("title")
@@ -48,7 +48,7 @@ func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 
 		// Gallery
 		e.ForEach(`img.videoClip__Details--galleryItem`, func(id int, e *colly.HTMLElement) {
-			imageURL := strings.Fields(e.Attr("data-big"))[0]
+			imageURL := strings.Replace(strings.Fields(e.Attr("data-big"))[0], "_small", "_large", 1)
 			sc.Gallery = append(sc.Gallery, strings.Replace(imageURL, "https:", "http:", 1))
 		})
 

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -50,7 +50,7 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 		})
 
 		// Gallery
-		e.ForEach(`figure[itemprop=associatedMedia] a`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`figure[itemprop=associatedMedia] > a`, func(id int, e *colly.HTMLElement) {
 			base := e.Request.AbsoluteURL(e.Attr("href"))
 			base = strings.Split(base, "?")[0]
 			sc.Gallery = append(sc.Gallery, base)

--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -78,7 +78,7 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 		e.ForEach(`div.right-info div.info`, func(id int, e *colly.HTMLElement) {
 			tmpData := funk.ReverseStrings(strings.Split(e.Text, "\n"))
 
-			tmpDate, _ := goment.New(strings.TrimSpace(tmpData[1]), "MMMM DD, YYYY")
+			tmpDate, _ := goment.New(strings.TrimSpace(tmpData[1]), "DD MMMM, YYYY")
 			sc.Released = tmpDate.Format("YYYY-MM-DD")
 
 			sc.Duration, _ = strconv.Atoi(strings.TrimSpace(strings.Replace(tmpData[3], "min", "", -1)))

--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -30,7 +30,8 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 		if e.ChildText(`.welldescription`) != "" {
 			coverURL := e.ChildAttr(`.col-lg-12 img`, "src")
-			sc.Covers = append(sc.Covers, coverURL)
+			altCover := strings.Replace(coverURL, "panel", "dvd", 1)
+			sc.Covers = append(sc.Covers, coverURL, altCover)
 
 			sc.Title = strings.TrimSpace(e.ChildText(`div.welldescription h4`))
 

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -73,7 +73,7 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		})
 
 		// Cover URLs
-		sc.Covers = e.ChildAttrs(`dl8-video`, "poster")
+		sc.Covers = append(sc.Covers, e.ChildAttrs(`dl8-video`, "poster")[0], e.ChildAttrs(`section.banner picture img`, "src")[0])
 
 		// Gallery
 		sc.Gallery = e.ChildAttrs(`div.gallery-top a.fancybox.image`, "href")

--- a/pkg/scrape/vrconk.go
+++ b/pkg/scrape/vrconk.go
@@ -41,8 +41,8 @@ func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.Title = strings.TrimSpace(e.ChildText(`div.item-tr-inner-col h1`))
 		sc.Covers = append(sc.Covers, rxRelaxed.FindString(e.ChildAttr(`div.splash-screen`, "style")))
 
-		e.ForEach(`.gallery-block img`, func(id int, e *colly.HTMLElement) {
-			sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("src")))
+		e.ForEach(`.gallery-block figure > a`, func(id int, e *colly.HTMLElement) {
+			sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("href")))
 		})
 
 		e.ForEach(`.stats-list li`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -2,9 +2,9 @@ package scrape
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
-	"regexp"
 
 	"github.com/gocolly/colly"
 	"github.com/mozillazg/go-slugify"


### PR DESCRIPTION
### Fixes/Changes to scrapers:

SLR
- Added StripzVR studio to SLR scraper.
- Use the newly added large covers (mostly for new scenes, not all older scenes have a large cover).
- Fixed everything that got broken when SLR changed the json metadata and some html.
- Tags were removed from json metadata entirely, changed it to grab the tags from html instead.

BaDoinkVR
- Use large covers for all BaDoink-sites (improves VRCosplayX & BabeVR).
- Added tags for VRCosplayX scenes, as they should always have "Cosplay" and "Parody" tags (Other sites already use those).

MilfVR
- Use slightly larger gallery images similar to WankzVR.

LethalhardcoreVR / WhorecraftVR
- Minor fix for a couple edge-cases, not all actor names were removed from tags (Isabel Moon, Carolina Sweets).

NaughtyAmericaVR
- Unescaped actor names because it's pulled from js (example cast: April O'Neil & Belle O'Hara).

Realitylovers
- Use larger cover and gallery images.

SexBabesVR
- Fix for the issue of every other gallery image being a blank.

VirtualTaboo
- Fix release date format (thx mauroamore).

VR3000
- Added alternative cover, it's a vertical DVD-style cover so the original banner cover is still used for thumbnail view.

VRBangers
- Added alternative cover, it's larger but also much wider so the small cover is still used for thumbnail view.

VRConk
- Fix for using the actual gallery images instead of the tiny thumbnails.

VRLatina
- Fix for edge cases: check for empty cast element and a cast name with a "!" in it.
- Fix for missing cast names with rare multi-girl scenes (only one cast name is featured, others are added as tags).
- Change castname in tag checking to EqualFold for case-insensitive comparisons (lower case actor tags were not filtered out, example tag: nikol sparta).