### PR TITLE
Fix scene detail scrolling and scraper menu clipping

### DIFF
--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -141,6 +141,7 @@
 
   .card {
     height: 100%;
+    overflow: visible;
   }
 
   .card-content {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -349,7 +349,11 @@
         }
       },
       getIndicatorURL(idx) {
-        return this.getImageURL(this.images[idx].url, "x40")
+        if (this.images[idx] !== undefined) {
+          return this.getImageURL(this.images[idx].url, "x40");
+        } else {
+          return "";
+        }
       },
       playCuepoint(cuepoint) {
         this.player.currentTime(cuepoint.time_start);


### PR DESCRIPTION
Two small UI fixes:
 - Resolve the issue when viewing scene details then navigating to a scene with fewer thumbnails. Reactivity resolution order causes getImageURL() calls beyond the array bounds.
 - Allow the scraper menus to overflow outside the card boundaries, preventing clipping.

Fixes #326