### PR TITLE
Add error handling when finding out the modification/creation times, …

### DIFF
--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -148,7 +148,10 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 		bar.Output = nil
 		for j, pth := range procList {
 			fStat, _ := os.Stat(pth)
-			fTimes, _ := times.Stat(pth)
+			fTimes, err := times.Stat(pth)
+			if err != nil {
+				tlog.Errorf("Can't get the modification/creation times for %s, error: %s", pth, err)
+			}
 
 			var birthtime time.Time
 			if fTimes.HasBirthTime() {

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -149,7 +149,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			return nil
 		})
 
-		for j, pth := range procList {
+		for j, pth := range videoProcList {
 			fStat, _ := os.Stat(pth)
 			fTimes, err := times.Stat(pth)
 			if err != nil {

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -149,11 +149,11 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			return nil
 		})
 
-		for j, pth := range videoProcList {
-			fStat, _ := os.Stat(pth)
-			fTimes, err := times.Stat(pth)
+		for j, path := range videoProcList {
+			fStat, _ := os.Stat(path)
+			fTimes, err := times.Stat(path)
 			if err != nil {
-				tlog.Errorf("Can't get the modification/creation times for %s, error: %s", pth, err)
+				tlog.Errorf("Can't get the modification/creation times for %s, error: %s", path, err)
 			}
 
 			var birthtime time.Time


### PR DESCRIPTION
…otherwise it fails on segfault later on w/o any info for the user


fixing:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x4bc82ae]
```
It will report a file that's broken, in my case it was `.@__thumb` directories created by some stupid service in qnap nas that i had to deactivate