### PR TITLE
Filter common words from match search (#342) 

### DIFF
--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -86,8 +86,19 @@ export default {
   },
   methods: {
     initView () {
+      const commonWords = [
+        '180', '180x180', '30fps', '360', '3dh', '4k', '5k', '60fps', '6k', '7k', '8k',
+        'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv', 'mkx200', 'mono',
+        'mp4', 'oculus', 'oculusrift', 'original', 'smartphone', 'vp9'
+      ]
+      const isNotCommonWord = word => !commonWords.includes(word.toLowerCase()) && !/^[0-9]+p$/.test(word)
+
       this.data = []
-      this.queryString = this.file.filename.replace(/\./g, ' ').replace(/\_/g, ' ').replace(/\+/g, ' ').replace(/\-/g, ' ')
+      this.queryString = (
+        this.file.filename
+          .replace(/\.|_|\+|-/g, ' ').replace(/\s+/g, ' ').trim()
+          .split(' ').filter(isNotCommonWord).join(' ')
+          .replace(/ s /g, '\'s '))
       this.loadData()
     },
     loadData: async function loadData () {

--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -40,6 +40,8 @@
       </div>
     </div>
 
+    <div class="is-clearfix"></div>
+
     <div class="columns is-multiline">
       <div :class="['column', 'is-multiline', cardSizeClass]"
            v-for="item in items" :key="item.id">


### PR DESCRIPTION
Removes some common words from the match search.

Also fixes a bug in the scenes list where on small screens, the "card size" widget would reduce the width of the first scene.

Closes #342