### PR TITLE
Clear cast/tag associations when updating scenes

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -340,6 +340,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	SaveWithRetry(db, &o)
 
 	// Clean & Associate Tags
+	db.Model(&o).Association("Tags").Clear()
 	var tmpTag Tag
 	for _, name := range ext.Tags {
 		tagClean := ConvertTag(name)
@@ -351,6 +352,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	}
 
 	// Clean & Associate Actors
+	db.Model(&o).Association("Cast").Clear()
 	var tmpActor Actor
 	for _, name := range ext.Cast {
 		tmpActor = Actor{}


### PR DESCRIPTION
Sometimes in the past the SinsVR scraper has picked up some false cast members, which didn't go away when rescraping these scenes. This PR clears these associations before appending the current data.