### PR TITLE
Update vr3000.go

### DIFF
--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -81,10 +81,10 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 					sc.Filenames = append(sc.Filenames, f)
 				} else {
 					// We're just gonna guess based on the newest filenames
-					filenames := []string{"VR3000_%s_1920_60fps_30mb_180x180_3dh.mp4",
-						"VR3000_%s_1440_60fps_30mb_180x180_3dh.mp4",
-						"VR3000_%s_960_60fps_15mb_180x180_3dh.mp4",
-						"VR3000_%s_960_30fps_10mb_180x180_3dh.mp4"}
+					filenames := []string{"%s_1920_60fps_30mb_180x180_3dh.mp4",
+						"%s_1440_60fps_30mb_180x180_3dh.mp4",
+						"%s_960_60fps_15mb_180x180_3dh.mp4",
+						"%s_960_30fps_10mb_180x180_3dh.mp4"}
 					for i := range filenames {
 						filenames[i] = fmt.Sprintf(filenames[i], sc.SiteID)
 					}


### PR DESCRIPTION
The current (and past) naming scheme didn't have VR3000 in the filename. Here is a list of the latest file:
73_1920_60fps_30mb_180x180_3dh.mp4
73_1440_60fps_30mb_180x180_3dh.mp4
73_960_60fps_15mb_180x180_3dh.mp4
73_960_30fps_10mb_180x180_3dh.mp4