### PR TITLE
Update wankz.go

### DIFF
--- a/pkg/scrape/wankz.go
+++ b/pkg/scrape/wankz.go
@@ -54,7 +54,7 @@ func WankzVRSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Filenames
 		base := e.Request.URL.Path
-		base = strings.Replace(base, "/", "", -1)
+		base = strings.Split(strings.Replace(base, "/", "", -1), sc.SiteID)[0]
 		sc.Filenames = append(sc.Filenames, base+"180_180x180_3dh_LR.mp4")
 		sc.Filenames = append(sc.Filenames, base+"gearvr-180_180x180_3dh_LR.mp4")
 		sc.Filenames = append(sc.Filenames, base+"smartphone-180_180x180_3dh_LR.mp4")


### PR DESCRIPTION
Removes SceneID from filenames for WankzVR, MilfVR, and TranzVR

Closes #386 