### PR TITLE
Fixes tag sorting

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -20,6 +20,9 @@
 
   export default {
     components: {Navbar, Socket, QuickFind, GlobalEvents},
+    mounted() {
+      this.$store.dispatch("optionsWeb/load");
+    }
   }
 </script>
 

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -3,7 +3,7 @@ import ky from "ky";
 const state = {
   loading: false,
   web: {
-    tagSort: 'By Tag Count',
+    tagSort: '',
   },
 };
 
@@ -11,6 +11,8 @@ const mutations = {};
 
 const actions = {
   async load({state}) {
+    // Doesn't need to be loaded more than once
+    if (state.web.tagSort !== '') return;
     state.loading = true;
     ky.get(`/api/options/state`)
       .json()

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -31,9 +31,6 @@
 <script>
   export default {
     name: 'InterfaceWeb',
-    mounted() {
-      this.$store.dispatch("optionsWeb/load");
-    },
     methods: {
       save() {
         this.$store.dispatch("optionsWeb/save");

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -250,7 +250,6 @@
       },
     },
     mounted() {
-      this.$store.dispatch("optionsWeb/load");
       this.setupPlayer();
     },
     methods: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -208,6 +208,8 @@
         const item = this.$store.state.overlay.details.scene;
         if (this.$store.state.optionsWeb.web.tagSort === 'alphabetically') {
           item.tags.sort((a, b) => a.name < b.name ? -1 : 1);
+        } else if (this.$store.state.optionsWeb.web.tagSort === 'by-tag-count') {
+          item.tags.sort((a, b) => a.count > b.count ? -1 : 1);
         }
         return item;
       },
@@ -248,6 +250,7 @@
       },
     },
     mounted() {
+      this.$store.dispatch("optionsWeb/load");
       this.setupPlayer();
     },
     methods: {


### PR DESCRIPTION
I was incorrectly under the impression that the default order of tags with no sorting applied would be by tag count. It was brought to my attention that this wasn't the case.

What this PR changes:

 - Changes the default sort to an empty string and uses it to only load WebUI options once.
 - Adds an `else-if` to where the sorting is applied to actually sort by tag counts.
 - Loads the WebUI options on mount of the App view and removes it from the InterfaceWeb view