### PR TITLE
Make scraper logging thread safe

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -259,5 +259,4 @@ func Migrate() {
 	}
 	common.Log.Printf("Migration did run successfully")
 
-	db.Close()
 }

--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -10,15 +10,18 @@ import (
 )
 
 var log = &common.Log
+var globalDB *gorm.DB
+var dbInit bool = false
 
 func GetDB() (*gorm.DB, error) {
-	db, err := gorm.Open("sqlite3", filepath.Join(common.AppDir, "main.db"))
-	if err != nil {
-		common.Log.Fatal("failed to connect database", err)
-	}
-	return db, nil
+	return globalDB, nil
 }
 
 func init() {
 	common.InitPaths()
+	db, err := gorm.Open("sqlite3", filepath.Join(common.AppDir, "main.db"))
+	if err != nil {
+		common.Log.Fatal("failed to connect database", err)
+	}
+	globalDB = db
 }

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -5,9 +5,9 @@ import (
 )
 
 type Actor struct {
-	ID        uint       `gorm:"primary_key" json:"id"`
-	CreatedAt time.Time  `json:"-"`
-	UpdatedAt time.Time  `json:"-"`
+	ID        uint      `gorm:"primary_key" json:"id"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
 
 	Name   string  `gorm:"unique_index" json:"name"`
 	Scenes []Scene `gorm:"many2many:scene_cast;" json:"-"`
@@ -17,6 +17,5 @@ type Actor struct {
 func (i *Actor) Save() error {
 	db, _ := GetDB()
 	err := db.Save(i).Error
-	db.Close()
 	return err
 }

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -42,7 +42,6 @@ func (f *File) GetPath() string {
 func (f *File) Save() error {
 	db, _ := GetDB()
 	err := db.Save(f).Error
-	db.Close()
 	return err
 }
 

--- a/pkg/models/model_history.go
+++ b/pkg/models/model_history.go
@@ -17,7 +17,6 @@ type History struct {
 
 func (o *History) GetIfExist(id uint) error {
 	db, _ := GetDB()
-	defer db.Close()
 
 	return db.Where(&History{ID: id}).First(o).Error
 }
@@ -25,11 +24,9 @@ func (o *History) GetIfExist(id uint) error {
 func (o *History) Save() {
 	db, _ := GetDB()
 	db.Save(o)
-	db.Close()
 }
 
 func (o *History) Delete() {
 	db, _ := GetDB()
 	db.Delete(o)
-	db.Close()
 }

--- a/pkg/models/model_kv.go
+++ b/pkg/models/model_kv.go
@@ -15,13 +15,11 @@ type KV struct {
 func (o *KV) Save() {
 	db, _ := GetDB()
 	db.Save(o)
-	db.Close()
 }
 
 func (o *KV) Delete() {
 	db, _ := GetDB()
 	db.Delete(o)
-	db.Close()
 }
 
 // Lock functions
@@ -39,7 +37,6 @@ func CreateLock(lock string) {
 
 func CheckLock(lock string) bool {
 	db, _ := GetDB()
-	defer db.Close()
 
 	var obj KV
 	err := db.Where(&KV{Key: "lock-" + lock}).First(&obj).Error
@@ -51,7 +48,6 @@ func CheckLock(lock string) bool {
 
 func RemoveLock(lock string) {
 	db, _ := GetDB()
-	defer db.Close()
 
 	db.Where("key = ?", "lock-"+lock).Delete(&KV{})
 

--- a/pkg/models/model_playlist.go
+++ b/pkg/models/model_playlist.go
@@ -21,6 +21,5 @@ type Playlist struct {
 func (o *Playlist) Save() error {
 	db, _ := GetDB()
 	err := db.Save(o).Error
-	db.Close()
 	return err
 }

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -28,7 +28,6 @@ type SceneCuepoint struct {
 func (o *SceneCuepoint) Save() error {
 	db, _ := GetDB()
 	err := db.Save(o).Error
-	db.Close()
 	return err
 }
 
@@ -85,7 +84,6 @@ type Image struct {
 func (i *Scene) Save() error {
 	db, _ := GetDB()
 	err := db.Save(i).Error
-	db.Close()
 	return err
 }
 
@@ -99,7 +97,6 @@ func (i *Scene) FromJSON(data []byte) error {
 
 func (o *Scene) GetIfExist(id string) error {
 	db, _ := GetDB()
-	defer db.Close()
 
 	return db.
 		Preload("Tags").
@@ -112,7 +109,6 @@ func (o *Scene) GetIfExist(id string) error {
 
 func (o *Scene) GetIfExistByPK(id uint) error {
 	db, _ := GetDB()
-	defer db.Close()
 
 	return db.
 		Preload("Tags").
@@ -125,7 +121,6 @@ func (o *Scene) GetIfExistByPK(id uint) error {
 
 func (o *Scene) GetIfExistURL(u string) error {
 	db, _ := GetDB()
-	defer db.Close()
 
 	return db.
 		Preload("Tags").
@@ -138,7 +133,6 @@ func (o *Scene) GetIfExistURL(u string) error {
 
 func (o *Scene) GetFiles() ([]File, error) {
 	db, _ := GetDB()
-	defer db.Close()
 
 	var files []File
 	db.Preload("Volume").Where(&File{SceneID: o.ID}).Find(&files)
@@ -313,7 +307,6 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 	offset := r.Offset.OrElse(0)
 
 	db, _ := GetDB()
-	defer db.Close()
 
 	var scenes []Scene
 	tx := db.Model(&scenes)

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -7,13 +7,20 @@ import (
 
 var scrapers []Scraper
 
-type ScraperFunc func(*sync.WaitGroup, bool, []string, chan<- ScrapedScene) error
+type ScraperFunc func(*sync.WaitGroup, bool, []string, chan<- ScrapedScene, chan<- ScraperStatus) error
 
 type Scraper struct {
 	ID        string
 	Name      string
 	AvatarURL string
 	Scrape    ScraperFunc
+}
+
+type ScraperStatus struct {
+	ScraperID  string
+	SiteID     string
+	Status     int
+	UpdateSite bool
 }
 
 type ScrapedScene struct {

--- a/pkg/models/model_site.go
+++ b/pkg/models/model_site.go
@@ -16,20 +16,17 @@ type Site struct {
 func (i *Site) Save() error {
 	db, _ := GetDB()
 	err := db.Save(i).Error
-	db.Close()
 	return err
 }
 
 func (i *Site) GetIfExist(id string) error {
 	db, _ := GetDB()
-	defer db.Close()
 
 	return db.Where(&Site{ID: id}).First(i).Error
 }
 
 func InitSites() {
 	db, _ := GetDB()
-	defer db.Close()
 
 	scrapers := GetScrapers()
 	for i := range scrapers {

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -17,7 +17,6 @@ type Tag struct {
 func (t *Tag) Save() error {
 	db, _ := GetDB()
 	err := db.Save(t).Error
-	db.Close()
 	return err
 }
 

--- a/pkg/models/model_volume.go
+++ b/pkg/models/model_volume.go
@@ -42,7 +42,6 @@ func (o *Volume) IsMounted() bool {
 func (o *Volume) Save() error {
 	db, _ := GetDB()
 	err := db.Save(o).Error
-	db.Close()
 	return err
 }
 
@@ -50,7 +49,6 @@ func (o *Volume) Files() []File {
 	var allFiles []File
 	db, _ := GetDB()
 	db.Preload("Volume").Where("volume_id = ?", o.ID).Find(&allFiles)
-	db.Close()
 	return allFiles
 }
 
@@ -62,7 +60,6 @@ func (o *Volume) GetPutIOClient() *putio.Client {
 
 func CheckVolumes() {
 	db, _ := GetDB()
-	defer db.Close()
 
 	var vol []Volume
 	db.Find(&vol)

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -12,9 +12,9 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com", "kinkvr.com")
 	siteCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com", "kinkvr.com")
@@ -128,31 +128,28 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 	siteCollector.Visit(URL)
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
-func BadoinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "badoinkvr", "BadoinkVR", "https://badoinkvr.com/vrpornvideos")
+func BadoinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, status, "badoinkvr", "BadoinkVR", "https://badoinkvr.com/vrpornvideos")
 }
 
-func B18VR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "18vr", "18VR", "https://18vr.com/vrpornvideos")
+func B18VR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, status, "18vr", "18VR", "https://18vr.com/vrpornvideos")
 }
 
-func VRCosplayX(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "vrcosplayx", "VRCosplayX", "https://vrcosplayx.com/cosplaypornvideos")
+func VRCosplayX(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, status, "vrcosplayx", "VRCosplayX", "https://vrcosplayx.com/cosplaypornvideos")
 }
 
-func BabeVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "babevr", "BabeVR", "https://babevr.com/vrpornvideos")
+func BabeVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, status, "babevr", "BabeVR", "https://babevr.com/vrpornvideos")
 }
 
-func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "kinkvr", "KinkVR", "https://kinkvr.com/bdsm-vr-videos")
+func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, status, "kinkvr", "KinkVR", "https://kinkvr.com/bdsm-vr-videos")
 }
 
 func init() {

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "czechvr"
 	siteID := "CzechVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.czechvrnetwork.com")
 	siteCollector := createCollector("www.czechvrnetwork.com")
@@ -133,10 +133,7 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 
 	siteCollector.Visit("https://www.czechvrnetwork.com/vr-porn-videos?next=1")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/ddfnetworkvr.go
+++ b/pkg/scrape/ddfnetworkvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func DDFNetworkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func DDFNetworkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "ddfnetworkvr"
 	siteID := "DDFNetworkVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("ddfnetworkvr.com")
 	siteCollector := createCollector("ddfnetworkvr.com")
@@ -111,10 +111,7 @@ func DDFNetworkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 
 	siteCollector.Visit("https://ddfnetworkvr.com/")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/groobyvr.go
+++ b/pkg/scrape/groobyvr.go
@@ -12,12 +12,12 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "groobyvr"
 	siteID := "GroobyVR"
 	allowedDomains := []string{"groobyvr.com", "www.groobyvr.com"}
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector(allowedDomains...)
 	siteCollector := createCollector(allowedDomains...)
@@ -86,10 +86,7 @@ func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	siteCollector.Visit("https://groobyvr.com/tour/categories/movies/1/latest/")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/hologirlsvr.go
+++ b/pkg/scrape/hologirlsvr.go
@@ -11,11 +11,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "hologirlsvr"
 	siteID := "HoloGirlsVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.hologirlsvr.com")
 	siteCollector := createCollector("www.hologirlsvr.com")
@@ -89,10 +89,7 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 	siteCollector.Visit("https://www.hologirlsvr.com/Scenes")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/lethalhardcorevr.go
+++ b/pkg/scrape/lethalhardcorevr.go
@@ -26,9 +26,9 @@ func isGoodTag(lookup string) bool {
 	return true
 }
 
-func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("lethalhardcorevr.com", "whorecraftvr.com")
 	siteCollector := createCollector("lethalhardcorevr.com", "whorecraftvr.com")
@@ -131,19 +131,16 @@ func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 
 	siteCollector.Visit(URL)
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
-func LethalHardcoreVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return LethalHardcoreSite(wg, updateSite, knownScenes, out, "lethalhardcorevr", "LethalHardcoreVR", "https://lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?studio=95595")
+func LethalHardcoreVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return LethalHardcoreSite(wg, updateSite, knownScenes, out, status, "lethalhardcorevr", "LethalHardcoreVR", "https://lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?studio=95595")
 }
 
-func WhorecraftVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return LethalHardcoreSite(wg, updateSite, knownScenes, out, "whorecraftvr", "WhorecraftVR", "https://lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?studio=95347")
+func WhorecraftVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return LethalHardcoreSite(wg, updateSite, knownScenes, out, status, "whorecraftvr", "WhorecraftVR", "https://lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?studio=95347")
 }
 
 func init() {

--- a/pkg/scrape/milfvr.go
+++ b/pkg/scrape/milfvr.go
@@ -13,11 +13,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func MilfVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func MilfVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "milfvr"
 	siteID := "MilfVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.milfvr.com")
 	siteCollector := createCollector("www.milfvr.com")
@@ -107,10 +107,7 @@ func MilfVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://www.milfvr.com/videos?o=d")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -14,11 +14,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "naughtyamericavr"
 	siteID := "NaughtyAmerica VR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.naughtyamerica.com")
 	siteCollector := createCollector("www.naughtyamerica.com")
@@ -133,10 +133,7 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 
 	siteCollector.Visit("https://www.naughtyamerica.com/vr-porn")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/resty.v1"
 )
 
-func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "realitylovers"
 	siteID := "RealityLovers"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("realitylovers.com")
 
@@ -98,10 +98,7 @@ func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		})
 	}
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -13,11 +13,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "realjamvr"
 	siteID := "RealJam VR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("realjamvr.com")
 	siteCollector := createCollector("realjamvr.com")
@@ -47,7 +47,7 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 
 		// Title
 		sc.Title = strings.TrimSpace(e.ChildText(`h1`))
-		
+
 		// Cover URL
 		re := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
 		coverURL := re.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`.splash-screen`, "style")))[1]
@@ -102,10 +102,7 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 
 	siteCollector.Visit("https://realjamvr.com/virtualreality/list")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -13,11 +13,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "sexbabesvr"
 	siteID := "SexBabesVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("sexbabesvr.com")
 	siteCollector := createCollector("sexbabesvr.com")
@@ -116,10 +116,7 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 
 	siteCollector.Visit("https://sexbabesvr.com/virtualreality/list")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/sinsvr.go
+++ b/pkg/scrape/sinsvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "sinsvr"
 	siteID := "SinsVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("sinsvr.com", "www.sinsvr.com")
 	siteCollector := createCollector("sinsvr.com", "www.sinsvr.com")
@@ -88,10 +88,7 @@ func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://sinsvr.com/virtualreality/list/sort/Recent")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -14,9 +14,9 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string) error {
+func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, company string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.sexlikereal.com")
 	siteCollector := createCollector("www.sexlikereal.com")
@@ -162,79 +162,76 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 	siteCollector.Visit("https://www.sexlikereal.com/studios/" + scraperID + "?sort=most_recent")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
 // SLR Originals - SexLikeReal own productions
-func SLROriginals(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "slr-originals", "SLR Originals", "SexLikeReal")
+func SLROriginals(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "slr-originals", "SLR Originals", "SexLikeReal")
 }
 
 // iStripper - Has a site for 2D desktop app, but doesn't even mention they do VR scenes: https://www.istripper.com/
-func iStripper(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "istripper", "iStripper", "TotemCore Ltd")
+func iStripper(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "istripper", "iStripper", "TotemCore Ltd")
 }
 
 // EmilyBloom - does have vertical covers on her site but no scene info to scrape: https://theemilybloom.com/virtual-reality/
-func EmilyBloom(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "emilybloom", "EmilyBloom", "Emily Bloom")
+func EmilyBloom(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "emilybloom", "EmilyBloom", "Emily Bloom")
 }
 
 // VRSexperts - does have large covers on their blog but they appear very delayed: http://www.vrsexperts.com/
-func VRSexperts(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsexperts", "VRSexperts", "VRSexperts")
+func VRSexperts(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "vrsexperts", "VRSexperts", "VRSexperts")
 }
 
 // VReXtasy - Can't find a site/twitter at all
-func VReXtasy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrextasy", "VReXtasy", "VReXtasy")
+func VReXtasy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "vrextasy", "VReXtasy", "VReXtasy")
 }
 
 // VRSolos - https://twitter.com/VRsolos/
-func VRSolos(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "vrsolos", "VRSolos", "VRSolos")
+func VRSolos(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "vrsolos", "VRSolos", "VRSolos")
 }
 
 // Jimmy Draws - https://twitter.com/ukpornmaker
-func JimmyDraws(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "jimmydraws", "JimmyDraws", "Jimmy Draws")
+func JimmyDraws(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "jimmydraws", "JimmyDraws", "Jimmy Draws")
 }
 
 // POVcentralVR - Has a site with mixed 2D/VR content, doesn't seem very scrapeable: http://povcentral.com/home.html
 // Does have a blog for VR scenes but no useful covers: http://blog.povcentralmembers.com/category/3d/
-func POVcentralVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "povcentralvr", "POVcentralVR", "POV Central")
+func POVcentralVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "povcentralvr", "POVcentralVR", "POV Central")
 }
 
 // OnlyTease - Has a site for their 2D scenes, only started doing VR since Oct 2019: https://www.onlytease.com/
-func OnlyTease(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "onlytease", "OnlyTease", "OT Publishing Ltd")
+func OnlyTease(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "onlytease", "OnlyTease", "OT Publishing Ltd")
 }
 
 // perVRt/Terrible - Likely to change to Terrible brand, is working on their own website here: http://terrible.porn/
 // Publishes on SLR as perVRt, includes brands: Juggs, Babygirl, Sappho
 // https://twitter.com/terribledotporn & https://twitter.com/perVRtPORN
-func perVRt(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "pervrt", "perVRt", "Terrible")
+func perVRt(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "pervrt", "perVRt", "Terrible")
 }
 
 // LeninaCrowne - Wife of https://twitter.com/DickTerrible from the perVRt/Terrible Studio.
-func LeninaCrowne(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "leninacrowne", "LeninaCrowne", "Terrible")
+func LeninaCrowne(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "leninacrowne", "LeninaCrowne", "Terrible")
 }
 
 // StripzVR.com doesn't have pagination or a model/scene index that's scrapeable
-func StripzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "stripzvr", "StripzVR", "N1ck Inc.")
+func StripzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "stripzvr", "StripzVR", "N1ck Inc.")
 }
 
 // RealHotVR.com doesn't have complete scene index, pagination stops after two pages
-func RealHotVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return SexLikeReal(wg, updateSite, knownScenes, out, "realhotvr", "RealHotVR", "RealHotVR")
+func RealHotVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, status, "realhotvr", "RealHotVR", "RealHotVR")
 }
 
 func init() {

--- a/pkg/scrape/stasyqvr.go
+++ b/pkg/scrape/stasyqvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "stasyqvr"
 	siteID := "StasyQVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("stasyqvr.com")
 	siteCollector := createCollector("stasyqvr.com")
@@ -110,10 +110,7 @@ func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	siteCollector.Visit("https://stasyqvr.com/virtualreality/list")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "tmwvrnet"
 	siteID := "TmwVRnet"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("tmwvrnet.com")
 	siteCollector := createCollector("tmwvrnet.com")
@@ -106,10 +106,7 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	siteCollector.Visit("https://tmwvrnet.com/categories/movies.html")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -14,9 +14,9 @@ import (
 	"gopkg.in/resty.v1"
 )
 
-func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("virtualrealporn.com", "virtualrealtrans.com")
 	siteCollector := createCollector("virtualrealporn.com", "virtualrealtrans.com")
@@ -220,18 +220,15 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 	siteCollector.Visit(URL)
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
-func VirtualRealPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealporn", "VirtualRealPorn", "https://virtualrealporn.com/")
+func VirtualRealPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, status, "virtualrealporn", "VirtualRealPorn", "https://virtualrealporn.com/")
 }
-func VirtualRealTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealtrans", "VirtualRealTrans", "https://virtualrealtrans.com/")
+func VirtualRealTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, status, "virtualrealtrans", "VirtualRealTrans", "https://virtualrealtrans.com/")
 }
 
 func init() {

--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "virtualtaboo"
 	siteID := "VirtualTaboo"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("virtualtaboo.com")
 	siteCollector := createCollector("virtualtaboo.com")
@@ -112,10 +112,7 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 
 	siteCollector.Visit("https://virtualtaboo.com/videos")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -14,11 +14,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vr3000"
 	siteID := "VR3000"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	siteCollector := createCollector("vr3000.com", "www.vr3000.com")
 
@@ -120,10 +120,7 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://www.vr3000.com")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -12,9 +12,9 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrbangers.com", "vrbtrans.com")
 	siteCollector := createCollector("vrbangers.com", "vrbtrans.com")
@@ -118,18 +118,15 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 
 	siteCollector.Visit(URL)
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
-func VRBangers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrbangers", "VRBangers", "https://vrbangers.com/videos/")
+func VRBangers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, status, "vrbangers", "VRBangers", "https://vrbangers.com/videos/")
 }
-func VRBTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrbtrans", "VRBTrans", "https://vrbtrans.com/videos/")
+func VRBTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, status, "vrbtrans", "VRBTrans", "https://vrbtrans.com/videos/")
 }
 
 func init() {

--- a/pkg/scrape/vrconk.go
+++ b/pkg/scrape/vrconk.go
@@ -13,11 +13,11 @@ import (
 	"mvdan.cc/xurls/v2"
 )
 
-func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vrconk"
 	siteID := "VRCONK"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrconk.com")
 	siteCollector := createCollector("vrconk.com")
@@ -103,10 +103,7 @@ func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://vrconk.com/virtualreality/list")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -13,11 +13,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vrhush"
 	siteID := "VRHush"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrhush.com")
 	siteCollector := createCollector("vrhush.com")
@@ -137,10 +137,7 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://vrhush.com/scenes")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vrlatina.go
+++ b/pkg/scrape/vrlatina.go
@@ -13,11 +13,11 @@ import (
 	"mvdan.cc/xurls/v2"
 )
 
-func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vrlatina"
 	siteID := "VRLatina"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrlatina.com")
 	siteCollector := createCollector("vrlatina.com")
@@ -130,10 +130,7 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	siteCollector.Visit("https://vrlatina.com/videos/?typ=newest")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vrpfilms.go
+++ b/pkg/scrape/vrpfilms.go
@@ -13,11 +13,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRPFilms(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRPFilms(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vrpfilms"
 	siteID := "VRP Films"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrpfilms.com", "www.vrpfilms.com")
 	siteCollector := createCollector("vrpfilms.com", "www.vrpfilms.com")
@@ -127,10 +127,7 @@ func VRPFilms(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	siteCollector.Visit("https://vrpfilms.com/vrp-movies")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/vrteenrs.go
+++ b/pkg/scrape/vrteenrs.go
@@ -11,11 +11,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRTeenrs(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRTeenrs(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "vrteenrs"
 	siteID := "VRTeenrs"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("vrteenrs.com", "www.vrteenrs.com")
 
@@ -59,10 +59,7 @@ func VRTeenrs(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 
 	sceneCollector.Visit("https://www.vrteenrs.com/vrporn.php")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/wankzvr.go
+++ b/pkg/scrape/wankzvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func WankzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func WankzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "wankzvr"
 	siteID := "WankzVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("www.wankzvr.com")
 	siteCollector := createCollector("www.wankzvr.com")
@@ -106,10 +106,7 @@ func WankzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 
 	siteCollector.Visit("https://www.wankzvr.com/videos?o=d")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -12,11 +12,11 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
 	defer wg.Done()
 	scraperID := "wetvr"
 	siteID := "WetVR"
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("wetvr.com")
 	siteCollector := createCollector("wetvr.com")
@@ -99,10 +99,7 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 
 	siteCollector.Visit("https://wetvr.com/")
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 

--- a/pkg/scrape/zexywankitnow.go
+++ b/pkg/scrape/zexywankitnow.go
@@ -13,9 +13,9 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
-	logScrapeStart(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusStarted, updateSite}
 
 	sceneCollector := createCollector("wankitnowvr.com", "zexyvr.com")
 	siteCollector := createCollector("wankitnowvr.com", "zexyvr.com")
@@ -170,19 +170,16 @@ func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, 
 
 	siteCollector.Visit(URL)
 
-	if updateSite {
-		updateSiteLastUpdate(scraperID)
-	}
-	logScrapeFinished(scraperID, siteID)
+	status <- models.ScraperStatus{scraperID, siteID, StatusFinished, updateSite}
 	return nil
 }
 
-func WankitNowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return TwoWebMediaSite(wg, updateSite, knownScenes, out, "wankitnowvr", "WankitNowVR", "https://wankitnowvr.com/videos/")
+func WankitNowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return TwoWebMediaSite(wg, updateSite, knownScenes, out, status, "wankitnowvr", "WankitNowVR", "https://wankitnowvr.com/videos/")
 }
 
-func ZexyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return TwoWebMediaSite(wg, updateSite, knownScenes, out, "zexyvr", "ZexyVR", "https://zexyvr.com/videos/")
+func ZexyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, status chan<- models.ScraperStatus) error {
+	return TwoWebMediaSite(wg, updateSite, knownScenes, out, status, "zexyvr", "ZexyVR", "https://zexyvr.com/videos/")
 }
 
 func init() {

--- a/pkg/xbvr/api_config.go
+++ b/pkg/xbvr/api_config.go
@@ -98,7 +98,6 @@ func (i ConfigResource) versionCheck(req *restful.Request, resp *restful.Respons
 
 func (i ConfigResource) listSites(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var sites []models.Site
 	db.Order("name asc").Find(&sites)
@@ -108,7 +107,6 @@ func (i ConfigResource) listSites(req *restful.Request, resp *restful.Response) 
 
 func (i ConfigResource) toggleSite(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	id := req.PathParameter("site")
 	if id == "" {
@@ -131,7 +129,6 @@ func (i ConfigResource) toggleSite(req *restful.Request, resp *restful.Response)
 
 func (i ConfigResource) listStorage(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var vol []models.Volume
 	db.Raw(`select id, path, last_scan,is_available, is_enabled, type,
@@ -154,7 +151,6 @@ func (i ConfigResource) addStorage(req *restful.Request, resp *restful.Response)
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	switch r.Type {
 	case "local":
@@ -225,7 +221,6 @@ func (i ConfigResource) removeStorage(req *restful.Request, resp *restful.Respon
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	vol := models.Volume{}
 	err = db.First(&vol, id).Error
@@ -263,7 +258,6 @@ func (i ConfigResource) forceSiteUpdate(req *restful.Request, resp *restful.Resp
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	db.Model(&models.Scene{}).Where("site = ?", r.SiteName).Update("needs_update", true)
 }
@@ -279,7 +273,6 @@ func (i ConfigResource) deleteScenes(req *restful.Request, resp *restful.Respons
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var scenes []models.Scene
 	db.Where("site = ?", r.SiteName).Find(&scenes)

--- a/pkg/xbvr/api_deovr.go
+++ b/pkg/xbvr/api_deovr.go
@@ -170,7 +170,6 @@ func (i DeoVRResource) WebService() *restful.WebService {
 
 func (i DeoVRResource) getDeoFile(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	fileId, err := strconv.Atoi(req.PathParameter("file-id"))
 	if err != nil {
@@ -213,7 +212,6 @@ func (i DeoVRResource) getDeoFile(req *restful.Request, resp *restful.Response) 
 
 func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var scene models.Scene
 	db.Preload("Cast").
@@ -311,7 +309,6 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 
 func (i DeoVRResource) getDeoLibrary(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var sceneLists []DeoListScenes
 

--- a/pkg/xbvr/api_dms.go
+++ b/pkg/xbvr/api_dms.go
@@ -65,7 +65,6 @@ func (i DMSResource) sceneById(req *restful.Request, resp *restful.Response) {
 	sceneId := req.QueryParameter("id")
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var scene models.Scene
 	db.Preload("Cast").
@@ -83,7 +82,6 @@ func (i DMSResource) fileById(req *restful.Request, resp *restful.Response) {
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var file models.File
 	db.Where(&models.File{ID: uint(fileId)}).First(&file)
@@ -93,7 +91,6 @@ func (i DMSResource) fileById(req *restful.Request, resp *restful.Response) {
 
 func (i DMSResource) base(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	// Get all accessible scenes
 	var scenes []models.Scene
@@ -168,7 +165,6 @@ func (i DMSResource) getFile(req *restful.Request, resp *restful.Response) {
 
 	// Check if scene exist
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	f := models.File{}
 	err = db.Preload("Volume").First(&f, id).Error

--- a/pkg/xbvr/api_files.go
+++ b/pkg/xbvr/api_files.go
@@ -56,7 +56,6 @@ func (i FilesResource) WebService() *restful.WebService {
 
 func (i FilesResource) listFiles(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var r RequestFileList
 	err := req.ReadEntity(&r)
@@ -191,7 +190,6 @@ func (i FilesResource) listFiles(req *restful.Request, resp *restful.Response) {
 
 func (i FilesResource) matchFile(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var r RequestMatchFile
 	err := req.ReadEntity(&r)
@@ -249,7 +247,6 @@ func (i FilesResource) removeFile(req *restful.Request, resp *restful.Response) 
 	var scene models.Scene
 	var file models.File
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	err = db.Preload("Volume").Where(&models.File{ID: uint(fileId)}).First(&file).Error
 	if err == nil {

--- a/pkg/xbvr/api_playlist.go
+++ b/pkg/xbvr/api_playlist.go
@@ -49,7 +49,6 @@ func (i PlaylistResource) WebService() *restful.WebService {
 
 func (i PlaylistResource) listPlaylists(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var playlists []models.Playlist
 	db.Order("ordering asc").Find(&playlists)
@@ -65,9 +64,6 @@ func (i PlaylistResource) createPlaylist(req *restful.Request, resp *restful.Res
 		return
 	}
 
-	db, _ := models.GetDB()
-	defer db.Close()
-
 	nv := models.Playlist{Name: r.Name, IsDeoEnabled: r.IsDeoEnabled, IsSmart: r.IsSmart, SearchParams: r.SearchParams}
 	nv.Save()
 
@@ -82,7 +78,6 @@ func (i PlaylistResource) updatePlaylist(req *restful.Request, resp *restful.Res
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	playlist := models.Playlist{}
 	err = db.First(&playlist, id).Error
@@ -108,7 +103,6 @@ func (i PlaylistResource) removePlaylist(req *restful.Request, resp *restful.Res
 	}
 
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	playlist := models.Playlist{}
 	err = db.First(&playlist, id).Error

--- a/pkg/xbvr/api_scenes.go
+++ b/pkg/xbvr/api_scenes.go
@@ -77,7 +77,6 @@ func (i SceneResource) WebService() *restful.WebService {
 
 func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	// Get all accessible scenes
 	var scenes []models.Scene
@@ -169,9 +168,6 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 		return
 	}
 
-	db, _ := models.GetDB()
-	defer db.Close()
-
 	var scene models.Scene
 	err = scene.GetIfExist(r.SceneID)
 	if err != nil {
@@ -192,9 +188,6 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 
 func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Response) {
 	q := req.QueryParameter("q")
-
-	db, _ := models.GetDB()
-	defer db.Close()
 
 	idx := NewIndex("scenes")
 	defer idx.bleve.Close()
@@ -243,7 +236,6 @@ func (i SceneResource) addSceneCuepoint(req *restful.Request, resp *restful.Resp
 	}
 
 	var scene models.Scene
-	db, _ := models.GetDB()
 	err = scene.GetIfExistByPK(uint(sceneId))
 	if err == nil {
 		t := models.SceneCuepoint{
@@ -255,7 +247,6 @@ func (i SceneResource) addSceneCuepoint(req *restful.Request, resp *restful.Resp
 
 		scene.GetIfExistByPK(uint(sceneId))
 	}
-	db.Close()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)
 }
@@ -275,13 +266,11 @@ func (i SceneResource) rateScene(req *restful.Request, resp *restful.Response) {
 	}
 
 	var scene models.Scene
-	db, _ := models.GetDB()
 	err = scene.GetIfExistByPK(uint(sceneId))
 	if err == nil {
 		scene.StarRating = r.Rating
 		scene.Save()
 	}
-	db.Close()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)
 }

--- a/pkg/xbvr/server.go
+++ b/pkg/xbvr/server.go
@@ -73,6 +73,9 @@ func authHandle(pattern string, authEnabled bool, authSecret auth.SecretProvider
 }
 
 func StartServer(version, commit, branch, date string) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
 	currentVersion = version
 
 	migrations.Migrate()

--- a/pkg/xbvr/task_content.go
+++ b/pkg/xbvr/task_content.go
@@ -48,7 +48,6 @@ func runScrapers(knownScenes []string, toScrape string, updateSite bool, collect
 	} else {
 		db.Where(&models.Site{ID: toScrape}).Find(&sites)
 	}
-	db.Close()
 
 	var wg sync.WaitGroup
 
@@ -79,7 +78,6 @@ func sceneDBWriter(wg *sync.WaitGroup, i *uint64, scenes <-chan models.ScrapedSc
 	defer wg.Done()
 
 	db, _ := models.GetDB()
-	defer db.Close()
 	for scene := range scenes {
 		if os.Getenv("DEBUG") != "" {
 			log.Printf("Saving %v", scene.SceneID)
@@ -103,7 +101,6 @@ func Scrape(toScrape string) {
 		var scenes []models.Scene
 		db, _ := models.GetDB()
 		db.Find(&scenes)
-		db.Close()
 
 		var knownScenes []string
 		for i := range scenes {
@@ -162,7 +159,6 @@ func ScrapeJAVR(queryString string) {
 		var scenes []models.Scene
 		db, _ := models.GetDB()
 		db.Find(&scenes)
-		db.Close()
 
 		var knownScenes []string
 		for i := range scenes {
@@ -180,7 +176,6 @@ func ScrapeJAVR(queryString string) {
 			for i := range collectedScenes {
 				models.SceneCreateUpdateFromExternal(db, collectedScenes[i])
 			}
-			db.Close()
 
 			tlog.Infof("Updating tag counts")
 			CountTags()
@@ -248,7 +243,6 @@ func ImportBundle(url string) {
 				tlog.Infof("Importing %v of %v scenes", i+1, len(bundleData.Scenes))
 				models.SceneCreateUpdateFromExternal(db, bundleData.Scenes[i])
 			}
-			db.Close()
 
 			tlog.Infof("Import complete")
 		} else {
@@ -260,7 +254,6 @@ func ImportBundle(url string) {
 
 func RenameTags() {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var scenes []models.Scene
 	db.Find(&scenes)
@@ -294,7 +287,6 @@ func RenameTags() {
 
 func CountTags() {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var tags []models.Tag
 	db.Model(&models.Tag{}).Find(&tags)

--- a/pkg/xbvr/task_preview.go
+++ b/pkg/xbvr/task_preview.go
@@ -17,7 +17,6 @@ import (
 
 func GeneratePreviews() {
 	db, _ := models.GetDB()
-	defer db.Close()
 
 	var scenes []models.Scene
 	db.Model(&models.Scene{}).Where("is_available = ?", true).Where("has_video_preview = ?", false).Order("release_date desc").Find(&scenes)
@@ -69,7 +68,7 @@ func renderPreview(sceneID string, inputFile string) error {
 			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
 			"-i", inputFile,
 			"-vf", "crop=in_w/2:in_h:in_w/2:in_h,scale=400:400",
-			"-t", fmt.Sprintf("%v",snippetLength),
+			"-t", fmt.Sprintf("%v", snippetLength),
 			"-an", snippetFile,
 		}
 

--- a/pkg/xbvr/task_search.go
+++ b/pkg/xbvr/task_search.go
@@ -70,7 +70,6 @@ func SearchIndex() {
 		idx := NewIndex("scenes")
 
 		db, _ := models.GetDB()
-		defer db.Close()
 
 		total := 0
 		offset := 0

--- a/pkg/xbvr/task_volume.go
+++ b/pkg/xbvr/task_volume.go
@@ -29,7 +29,6 @@ func RescanVolumes() {
 		models.CheckVolumes()
 
 		db, _ := models.GetDB()
-		defer db.Close()
 
 		tlog := log.WithFields(logrus.Fields{"task": "rescan"})
 


### PR DESCRIPTION
Sometimes scrapers try to write their status at the same time causing the following error:

```
(/go/appsrc/pkg/models/model_site.go:27) 
[2020-04-28 00:40:45]  database is locked 
time="2020-04-28T00:40:45Z" level=error msg="database is locked"
```

This causes the daemon to die. This fix addresses this by creating a channel to send log messages to and it processes them in order ensuring that only one message has a db lock at any given time.