### PR TITLE
Fix VirtualRealPorn Site ID scraping

### DIFF
--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -34,14 +34,13 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 		var tmpCast []string
 
-		e.ForEach(`body`, func(id int, e *colly.HTMLElement) {
-			bodyClasses := strings.Split(e.Attr("class"), " ")
-			for _, c := range bodyClasses {
-				if strings.HasPrefix(c, "postid-") {
-					sc.SiteID = strings.Split(c, "-")[1]
-					sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
-				}
-			}
+		e.ForEach(`script[id="deovr-js-extra"]`, func(id int, e *colly.HTMLElement) {
+			var jsonObj map[string]interface{}
+			jsonData := e.Text[strings.Index(e.Text, "{") : len(e.Text)-12]
+			json.Unmarshal([]byte(jsonData), &jsonObj)
+
+			sc.SiteID = jsonObj["post_id"].(string)
+			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 		})
 
 		// Title
@@ -59,7 +58,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 		})
 
 		// Gallery
-		e.ForEach(`a.w-gallery-tnail`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`figure[itemprop="associatedMedia"] a`, func(id int, e *colly.HTMLElement) {
 			sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(strings.Split(e.Attr("href"), "?")[0]))
 		})
 

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -34,10 +34,14 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 		var tmpCast []string
 
-		// Scene ID - get from URL
-		e.ForEach(`link[rel=shortlink]`, func(id int, e *colly.HTMLElement) {
-			sc.SiteID = strings.Split(e.Attr("href"), "?p=")[1]
-			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+		e.ForEach(`body`, func(id int, e *colly.HTMLElement) {
+			bodyClasses := strings.Split(e.Attr("class"), " ")
+			for _, c := range bodyClasses {
+				if strings.HasPrefix(c, "postid-") {
+					sc.SiteID = strings.Split(c, "-")[1]
+					sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+				}
+			}
 		})
 
 		// Title


### PR DESCRIPTION
VRP no longer gives the video id as part in a `link[rel=shortLink]`, so scraping videos from them does not work currently. Instead I'm scraping it from the `body` classes.