### PR TITLE
Fix synopsis for SLR scraper in interactive scenes

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -50,7 +50,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Synopsis
 		sc.Synopsis = strings.TrimSpace(
-			e.DOM.Find(`div#tabs-about div.u-mb--four`).First().Text())
+			e.DOM.Find(`div#tabs-about > div.u-mt--three > div.u-mb--four`).First().Text())
 
 		// Skipping some very generic and useless tags
 		skiptags := map[string]bool{


### PR DESCRIPTION
On SLR, videos with teledildonics support have another `.u-mb--four` element before the synopsis. This PR fixes the scraper so it will always return the correct synopsis.