### PR TITLE
Fix off-by-1 error in session heatmap

### DIFF
--- a/pkg/session/remote.go
+++ b/pkg/session/remote.go
@@ -20,6 +20,7 @@ type DeoPacket struct {
 
 const PLAYING = 0
 const PAUSED = 1
+const FINISHED = 2
 
 var DeoPlayerHost = ""
 var DeoRequestHost = ""

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -96,7 +96,7 @@ func TrackSessionFromRemote(packet DeoPacket) {
 		lastSessionEnd = time.Now()
 
 		position := int(packet.CurrentTime)
-		if position != 0 && len(currentSessionHeatmap) >= position {
+		if position > 0 && position < len(currentSessionHeatmap) {
 			currentSessionHeatmap[position] = currentSessionHeatmap[position] + 1
 		}
 	}


### PR DESCRIPTION
Fixes a crash with DeoVR session tracking: Currently, we allow `len(arr)` as array index when we should only allow `len(arr) - 1`. Also disallows negative values; DeoVR currently does not send negative positions but this makes the function future proof.

Fixes #475