### PR TITLE
Fix Preview Generation

### DIFF
--- a/pkg/xbvr/task_preview.go
+++ b/pkg/xbvr/task_preview.go
@@ -130,9 +130,9 @@ func renderPreview(inputFile string, destFile string, startTime int, snippetLeng
 		"-y",
 		"-f", "concat",
 		"-safe", "0",
-		"-i", concatFile,
+		"-i", filepath.ToSlash(concatFile),
 		"-c", "copy",
-		destFile,
+		filepath.ToSlash(destFile),
 	}
 	err = exec.Command(GetBinPath("ffmpeg"), cmd...).Run()
 	if err != nil {

--- a/pkg/xbvr/task_preview.go
+++ b/pkg/xbvr/task_preview.go
@@ -72,11 +72,11 @@ func renderPreview(inputFile string, destFile string, startTime int, snippetLeng
 	}
 
 	crop := "iw/2:ih:iw/2:ih" // LR videos
-	if strings.Contains(inputFile, "TB") {
+	if vs.Height == vs.Width {
 		crop = "iw/2:ih/2:iw/4:ih/2" // TB videos
-	} else if !strings.Contains(inputFile, "LR") {
-		crop = "iw/2:ih:iw/4:ih" // mono videos
 	}
+	// Mono 360 crop args: (no way of accurately determining)
+	// "iw/2:ih:iw/4:ih"
 	vfArgs := fmt.Sprintf("crop=%v,scale=%v:%v", crop, resolution, resolution)
 
 	// Prepare snippets

--- a/pkg/xbvr/task_preview.go
+++ b/pkg/xbvr/task_preview.go
@@ -71,7 +71,13 @@ func renderPreview(inputFile string, destFile string, startTime int, snippetLeng
 		return err
 	}
 
-	vfArgs := fmt.Sprintf("crop=in_w/2:in_h:in_w/2:in_h,scale=%v:%v", resolution, resolution)
+	crop := "iw/2:ih:iw/2:ih" // LR videos
+	if strings.Contains(inputFile, "TB") {
+		crop = "iw/2:ih/2:iw/4:ih/2" // TB videos
+	} else if !strings.Contains(inputFile, "LR") {
+		crop = "iw/2:ih:iw/4:ih" // mono videos
+	}
+	vfArgs := fmt.Sprintf("crop=%v,scale=%v:%v", crop, resolution, resolution)
 
 	// Prepare snippets
 	interval := dur/float64(snippetAmount) - float64(startTime)

--- a/pkg/xbvr/task_preview.go
+++ b/pkg/xbvr/task_preview.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -66,10 +65,7 @@ func renderPreview(inputFile string, destFile string, startTime int, snippetLeng
 		return err
 	}
 	vs := ffdata.GetFirstVideoStream()
-	dur, err := strconv.ParseFloat(vs.Duration, 64)
-	if err != nil {
-		return err
-	}
+	dur := ffdata.Format.DurationSeconds
 
 	crop := "iw/2:ih:iw/2:ih" // LR videos
 	if vs.Height == vs.Width {


### PR DESCRIPTION
`...\xbvr\video_preview\tmp\concat` becomes `.../xbvr/video_preview/tmp/concat`

Unescaped backslashes will cause problems in ffmpeg arguments so we convert the path to a Unix format (which Windows still supports). For Unix systems this change would do absolutely nothing.

The alternative would be `strings.replace(concatFile, "\\", "\\\\", -1)` which just looks messy and confusing at a glance.