### PR TITLE
modify action table column length

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -304,6 +304,17 @@ func Migrate() {
 				return tx.AutoMigrate(&models.Action{}).Error
 			},
 		},
+		{
+			ID: "0016-action-value-size",
+			Migrate: func(tx *gorm.DB) error {
+				if models.GetDBConn().Driver == "mysql" {
+					return tx.AutoMigrate(&models.Action{}).Error
+				}
+				tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old")
+				tx.AutoMigrate(&models.Action{})
+				return tx.Model(&models.Action{}).Exec("INSERT INTO actions SELECT * FROM actions_old").Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -308,9 +308,10 @@ func Migrate() {
 			ID: "0016-action-value-size",
 			Migrate: func(tx *gorm.DB) error {
 				if models.GetDBConn().Driver == "mysql" {
-					return tx.AutoMigrate(&models.Action{}).Error
+					tx.Model(&models.Action{}).Exec("RENAME TABLE actions TO actions_old")
+				} else {
+					tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old")
 				}
-				tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old")
 				tx.AutoMigrate(&models.Action{})
 				return tx.Model(&models.Action{}).Exec("INSERT INTO actions SELECT * FROM actions_old").Error
 			},

--- a/pkg/models/model_action.go
+++ b/pkg/models/model_action.go
@@ -8,7 +8,7 @@ type Action struct {
 	SceneID       string `json:"scene_id"`
 	ActionType    string `json:"action_type"`
 	ChangedColumn string `json:"changed_column"`
-	NewValue      string `json:"new_value"`
+	NewValue      string `json:"new_value" gorm:"size:4095"`
 }
 
 func (a *Action) GetIfExist(id uint) error {


### PR DESCRIPTION
MySQL databases have a problem where any value over the column length will throw an error. SQLite does not have this problem. SQLite has a problem where you cannot alter tables, thus the convoluted method of creating a new table and copying the data over.

I will need someone who uses a MySQL database to confirm that this works for them. I can confirm that it works for SQLite.