### PR TITLE
Reset star rating when switching scenes

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -60,8 +60,8 @@
                 <small>{{item.site}}</small>
                 <div class="columns">
                   <div class="column">
-                    <star-rating :rating="item.star_rating" @rating-selected="setRating" :increment="0.5"
-                                 :star-size="20"/>
+                    <star-rating :key="item.id" :rating="item.star_rating" @rating-selected="setRating"
+                                 :increment="0.5" :star-size="20"/>
                   </div>
                   <div class="column">
                     <div class="is-pulled-right">


### PR DESCRIPTION
This PR fixes a bug with the star rating display.

Currently, whenever a user rates a scene, the rating is sent to the server and the scene list is updated but the scene details stay unchanged. Because of this, the `star-rating` component still has the original rating in its `rating` prop and is not re-rendered.

When the user now switches to another scene with the same original rating, the `star-rating` component still shows the user-selected rating of the previous scene, and not the correct rating of the current scene.

Steps to reproduce:
1. Find two scenes with the same rating (e.g. two unrated scenes, or two scenes at rating 4.0)
2. Open the first scene and set the rating to 5.0.
3. Switch to the next scene and note how the rating stays at 5.0, even though the next scene should be 0 or 4.0.

**Note:** This PR adds a `key` prop to the `star-rating` component. Alternatively, we could update the scene after the server response like this:

```diff
    setRating (val) {
-     ky.post(`/api/scene/rate/${this.item.id}`, { json: { rating: val } })
-
-      const updatedScene = Object.assign({}, this.item)
-      updatedScene.star_rating = val
-      this.$store.commit('sceneList/updateScene', updatedScene)
+      ky.post(`/api/scene/rate/${this.item.id}`, {
+        json: { rating: val }
+      }).json().then(data => {
+        this.$store.commit('overlay/showDetails', { scene: data })
+        this.$store.commit('sceneList/updateScene', data)
+      })
    },
```

However, I have not been able to get Go to build locally and test it, so I am more comfortable with adding the `key` prop.