### PR TITLE
remove event interruptions

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <GlobalEvents
+      :filter="e => !['INPUT', 'TEXTAREA'].includes(e.target.tagName)"
       @keypress.prevent.questionMark="$store.commit('overlay/showQuickFind')"
     />
     <Navbar/>

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="modal is-active">
     <GlobalEvents
+      :filter="e => !['INPUT', 'TEXTAREA'].includes(e.target.tagName)"
       @keyup.esc="close"
       @keydown.arrowLeft="playerStepBack"
       @keydown.arrowRight="playerStepForward"


### PR DESCRIPTION
This will prevent the global events from triggering while in a text field. Noticed this happening a lot while working on #343.