### PR TITLE
Do not suggest already selected cast/sites/tags

### DIFF
--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -102,9 +102,9 @@
 </template>
 
 <script>
-import ky from 'ky';
-import GlobalEvents from 'vue-global-events';
-import ListEditor from '../../components/ListEditor';
+import ky from 'ky'
+import GlobalEvents from 'vue-global-events'
+import ListEditor from '../../components/ListEditor'
 
 export default {
   name: 'EditScene',
@@ -141,12 +141,16 @@ export default {
   },
   methods: {
     getFilteredCast (text) {
-      this.filteredCast = this.filters.cast.filter(option =>
-        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
+      this.filteredCast = this.filters.cast.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0) &&
+        !this.scene.cast.some(entry => entry.name === option.toString())
+      )
     },
     getFilteredTags (text) {
-      this.filteredTags = this.filters.tags.filter(option =>
-        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
+      this.filteredTags = this.filters.tags.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0) &&
+        !this.scene.tags.some(entry => entry.name === option.toString())
+      )
     },
     close () {
       if (this.changesMade) {

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -158,19 +158,22 @@ export default {
       })
     },
     getFilteredCast (text) {
-      this.filteredCast = this.filters.cast.filter((option) => {
-        return option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0
-      })
+      this.filteredCast = this.filters.cast.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
+        !this.cast.some(entry => entry.toString() === option.toString())
+      ))
     },
     getFilteredSites (text) {
-      this.filteredSites = this.filters.sites.filter((option) => {
-        return option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0
-      })
+      this.filteredSites = this.filters.sites.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
+        !this.sites.some(entry => entry.toString() === option.toString())
+      ))
     },
     getFilteredTags (text) {
-      this.filteredTags = this.filters.tags.filter((option) => {
-        return option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0
-      })
+      this.filteredTags = this.filters.tags.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
+        !this.tags.some(entry => entry.toString() === option.toString())
+      ))
     },
     clearReleaseMonth () {
       this.$store.state.sceneList.filters.releaseMonth = ''


### PR DESCRIPTION
Currently, the filters by cast/sites/tags and the cast/tag selection when editing a scene will suggest entries even if the user has already selected them. This PR removes already selected entries from the suggestions.