### PR TITLE
Replace Twivatar Images

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -162,9 +162,9 @@ func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("badoinkvr", "BadoinkVR", "https://twivatar.glitch.me/badoinkofficial", BadoinkVR)
-	registerScraper("18vr", "18VR", "https://twivatar.glitch.me/18vrofficial", B18VR)
-	registerScraper("vrcosplayx", "VRCosplayX", "https://twivatar.glitch.me/vrcosplayx", VRCosplayX)
+	registerScraper("badoinkvr", "BadoinkVR", "https://pbs.twimg.com/profile_images/618071358933610497/QaMV81nF_200x200.png", BadoinkVR)
+	registerScraper("18vr", "18VR", "https://pbs.twimg.com/profile_images/989481761783545856/w-iKqgqV_200x200.jpg", B18VR)
+	registerScraper("vrcosplayx", "VRCosplayX", "https://pbs.twimg.com/profile_images/900675974039298049/ofMytpkQ_200x200.jpg", VRCosplayX)
 	registerScraper("babevr", "BabeVR", "https://babevr.com/babevr_icons/apple-touch-icon.png", BabeVR)
 	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/kinkvr_icons/apple-touch-icon.png", KinkVR)
 }

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -144,5 +144,5 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 }
 
 func init() {
-	registerScraper("czechvr", "Czech VR (all sites)", "https://twivatar.glitch.me/czechvr", CzechVR)
+	registerScraper("czechvr", "Czech VR (all sites)", "https://pbs.twimg.com/profile_images/1341840147382464517/ZLFgYrt6_200x200.jpg", CzechVR)
 }

--- a/pkg/scrape/ddfnetworkvr.go
+++ b/pkg/scrape/ddfnetworkvr.go
@@ -119,5 +119,5 @@ func DDFNetworkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 }
 
 func init() {
-	registerScraper("ddfnetworkvr", "DDFNetworkVR", "https://twivatar.glitch.me/ddfnetwork", DDFNetworkVR)
+	registerScraper("ddfnetworkvr", "DDFNetworkVR", "https://pbs.twimg.com/profile_images/1083417183722434560/Ur5xIhqG_200x200.jpg", DDFNetworkVR)
 }

--- a/pkg/scrape/groobyvr.go
+++ b/pkg/scrape/groobyvr.go
@@ -94,5 +94,5 @@ func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("groobyvr", "GroobyVR", "https://twivatar.glitch.me/groobyvr", GroobyVR)
+	registerScraper("groobyvr", "GroobyVR", "https://pbs.twimg.com/profile_images/981677396695773184/-kKaWumY_200x200.jpg", GroobyVR)
 }

--- a/pkg/scrape/hologirlsvr.go
+++ b/pkg/scrape/hologirlsvr.go
@@ -102,5 +102,5 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func init() {
-	registerScraper("hologirlsvr", "HoloGirlsVR", "https://twivatar.glitch.me/hologirlsvr", HoloGirlsVR)
+	registerScraper("hologirlsvr", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg", HoloGirlsVR)
 }

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -161,5 +161,5 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 }
 
 func init() {
-	registerScraper("naughtyamericavr", "NaughtyAmerica VR", "https://twivatar.glitch.me/naughtyamerica", NaughtyAmericaVR)
+	registerScraper("naughtyamericavr", "NaughtyAmerica VR", "https://pbs.twimg.com/profile_images/1176909015369965569/Kr31SHCL_200x200.jpg", NaughtyAmericaVR)
 }

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -110,5 +110,5 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 }
 
 func init() {
-	registerScraper("realjamvr", "RealJam VR", "https://twivatar.glitch.me/realjamvr", RealJamVR)
+	registerScraper("realjamvr", "RealJam VR", "https://styles.redditmedia.com/t5_3iym1/styles/communityIcon_kqzp15xw0r361.png", RealJamVR)
 }

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -191,7 +191,7 @@ func init() {
 	addSLRScraper("anal-delight", "Anal Delight", "AnalDelight", "https://mcdn.vrporn.com/files/20200907184611/AnalDelight_Logo.jpg")
 	addSLRScraper("bravomodelsmedia", "BravoModelsMedia", "Bravo Models", "https://mcdn.vrporn.com/files/20181015142403/ohNFa81Q_400x400.png")
 	addSLRScraper("burningangelvr", "BurningAngelVR", "BurningAngelVR", "https://mcdn.vrporn.com/files/20170830191746/burningangel-icon-vr-porn-studio-vrporn.com-virtual-reality.png")
-	addSLRScraper("emilybloom", "EmilyBloom", "Emily Bloom", "https://theemilybloom.com/wp-content/uploads/2017/05/FlowerHeaderLogo.png")
+	addSLRScraper("emilybloom", "EmilyBloom", "Emily Bloom", "https://i.imgur.com/LxYzAQX.png")
 	addSLRScraper("grannies-vr", "GranniesVR", "GranniesVR", "https://mcdn.vrporn.com/files/20180222024100/itsmorti-logo-vr-porn-studio-vrporn.com-virtual-reality.jpg")
 	addSLRScraper("herfirstvr", "HerFirstVR", "HerFirstVR", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png")
 	addSLRScraper("holivr", "HoliVR", "HoliVR", "https://mcdn.vrporn.com/files/20170519145416/Holi_400x400.jpg")

--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -114,5 +114,5 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("tmwvrnet", "TmwVRnet", "https://twivatar.glitch.me/tmwvrnet", TmwVRnet)
+	registerScraper("tmwvrnet", "TmwVRnet", "https://pbs.twimg.com/profile_images/832208391967797250/1rEowkN6_200x200.jpg", TmwVRnet)
 }

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -257,9 +257,9 @@ func VirtualRealPassion(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 }
 
 func init() {
-	registerScraper("virtualrealporn", "VirtualRealPorn", "https://twivatar.glitch.me/virtualrealporn", VirtualRealPorn)
-	registerScraper("virtualrealtrans", "VirtualRealTrans", "https://twivatar.glitch.me/virtualrealporn", VirtualRealTrans)
-	registerScraper("virtualrealgay", "VirtualRealGay", "https://twivatar.glitch.me/virtualrealgay", VirtualRealGay)
-	registerScraper("virtualrealpassion", "VirtualRealPassion", "https://twivatar.glitch.me/vrpassion", VirtualRealPassion)
+	registerScraper("virtualrealporn", "VirtualRealPorn", "https://pbs.twimg.com/profile_images/921297545195859968/E5-ClWkm_200x200.jpg", VirtualRealPorn)
+	registerScraper("virtualrealtrans", "VirtualRealTrans", "https://pbs.twimg.com/profile_images/921298616970555392/3coTQ6UZ_200x200.jpg", VirtualRealTrans)
+	registerScraper("virtualrealgay", "VirtualRealGay", "https://pbs.twimg.com/profile_images/921298132129992704/jIOE0LxX_200x200.jpg", VirtualRealGay)
+	registerScraper("virtualrealpassion", "VirtualRealPassion", "https://pbs.twimg.com/profile_images/921298874249175041/LjWabMPh_200x200.jpg", VirtualRealPassion)
 	registerScraper("virtualrealamateur", "VirtualRealAmateurPorn", "https://mcdn.vrporn.com/files/20170718094205/virtualrealameteur-vr-porn-studio-vrporn.com-virtual-reality.png", VirtualRealAmateur)
 }

--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -120,5 +120,5 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 }
 
 func init() {
-	registerScraper("virtualtaboo", "VirtualTaboo", "https://twivatar.glitch.me/virtualtaboo", VirtualTaboo)
+	registerScraper("virtualtaboo", "VirtualTaboo", "https://pbs.twimg.com/profile_images/978642233011384320/lqF0Rl7K_200x200.jpg", VirtualTaboo)
 }

--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -128,5 +128,5 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("vr3000", "VR3000", "https://twivatar.glitch.me/vrballers", VR3000)
+	registerScraper("vr3000", "VR3000", "https://pbs.twimg.com/profile_images/753992720348217344/-q03m_OT_200x200.jpg", VR3000)
 }

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -146,7 +146,7 @@ func VRBGay(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("vrbangers", "VRBangers", "https://twivatar.glitch.me/vrbangers", VRBangers)
-	registerScraper("vrbtrans", "VRBTrans", "https://twivatar.glitch.me/vrbtrans", VRBTrans)
-	registerScraper("vrbgay", "VRBGay", "https://twivatar.glitch.me/vrbgay", VRBGay)
+	registerScraper("vrbangers", "VRBangers", "https://pbs.twimg.com/profile_images/1115746243320246272/Tiaofu5P_200x200.png", VRBangers)
+	registerScraper("vrbtrans", "VRBTrans", "https://pbs.twimg.com/profile_images/980851177557340160/eTnu1ZzO_200x200.jpg", VRBTrans)
+	registerScraper("vrbgay", "VRBGay", "https://pbs.twimg.com/profile_images/916453413344313344/8pT50i9j_200x200.jpg", VRBGay)
 }

--- a/pkg/scrape/vrlatina.go
+++ b/pkg/scrape/vrlatina.go
@@ -138,5 +138,5 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("vrlatina", "VRLatina", "https://twivatar.glitch.me/vrlatinas", VRLatina)
+	registerScraper("vrlatina", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg", VRLatina)
 }

--- a/pkg/scrape/wankz.go
+++ b/pkg/scrape/wankz.go
@@ -144,7 +144,7 @@ func TranzVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 }
 
 func init() {
-	registerScraper("wankzvr", "WankzVR", "https://twivatar.glitch.me/wankzvr", WankzVR)
-	registerScraper("milfvr", "MilfVR", "https://twivatar.glitch.me/milfvr", MilfVR)
-	registerScraper("tranzvr", "TranzVR", "https://twivatar.glitch.me/tranzvr", TranzVR)
+	registerScraper("wankzvr", "WankzVR", "https://pbs.twimg.com/profile_images/705066968986955776/3Pme_Bss_200x200.jpg", WankzVR)
+	registerScraper("milfvr", "MilfVR", "https://pbs.twimg.com/profile_images/839152136449470464/Yw3Q3es2_200x200.jpg", MilfVR)
+	registerScraper("tranzvr", "TranzVR", "https://pbs.twimg.com/profile_images/1038092474822979584/JduwAUTl_200x200.jpg", TranzVR)
 }


### PR DESCRIPTION
Twivatar has been down for months and as such, caused numerous 404 errors when XBVR attempts to fetch scraper images.

This PR replaces Twivatar calls with a direct link to the image on Twitter's servers. This is only a temporary fix and a proper solution needs to be found.

I have also fixed the image for EmilyBloom in this PR as the site is now behind Cloud Flare and as such cannot be fetched in the same manner. The image is the same, just reuploaded to imgur. This is also temporary pending a proper fix.