### PR TITLE
Fix preview generation for short videos

### DIFF
--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -76,7 +76,7 @@ func RenderPreview(inputFile string, destFile string, startTime int, snippetLeng
 	vfArgs := fmt.Sprintf("crop=%v,scale=%v:%v", crop, resolution, resolution)
 
 	// Prepare snippets
-	interval := dur/float64(snippetAmount) - float64(startTime)
+	interval := (dur - float64(startTime)) / float64(snippetAmount)
 	for i := 1; i <= snippetAmount; i++ {
 		start := time.Duration(float64(i)*interval+float64(startTime)) * time.Second
 		snippetFile := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i))
@@ -97,7 +97,7 @@ func RenderPreview(inputFile string, destFile string, startTime int, snippetLeng
 	}
 
 	// Ensure ending is always in preview
-	if extraSnippet {
+	if extraSnippet && dur/float64(snippetAmount) > float64(150) {
 		snippetAmount = snippetAmount + 1
 
 		start := time.Duration(dur-float64(150)) * time.Second


### PR DESCRIPTION
Currently, the preview generation fails on videos shorter than 200 seconds (using default settings), e.g. [this SLR Orignals scene which is 93 seconds long](https://www.sexlikereal.com/scenes/carolina-abril-enjoying-beatsaber-in-vr-12784). This PR fixes the timing calculations so it will work with short videos as well.

Also, changes the code so that the extra snippet is only generated if it comes after the last snippet. If the last snippet is already at the end (which is always the case if the video is shorter than 50 minutes, using default settings), we do not need to add another snippet that travels backwards in time.

Unfortunately, with this PR all previously generated previews will be outdated as the timings have slightly changed. So if a user deletes his previews and regenerates, the new previews will be slightly different but I don't expect most users to notice it.