### PR TITLE
Add unlisted VRConk scenes & two studios to SLR

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -237,6 +237,16 @@ func RealHotVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 	return SexLikeReal(wg, updateSite, knownScenes, out, "realhotvr", "RealHotVR", "RealHotVR")
 }
 
+// EvilEyeVR doesn't have a working site
+func EvilEyeVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, "evileyevr", "EvilEyeVR", "EvilEyeVR")
+}
+
+// VirtualXPorn does have own site but it's messy, no capitalization, missing tags, description, etc
+func VirtualXPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+	return SexLikeReal(wg, updateSite, knownScenes, out, "virtualxporn", "VirtualXPorn", "VirtualXPorn")
+}
+
 func init() {
 	registerScraper("slr-originals", "SLR Originals", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png", SLROriginals)
 	registerScraper("istripper", "iStripper (SLR)", "https://www.istripper.com/favicons/istripper/apple-icon-120x120.png", iStripper)
@@ -251,4 +261,6 @@ func init() {
 	registerScraper("leninacrowne", "LeninaCrowne (SLR)", "https://mcdn.vrporn.com/files/20190711135807/terrible_logo-e1562878668857_400x400_acf_cropped.jpg", LeninaCrowne)
 	registerScraper("stripzvr", "StripzVR (SLR)", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", StripzVR)
 	registerScraper("realhotvr", "RealHotVR (SLR)", "https://g8iek4luc8.ent-cdn.com/templates/realhotvr/images/favicon.jpg", RealHotVR)
+	registerScraper("evileyevr", "EvilEyeVR (SLR)", "https://mcdn.vrporn.com/files/20190605151715/evileyevr-logo.jpg", EvilEyeVR)
+	registerScraper("virtualxporn", "VirtualXPorn (SLR)", "https://www.virtualxporn.com/tour/custom_assets/favicons/android-chrome-192x192.png", VirtualXPorn)
 }

--- a/pkg/scrape/vrconk.go
+++ b/pkg/scrape/vrconk.go
@@ -103,6 +103,22 @@ func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://vrconk.com/virtualreality/list")
 
+	// Edge-cases: Some early scenes are unlisted in both scenes and model index
+	// #1-10 + 15 by FantAsia, #11-14, 19, 23 by Miss K. #22, 25 by Emi.
+	// Unlisted but not added here: #86 by CumCoders (7 scenes on SLR) & some recent ones are WankzVR scenes from covid partnership.
+	unlistedscenes := [19]string{"1-sex-with-slavic-chick", "2-only-for-your-eyes", "3-looking-for-your-cock",
+		"4-finger-warm-up", "5-fun-with-sex-toy", "6-may-i-suck-it", "7-my-pleasure-in-your-hands", "8-take-me-baby",
+		"9-breakfast-on-the-table", "10-united-boobs-of-desire", "15-i-change-my-lingerie-three-times-for-you",
+		"11-take-care-of-the-bunny", "12-pussy-wide-open", "13-want-to-know-whats-for-dinner", "14-your-eastern-maid",
+		"19-fun-with-real-vr-amateur", "22-juicy-holes", "23-rabbit-fuck", "25-amateur-chick-in-the-kitchen"}
+
+	for _, scene := range unlistedscenes {
+		sceneURL := "https://vrconk.com/virtualreality/scene/id/" + scene
+		if !funk.ContainsString(knownScenes, sceneURL) {
+			sceneCollector.Visit(sceneURL)
+		}
+	}
+
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
 	}


### PR DESCRIPTION
- Add missing unlisted VRConk scenes (fixes #306)
- Add EvilEyeVR & VirtualXPorn studios to SLR scraper (requested in #142)