### PR TITLE
fix force-update and delete scenes

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -256,7 +256,7 @@ func init() {
 	registerScraper("jimmydraws", "JimmyDraws (SLR)", "https://mcdn.vrporn.com/files/20190821145930/iLPJW6J7_400x400.png", JimmyDraws)
 	registerScraper("povcentralvr", "POVcentralVR (SLR)", "https://mcdn.vrporn.com/files/20191125091909/POVCentralLogo.jpg", POVcentralVR)
 	registerScraper("onlytease", "OnlyTease (SLR)", "https://www.onlytease.com/assets/img/favicons/ot/apple-touch-icon.png", OnlyTease)
-	registerScraper("pervrt", "perVRt/Terrible (SLR)", "https://mcdn.vrporn.com/files/20181218151630/pervrt-logo.jpg", perVRt)
+	registerScraper("pervrt", "perVRt (SLR)", "https://mcdn.vrporn.com/files/20181218151630/pervrt-logo.jpg", perVRt)
 	registerScraper("leninacrowne", "LeninaCrowne (SLR)", "https://mcdn.vrporn.com/files/20190711135807/terrible_logo-e1562878668857_400x400_acf_cropped.jpg", LeninaCrowne)
 	registerScraper("stripzvr", "StripzVR (SLR)", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", StripzVR)
 	registerScraper("realhotvr", "RealHotVR (SLR)", "https://g8iek4luc8.ent-cdn.com/templates/realhotvr/images/favicon.jpg", RealHotVR)

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -157,7 +157,7 @@ func VRClubz(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 }
 
 func init() {
-	registerScraper("randysroadstop", "Randys Road Stop (VRPorn)", "https://mcdn.vrporn.com/files/20170718073527/randysroadstop-vr-porn-studio-vrporn.com-virtual-reality.png", RandysRoadStop)
+	registerScraper("randysroadstop", "Randy's Road Stop (VRPorn)", "https://mcdn.vrporn.com/files/20170718073527/randysroadstop-vr-porn-studio-vrporn.com-virtual-reality.png", RandysRoadStop)
 	registerScraper("realteensvr", "Real Teens VR (VRPorn)", "https://mcdn.vrporn.com/files/20170718063811/realteensvr-vr-porn-studio-vrporn.com-virtual-reality.png", RealTeensVR)
 	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend VR (VRPorn)", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", TonightsGirlfriend)
 	registerScraper("vrclubz", "VRClubz (VRPorn)", "https://mcdn.vrporn.com/files/20200421094123/vrclubz_logo_NEW-400x400_webwhite.png", VRClubz)

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -97,12 +97,14 @@
         ky.get(`/api/task/scrape?site=${site}`);
       },
       forceSiteUpdate(site) {
+        site = this.sanitizeSiteName(site);
         ky.post(`/api/options/scraper/force-site-update`, {
           json: {"site_name": site}
         });
         this.$buefy.toast.open(`Scenes from ${site} will be updated on next scrape`);
       },
       deleteScenes(site) {
+        site = this.sanitizeSiteName(site);
         this.$buefy.dialog.confirm({
           title: this.$t('Delete scraped scenes'),
           message: `You're about to delete scraped scenes for <strong>${site}</strong>. Previously matched files will return to unmatched state.`,
@@ -114,6 +116,9 @@
             });
           }
         });
+      },
+      sanitizeSiteName(site) {
+        return site.split('(')[0].trim();
       },
       scrapeJAVR() {
         ky.post(`/api/task/scrape-javr`, {json: {q: this.javrQuery}});


### PR DESCRIPTION
For sites where their name doesn't match what's been set in the database (VRPorn and SLR namely), they cannot be deleted or force updated as the query will find no matches.

This PR strips the scraper suffix from the site name as well as tidies up two site names where they also wouldn't match.

Closes #334