### PR TITLE
Enforce yuv420p format to fix error with 7k BadoinkVR videos

### DIFF
--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -85,6 +85,7 @@ func RenderPreview(inputFile string, destFile string, startTime int, snippetLeng
 			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
 			"-i", inputFile,
 			"-vf", vfArgs,
+			"-pix_fmt", "yuv420p",
 			"-t", fmt.Sprintf("%v", snippetLength),
 			"-an", snippetFile,
 		}


### PR DESCRIPTION
This PR fixes the preview generation of 7k BadoinkVR videos.

Currently, the 7k BadoinkVR videos are converted into pixel format `yuv420p10le`, while all other videos are converted into pixel format `yuv420p`.

The `yuv420p10le` videos cause the following problems:
- DeoVR immediately freezes when hovering over a BadoinkVR 7k scene. You need to force close it and when restarting, be careful not to hover over a BadoinkVR scene.
- The Firefox video renderer crashes, meaning that all video playback (on all websites) is broken until Firefox is restarted.
- Thumbnails are missing in Windows Explorer: https://i.imgur.com/n1tGRN4.jpg (NSFW)

However, these videos play fine in VLC and Chromium-based browsers.

This PR ensures that all videos are converted into `yuv420p` pixel format.