### PR TITLE
Unescape HTML Elements in Scene Descriptions

### DIFF
--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"html"
 	"strconv"
 	"strings"
 	"sync"
@@ -83,7 +84,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 			out3, _ := vm.Get("desc")
 			desc, _ := out3.ToString()
-			sc.Synopsis = desc
+			sc.Synopsis = html.UnescapeString(desc)
 
 			out4, _ := vm.Get("cast")
 			cast, _ := out4.Export()


### PR DESCRIPTION
I do not know how many scenes this applies to but I noticed it with [this one in particular](https://virtualrealporn.com/vr-porn-video/doggy/flight-cancellation/) where the apostrophes aren't standard apostrophes (`&#x27`) and are written in an encoded HTML. They are actually `&#8217`.

There are likely other scenes out there with this same problem so this should fix those as well.

An alternate solution would be to grab the text of the description element instead of reading the JSON value.