### PR TITLE
Add tonight's girlfriend to vrporn.com scraper

### DIFF
--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -149,5 +149,5 @@ func TonightsGirlfriend(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 func init() {
 	registerScraper("randysroadstop", "Randys Road Stop (VRPorn)", "https://mcdn.vrporn.com/files/20170718073527/randysroadstop-vr-porn-studio-vrporn.com-virtual-reality.png", RandysRoadStop)
 	registerScraper("realteensvr", "Real Teens VR (VRPorn)", "https://mcdn.vrporn.com/files/20170718063811/realteensvr-vr-porn-studio-vrporn.com-virtual-reality.png", RealTeensVR)
-	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", TonightsGirlfriend)
+	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend (VRPorn)", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", TonightsGirlfriend)
 }

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -141,7 +141,13 @@ func RealTeensVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	return VRPorn(wg, updateSite, knownScenes, out, "realteensvr", "Real Teens VR", "NaughtyAmerica")
 }
 
+// TonightsGirlfriend - Has its own site but no tags or previews. : https://tonightsgirlfriend.com
+func TonightsGirlfriend(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+	return VRPorn(wg, updateSite, knownScenes, out, "tonightsgirlfriend", "Tonight's Girlfriend", "NaughtyAmerica")
+}
+
 func init() {
 	registerScraper("randysroadstop", "Randys Road Stop (VRPorn)", "https://mcdn.vrporn.com/files/20170718073527/randysroadstop-vr-porn-studio-vrporn.com-virtual-reality.png", RandysRoadStop)
 	registerScraper("realteensvr", "Real Teens VR (VRPorn)", "https://mcdn.vrporn.com/files/20170718063811/realteensvr-vr-porn-studio-vrporn.com-virtual-reality.png", RealTeensVR)
+	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", TonightsGirlfriend)
 }


### PR DESCRIPTION
Added Tonight's Girlfriend. Another "Naughty America" Site. Actual website has VR mixed in with regular videos and there is no information such as tags or preview images on "tour" (non member) pages.