### PR TITLE
Scraper fixes for NAVR and MilfVR

### DIFF
--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -44,7 +44,8 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 
 		// Duration
 		e.ForEach(`div.date-tags div.duration`, func(id int, e *colly.HTMLElement) {
-			tmpDuration, err := strconv.Atoi(strings.Replace(strings.TrimSpace(e.Text), " Min", "", -1))
+			r := strings.NewReplacer("|", "", "min", "")
+			tmpDuration, err := strconv.Atoi(strings.TrimSpace(r.Replace(e.Text)))
 			if err == nil {
 				sc.Duration = tmpDuration
 			}


### PR DESCRIPTION
#291 - MilfVR code is now pretty much identical to WankzVR.

#293 - NAVR has started using a DeoVR video element but only for new scenes, older scenes still use the old video element. Only affects covers and filenames. I added a release date check so it'll work with both but they might change it all to DeoVR at some point.
Also I'm sure the code could be shortened as it's only one element & attribute that's different but since scrapers are changing to a new system soon anyway I didn't want to spend more time on this.