### PR TITLE
Ignore old search results if they arrive out of order

### DIFF
--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -80,6 +80,8 @@ export default {
   data () {
     return {
       data: [],
+      dataNumRequests: 0,
+      dataNumResponses: 0,
       selected: null,
       isFetching: false
     }
@@ -88,8 +90,13 @@ export default {
     format,
     parseISO,
     getAsyncData: async function (query) {
+      const requestIndex = this.dataNumRequests
+      this.dataNumRequests = this.dataNumRequests + 1
+
       if (!query.length) {
         this.data = []
+        this.dataNumResponses = requestIndex + 1
+        this.isFetching = false
         return
       }
 
@@ -101,12 +108,18 @@ export default {
         }
       }).json()
 
-      this.isFetching = false
 
-      if (resp.results > 0) {
-        this.data = resp.scenes
-      } else {
-        this.data = []
+      if (requestIndex >= this.dataNumResponses) {
+        this.dataNumResponses = requestIndex + 1
+        if (this.dataNumResponses === this.dataNumRequests) {
+          this.isFetching = false
+        }
+
+        if (resp.results > 0) {
+          this.data = resp.scenes
+        } else {
+          this.data = []
+        }
       }
     },
     getImageURL (u) {

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -70,6 +70,8 @@ export default {
   data () {
     return {
       data: [],
+      dataNumRequests: 0,
+      dataNumResponses: 0,
       currentPage: 1,
       queryString: '',
       format,
@@ -103,18 +105,25 @@ export default {
       this.loadData()
     },
     loadData: async function loadData () {
+      const requestIndex = this.dataNumRequests
+      this.dataNumRequests = this.dataNumRequests + 1
+
       const resp = await ky.get('/api/scene/search', {
         searchParams: {
           q: this.queryString
         }
       }).json()
 
-      if (resp.scenes !== null) {
-        this.data = resp.scenes
-      } else {
-        this.data = []
+      if (requestIndex >= this.dataNumResponses) {
+        this.dataNumResponses = requestIndex + 1
+
+        if (resp.scenes !== null) {
+          this.data = resp.scenes
+        } else {
+          this.data = []
+        }
+        this.currentPage = 1
       }
-      this.currentPage = 1
     },
     getImageURL (u) {
       if (u.startsWith('http')) {


### PR DESCRIPTION
Fixes a bug where the search results are incorrect if the responses arrive out of order. This affects both file matching and quick find.