### PR TITLE
Add scripted icon in scene card, fix video previews

### DIFF
--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -7,24 +7,22 @@
            @mouseover="preview = true"
            @mouseleave="preview = false">
         <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}`" autoplay loop></video>
-        <div v-else>
-          <div class="overlay align-bottom-left">
-            <div style="padding: 5px">
-              <b-tag v-if="item.is_watched">
-                <b-icon pack="mdi" icon="eye" size="is-small"/>
-              </b-tag>
-              <b-tag type="is-info" v-if="videoFilesCount > 1 && !item.is_multipart">
-                <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
-                {{item.file.length}}
-              </b-tag>
-              <b-tag type="is-info" v-if="item.is_scripted">
-                <b-icon pack="mdi" icon="pulse" size="is-small"/>
-              </b-tag>
-              <b-tag type="is-warning" v-if="item.star_rating > 0">
-                <b-icon pack="mdi" icon="star" size="is-small"/>
-                {{item.star_rating}}
-              </b-tag>
-            </div>
+        <div class="overlay align-bottom-left">
+          <div style="padding: 5px">
+            <b-tag v-if="item.is_watched">
+              <b-icon pack="mdi" icon="eye" size="is-small"/>
+            </b-tag>
+            <b-tag type="is-info" v-if="videoFilesCount > 1 && !item.is_multipart">
+              <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
+              {{item.file.length}}
+            </b-tag>
+            <b-tag type="is-info" v-if="item.is_scripted">
+              <b-icon pack="mdi" icon="pulse" size="is-small"/>
+            </b-tag>
+            <b-tag type="is-warning" v-if="item.star_rating > 0">
+              <b-icon pack="mdi" icon="star" size="is-small"/>
+              {{item.star_rating}}
+            </b-tag>
           </div>
         </div>
       </div>
@@ -105,6 +103,15 @@ export default {
     line-height: 0;
   }
 
+  .bbox:not(:hover) > video {
+    display: none;
+  }
+
+  video {
+    position: absolute;
+    max-height: 100%;
+  }
+
   .overlay {
     flex: 1 0 calc(25%);
     display: flex;
@@ -118,6 +125,7 @@ export default {
     top: 0;
     right: 0;
     bottom: 0;
+    pointer-events: none;
   }
 
   .align-bottom-left {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -17,6 +17,9 @@
                 <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
                 {{item.file.length}}
               </b-tag>
+              <b-tag type="is-info" v-if="item.is_scripted">
+                <b-icon pack="mdi" icon="pulse" size="is-small"/>
+              </b-tag>
               <b-tag type="is-warning" v-if="item.star_rating > 0">
                 <b-icon pack="mdi" icon="star" size="is-small"/>
                 {{item.star_rating}}
@@ -100,10 +103,6 @@ export default {
     overflow: hidden;
     padding: 0;
     line-height: 0;
-  }
-
-  .is-scripted {
-    background: ;
   }
 
   .overlay {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -108,8 +108,10 @@ export default {
   }
 
   video {
+    object-fit: cover;
     position: absolute;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
   }
 
   .overlay {


### PR DESCRIPTION
This PR adds a small icon in the scene card if the scene is scripted. I used Material Design's `pulse` icon which matches the icon we show in the scene details.

Also, this PR changes how video previews work:
- Tags (rating, is_watched, is_scripted, is_multipart) are now displayed on the video preview. They don't take up much space so I don't see why we would want to hide them.
- Fixes a bug where the video previews would keep playing after mouseout. I haven't been able to find the root cause (seems to be related to how the mouse events fire), so this just hides the videos with CSS for now.
- Fixes a bug with some older VirtualRealPorn scenes that are not in 2:1 format (the previews get generated as 400x450, not 400x400). The preview videos are now shrunk to 100% height so that they do not mess up the layout.