### PR TITLE
Remove unneeded Go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,6 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/blevesearch/bleve v1.0.14
 	github.com/creasty/defaults v1.5.1
-	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
-	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
-	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
 	github.com/darwayne/go-timecode v1.1.0
 	github.com/djherbis/times v1.2.0
 	github.com/dsnet/compress v0.0.1 // indirect
@@ -37,7 +34,6 @@ require (
 	github.com/gowww/log v1.0.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/jinzhu/gorm v1.9.16
-	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kennygrant/sanitize v1.2.4 // indirect


### PR DESCRIPTION
These dependencies are automatically removed from `go.mod` during `go generate` so we can probably remove them.