### PR TITLE
Update badoink.go

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -96,7 +96,12 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		e.ForEach(`dl8-video source`, func(id int, e *colly.HTMLElement) {
 			if id == 0 {
 				origURL := e.Attr("src")
-				fpName := strings.Split(strings.Split(strings.Split(origURL, "_trailer")[0], "_3M")[0], "_3m")[0]
+				
+				// Some scenes had different trailer name "templates". Some videos didn't have trailers and one VRCosplayX (Death Note) was was missing "_" in the name
+				fpName3m := strings.Split(strings.Split(strings.Split(strings.Split(origURL, "_trailer")[0], "_3M")[0], "_3m")[0], "3M")[0]
+				fpName2m := strings.Split(strings.Split(strings.Split(fpName3m, "_trailer")[0], "_2M")[0], "_2m")[0]
+				fpName := strings.Split(strings.Split(strings.Split(fpName2m, "_trailer")[0], "_1M")[0], "_1m")[0]
+				
 				fragmentName := strings.Split(fpName, "/")
 				baseName := fragmentName[len(fragmentName)-1]
 


### PR DESCRIPTION
Fixes pre-existing issue on BaDoink network sites where video trailer used to construct matches was either non-existent or name wasn't what was expected.

Closes #379 