### PR TITLE
Fix cover URLs of free Badoink videos, fix VR Bangers synopsis

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -39,10 +39,16 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			sc.Title = strings.TrimSpace(e.Text)
 		})
 
-		// Cover URLs
-		e.ForEach(`div#videoPreviewContainer picture img`, func(id int, e *colly.HTMLElement) {
+		// Cover URLs for paid videos
+		e.ForEach(`div#videoPreviewContainer .video-image-container picture img`, func(id int, e *colly.HTMLElement) {
 			if id == 0 {
 				sc.Covers = append(sc.Covers, strings.Split(e.Attr("src"), "?")[0])
+			}
+		})
+		// Cover URLs for free videos
+		e.ForEach(`div#videoPreviewContainer dl8-video`, func(id int, e *colly.HTMLElement) {
+			if id == 0 {
+				sc.Covers = append(sc.Covers, strings.Split(e.Attr("poster"), "?")[0])
 			}
 		})
 

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -96,7 +96,7 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		sc.Gallery = e.ChildAttrs(`div.free-gallery a.fancybox`, "href")
 
 		// Synopsis
-		sc.Synopsis = strings.TrimSpace(e.ChildText(`div.video-content__description div.less-text`))
+		sc.Synopsis = strings.TrimSpace(strings.Replace(e.ChildText(`div.video-content__description div.less-text`), `arrow_drop_up`, ``, -1))
 
 		// Tags
 		e.ForEach(`div.video-item__tags a`, func(id int, e *colly.HTMLElement) {


### PR DESCRIPTION
Badoink's free scenes, like BadoinkVR's Over Qualified or 18VR's Basket Balling, have a slightly different DOM than the paid scenes. Currently, on those scenes the scraper uses the first gallery image, not the actual cover image. With this change it will always pick the correct cover image.

Also fixes VR Bangers' synopsis, which currently always contains the text "arrow_drop_up" at the end because of the collapse icon.