### PR TITLE
add support for MKX200 projection in DeoVR

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -316,6 +316,11 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		})
 	}
 
+	if videoFiles[0].VideoProjection == "mkx200" {
+		stereoMode = "sbs"
+		screenType = "mkx200"
+	}
+
 	if videoFiles[0].VideoProjection == "180_sbs" {
 		stereoMode = "sbs"
 		screenType = "dome"

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -149,6 +150,8 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			return nil
 		})
 
+		filenameSeparator := regexp.MustCompile("[ _.-]+")
+
 		for j, path := range videoProcList {
 			fStat, _ := os.Stat(path)
 			fTimes, err := times.Stat(path)
@@ -195,6 +198,12 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 
 				if vs.Height*2 == vs.Width || vs.Width > vs.Height {
 					fl.VideoProjection = "180_sbs"
+					nameparts := filenameSeparator.Split(strings.ToLower(filepath.Base(path)), -1)
+					for _, part := range nameparts {
+						if part == "mkx200" {
+							fl.VideoProjection = "mkx200"
+						}
+					}
 				}
 
 				if vs.Height == vs.Width {


### PR DESCRIPTION
The last update of DeoVR removed the fisheye switch from the option panel, which could somewhat correct the projection of certain SLR Originals releases. This PR sends the correct option to DeoVR for file names containing "mkx200". 