### PR TITLE
fix wankzvr description

### DIFF
--- a/pkg/scrape/wankzvr.go
+++ b/pkg/scrape/wankzvr.go
@@ -74,7 +74,7 @@ func WankzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 
 		// Synopsis
 		e.ForEach(`div.detail__txt`, func(id int, e *colly.HTMLElement) {
-			sc.Synopsis = strings.TrimSpace(e.Text + e.ChildText("span.more__body"))
+			sc.Synopsis = strings.TrimSpace(e.Text)
 		})
 
 		// Tags


### PR DESCRIPTION
Because the child element is included in `e.Text`, its doubling up the result. You only need to grab it once.