### PR TITLE
Close pop-up after last file match (#240)

### DIFF
--- a/ui/src/store/files.js
+++ b/ui/src/store/files.js
@@ -16,18 +16,26 @@ const state = {
 
 const getters = {
   prevFile: (state) => (currentFile) => {
-    const i = state.items.findIndex(item => item.id === currentFile.id)
-    if (i === 0) {
+    if (state.items.length <= 1) {
+      return null
+    }
+
+    const currentIndex = state.items.findIndex(item => item.id === currentFile.id)
+    if (currentIndex === 0) {
       return state.items[state.items.length - 1]
     }
-    return state.items[i - 1]
+    return state.items[currentIndex - 1]
   },
   nextFile: (state) => (currentFile) => {
-    const i = state.items.findIndex(item => item.id === currentFile.id)
-    if (i === state.items.length - 1) {
+    if (state.items.length <= 1) {
+      return null
+    }
+
+    const currentIndex = state.items.findIndex(item => item.id === currentFile.id)
+    if (currentIndex === state.items.length - 1) {
       return state.items[0]
     }
-    return state.items[i + 1]
+    return state.items[currentIndex + 1]
   }
 }
 

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -136,6 +136,8 @@ export default {
       const data = this.$store.getters['files/nextFile'](this.file)
       if (data !== null) {
         this.nextFile()
+      } else {
+        this.close()
       }
     },
     nextFile () {

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -90,7 +90,7 @@ export default {
         '180', '180x180', '30fps', '360', '3dh', '4k', '5k', '60fps', '6k', '7k', '8k',
         'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv', 'mkx200', 'mkx220',
         'mono', 'mp4', 'oculus', 'oculus5k', 'oculusrift', 'original', 'smartphone',
-        'vrca220', 'vp9'
+        'tb', 'vrca220', 'vp9'
       ]
       const isNotCommonWord = word => !commonWords.includes(word.toLowerCase()) && !/^[0-9]+p$/.test(word)
 


### PR DESCRIPTION
Closes the SceneMatch modal if we matched the last file in the list.

Also adds "tb" (top/bottom) to the list of common words, which is used for some older 360 scenes.

Fixes #240.