### PR TITLE
Fix NAVR and MilfVR scrapers again

### DIFF
--- a/pkg/scrape/milfvr.go
+++ b/pkg/scrape/milfvr.go
@@ -90,7 +90,7 @@ func MilfVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		out <- sc
 	})
 
-	siteCollector.OnHTML(`ul.pagenav__list a.pagenav__item`, func(e *colly.HTMLElement) {
+	siteCollector.OnHTML(`ul.pagenav__list a.pagenav__link`, func(e *colly.HTMLElement) {
 		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
 		siteCollector.Visit(pageURL)
 	})

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -52,59 +52,51 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 		})
 
 		// Filenames & Covers
-		// There's a different video element for scenes after 20.05.30
-		var since, _ = goment.New("2020-05-30", "YYYY-MM-DD")
-		var current, _ = goment.New(sc.Released, "YYYY-MM-DD")
+		// There's a different video element for the four most recent scenes
+		// New video element
+		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
+			// images5.naughtycdn.com/cms/nacmscontent/v1/scenes/2cst/nikkijaclynmarco/scene/horizontal/1252x708c.jpg
+			base := strings.Split(strings.Replace(e.Attr("poster"), "//", "", -1), "/")
+			baseName := base[5] + base[6]
 
-		if current.IsSameOrAfter(since) {
-			// New video element
-			e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
-				// images5.naughtycdn.com/cms/nacmscontent/v1/scenes/2cst/nikkijaclynmarco/scene/horizontal/1252x708c.jpg
-				base := strings.Split(strings.Replace(e.Attr("poster"), "//", "", -1), "/")
-				baseName := base[5] + base[6]
+			filenames := []string{"_180x180_3dh.mp4", "_smartphonevr60.mp4", "_smartphonevr30.mp4", "_vrdesktopsd.mp4", "_vrdesktophd.mp4", "_180_sbs.mp4", "_180x180_3dh.mp4"}
 
-				filenames := []string{"_180x180_3dh.mp4", "_smartphonevr60.mp4", "_smartphonevr30.mp4", "_vrdesktopsd.mp4", "_vrdesktophd.mp4", "_180_sbs.mp4", "_180x180_3dh.mp4"}
+			for i := range filenames {
+				filenames[i] = baseName + filenames[i]
+			}
 
-				for i := range filenames {
-					filenames[i] = baseName + filenames[i]
-				}
+			sc.Filenames = filenames
 
-				sc.Filenames = filenames
+			base[8] = "horizontal"
+			base[9] = "1182x777c.jpg"
+			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
 
-				base[8] = "horizontal"
-				base[9] = "1182x777c.jpg"
-				sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
+			base[8] = "vertical"
+			base[9] = "1182x1788c.jpg"
+			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
+		})
+		// Old video element
+		e.ForEach(`a.play-trailer img.start-card`, func(id int, e *colly.HTMLElement) {
+			// images5.naughtycdn.com/cms/nacmscontent/v1/scenes/2cst/nikkijaclynmarco/scene/horizontal/1252x708c.jpg
+			base := strings.Split(strings.Replace(e.Attr("src"), "//", "", -1), "/")
+			baseName := base[5] + base[6]
 
-				base[8] = "vertical"
-				base[9] = "1182x1788c.jpg"
-				sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
-			})
+			filenames := []string{"_180x180_3dh.mp4", "_smartphonevr60.mp4", "_smartphonevr30.mp4", "_vrdesktopsd.mp4", "_vrdesktophd.mp4", "_180_sbs.mp4", "_180x180_3dh.mp4"}
 
-		} else {
-			// Old video element
-			e.ForEach(`a.play-trailer img.start-card`, func(id int, e *colly.HTMLElement) {
-				// images5.naughtycdn.com/cms/nacmscontent/v1/scenes/2cst/nikkijaclynmarco/scene/horizontal/1252x708c.jpg
-				base := strings.Split(strings.Replace(e.Attr("src"), "//", "", -1), "/")
-				baseName := base[5] + base[6]
+			for i := range filenames {
+				filenames[i] = baseName + filenames[i]
+			}
 
-				filenames := []string{"_180x180_3dh.mp4", "_smartphonevr60.mp4", "_smartphonevr30.mp4", "_vrdesktopsd.mp4", "_vrdesktophd.mp4", "_180_sbs.mp4", "_180x180_3dh.mp4"}
+			sc.Filenames = filenames
 
-				for i := range filenames {
-					filenames[i] = baseName + filenames[i]
-				}
+			base[8] = "horizontal"
+			base[9] = "1182x777c.jpg"
+			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
 
-				sc.Filenames = filenames
-
-				base[8] = "horizontal"
-				base[9] = "1182x777c.jpg"
-				sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
-
-				base[8] = "vertical"
-				base[9] = "1182x1788c.jpg"
-				sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
-			})
-
-		}
+			base[8] = "vertical"
+			base[9] = "1182x1788c.jpg"
+			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
+		})
 
 		// Gallery
 		e.ForEach(`div.contain-scene-images.desktop-only a.thumbnail`, func(id int, e *colly.HTMLElement) {


### PR DESCRIPTION
Fix for #291 - Overlooked a mistake in the pagination on the MilfVR scraper which caused it to only scrape the first page.

Fix for #293 - NAVR seems to use the different video player for only the four most recent scenes, not from at a certain date. Release date check has been removed so it'll run both video player elements.