### PR TITLE
add duration fallback to ffprobe scans to avoid infinite re-probing

### DIFF
--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -186,6 +186,8 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 				fl.VideoHeight = vs.Height
 				if dur, err := strconv.ParseFloat(vs.Duration, 64); err == nil {
 					fl.VideoDuration = dur
+				} else if ffdata.Format.DurationSeconds > 0.0 {
+					fl.VideoDuration = ffdata.Format.DurationSeconds
 				}
 
 				if vs.Height*2 == vs.Width || vs.Width > vs.Height {
@@ -288,7 +290,7 @@ func scanPutIO(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			db.Delete(&allFiles[i])
 		}
 	}
-	
+
 	// Update volume info
 	vol.IsAvailable = true
 	vol.Path = "Put.io (" + acct.Username + ")"


### PR DESCRIPTION
certain video codecs don't seem to report a video stream duration, and thus these videos get ffprobed on every rescan. This PR uses the duration field of the Format record as a fallback.