### PR TITLE
Update navr.go

### DIFF
--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -37,7 +37,7 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 
 		// Title
-		sc.Title = strings.TrimSpace(e.ChildText(`Title`))
+		sc.Title = strings.TrimSpace(e.ChildText(`div.scene-info a.site-title`)) + " - " + strings.TrimSpace(e.ChildText(`Title`))
 
 		// Date
 		e.ForEach(`div.date-tags span.entry-date`, func(id int, e *colly.HTMLElement) {
@@ -78,9 +78,9 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 			sc.Covers = append(sc.Covers, "https://"+strings.Join(base, "/"))
 		})
 		// Old video element
-		e.ForEach(`a.play-trailer img.start-card`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`a.play-trailer img.start-card.desktop-only`, func(id int, e *colly.HTMLElement) {
 			// images5.naughtycdn.com/cms/nacmscontent/v1/scenes/2cst/nikkijaclynmarco/scene/horizontal/1252x708c.jpg
-			base := strings.Split(strings.Replace(e.Attr("src"), "//", "", -1), "/")
+			base := strings.Split(strings.Replace(e.Attr("data-srcset"), "//", "", -1), "/")
 			baseName := base[5] + base[6]
 			defaultBaseName := "nam" + base[6]
 


### PR DESCRIPTION
add "Site" to Title. Updated "old video element" code (pre 11/2017 scenes) to correct crashing on filename manipulation and avoid (or remove during forced scene update) duplicate "cover" images.