### PR TITLE
show title on scene card

### DIFF
--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -29,7 +29,8 @@
     </div>
 
     <div style="padding-top:4px;">
-
+      <div class="scene_title">{{item.title}}</div>
+      
       <watchlist-button :item="item"/>
       <favourite-button :item="item"/>
       <edit-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneEdit" />
@@ -143,5 +144,13 @@ export default {
 
   .tag {
     margin-left: 0.2em;
+  }
+
+  .scene_title {
+    font-size: 12px;
+    text-align: right;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 </style>


### PR DESCRIPTION
Some studios don't put the scene title on the cover image. This PR puts the title on the scene card in a unobtrusive way.