### PR TITLE
Fix DLNA returning funscripts instead of videos

### DIFF
--- a/pkg/dms/dlna/dms/cds.go
+++ b/pkg/dms/dlna/dms/cds.go
@@ -210,7 +210,8 @@ func (me *contentDirectoryService) sceneToContainer(scene models.Scene, parent s
 		c = append(c, scene.Cast[i].Name)
 	}
 
-	if len(scene.Files) == 0 {
+	videoFiles, err := scene.GetVideoFiles()
+	if err != null || len(videoFiles) == 0 {
 		return nil
 	}
 
@@ -240,7 +241,7 @@ func (me *contentDirectoryService) sceneToContainer(scene models.Scene, parent s
 		Res:    make([]upnpav.Resource, 0, 2),
 	}
 
-	file := scene.Files[0]
+	file := videoFiles[0]
 	mimeType := "video/mp4"
 
 	item.Res = append(item.Res, upnpav.Resource{

--- a/pkg/dms/dlna/dms/dms.go
+++ b/pkg/dms/dlna/dms/dms.go
@@ -735,7 +735,11 @@ func (server *Server) initMux(mux *http.ServeMux) {
 			var scene models.Scene
 			scene.GetIfExist(sceneId)
 
-			filePath = filepath.Join(scene.Files[0].Path, scene.Files[0].Filename)
+			videoFiles, err := scene.GetVideoFiles()
+			if err != nil || len(videoFiles) == 0 {
+				return
+			}
+			filePath = filepath.Join(videoFiles[0].Path, videoFiles[0].Filename)
 		}
 
 		if fileId != 0 {


### PR DESCRIPTION
Currently, DLNA returns the first file for a scene which can result in errors if the first file is a funscript file. Instead, it now returns the first video file.

Can't test the changes myself as I don't use DLNA but it is pretty self-explanatory.

Fixes #478