### PR TITLE
Do not run cron job during active session

### DIFF
--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -16,12 +16,20 @@ func SetupCron() {
 	cronInstance.AddFunc("@every 2s", session.CheckForDeadSession)
 	cronInstance.AddFunc("@every 6h", tasks.CalculateCacheSizes)
 	cronInstance.AddFunc(fmt.Sprintf("@every %vh", config.Config.Cron.ScrapeContentInterval), scrapeCron)
-	cronInstance.AddFunc(fmt.Sprintf("@every %vh", config.Config.Cron.RescanLibraryInterval), tasks.RescanVolumes)
+	cronInstance.AddFunc(fmt.Sprintf("@every %vh", config.Config.Cron.RescanLibraryInterval), rescanCron)
 	cronInstance.Start()
 
 	go tasks.CalculateCacheSizes()
 }
 
 func scrapeCron() {
-	tasks.Scrape("_enabled")
+	if !session.HasActiveSession() {
+		tasks.Scrape("_enabled")
+	}
+}
+
+func rescanCron() {
+	if !session.HasActiveSession() {
+		tasks.RescanVolumes()
+	}
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -31,6 +31,10 @@ var (
 
 var currentSessionHeatmap []int
 
+func HasActiveSession() bool {
+	return lastSessionID != 0
+}
+
 func TrackSessionFromFile(f models.File, doNotTrack string) {
 	sessionSource = "file"
 
@@ -106,7 +110,7 @@ func CheckForDeadSession() {
 		timeout = 5
 	}
 
-	if time.Since(lastSessionEnd).Seconds() > timeout && lastSessionSceneID != 0 && lastSessionID != 0 {
+	if time.Since(lastSessionEnd).Seconds() > timeout && lastSessionSceneID != 0 && HasActiveSession() {
 		watchSessionFlush()
 		lastSessionID = 0
 		lastSessionSceneID = 0
@@ -114,7 +118,7 @@ func CheckForDeadSession() {
 }
 
 func newWatchSession(sceneID uint) {
-	if lastSessionID != 0 {
+	if HasActiveSession() {
 		watchSessionFlush()
 	}
 


### PR DESCRIPTION
The cron jobs for recanning and scraping reduce performance, so we should avoid running them during an active watch session.