### PR TITLE
Fix dlState & volume with built-in playlists

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -17,6 +17,7 @@ import (
 )
 
 type RequestSceneList struct {
+	DlState      optional.String   `json:"dlState"`
 	Limit        optional.Int      `json:"limit"`
 	Offset       optional.Int      `json:"offset"`
 	IsAvailable  optional.Bool     `json:"isAvailable"`
@@ -27,6 +28,7 @@ type RequestSceneList struct {
 	Tags         []optional.String `json:"tags"`
 	Cast         []optional.String `json:"cast"`
 	Cuepoint     []optional.String `json:"cuepoint"`
+	Volume       optional.Int      `json:"volume"`
 	Released     optional.String   `json:"releaseMonth"`
 	Sort         optional.String   `json:"sort"`
 }
@@ -436,6 +438,25 @@ func Migrate() {
 			ID: "0024-drop-actions-old",
 			Migrate: func(tx *gorm.DB) error {
 				return tx.Exec("DROP TABLE IF EXISTS actions_old").Error
+			},
+		},
+		{
+			ID: "0025-playlist-add-dlstate",
+			Migrate: func(tx *gorm.DB) error {
+				var playlists []models.Playlist
+				db.Find(&playlists)
+				for _, playlist := range playlists {
+					if playlist.IsSystem {
+						var jsonResult RequestSceneList
+						json.Unmarshal([]byte(playlist.SearchParams), &jsonResult)
+						if !jsonResult.DlState.Present() {
+							jsonResult.DlState = optional.NewString("available")
+							playlist.SearchParams = jsonResult.ToJSON()
+							playlist.Save()
+						}
+					}
+				}
+				return nil
 			},
 		},
 	})

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -449,8 +449,17 @@ func Migrate() {
 					if playlist.IsSystem {
 						var jsonResult RequestSceneList
 						json.Unmarshal([]byte(playlist.SearchParams), &jsonResult)
+
+						hasChanged := false
 						if !jsonResult.DlState.Present() {
 							jsonResult.DlState = optional.NewString("available")
+							hasChanged = true
+						}
+						if !jsonResult.Volume.Present() {
+							jsonResult.Volume = optional.NewInt(0)
+							hasChanged = true
+						}
+						if hasChanged {
 							playlist.SearchParams = jsonResult.ToJSON()
 							playlist.Save()
 						}


### PR DESCRIPTION
Fixes a bug where the `dlState` UI would get out of sync with the internal state:

![dlstate](https://user-images.githubusercontent.com/51096617/115158604-4696fd80-a08f-11eb-9048-5cc2cbcc3c9c.png)

The problem was that built-in playlists (Default, Recent, Favourite, Watchlist) are missing the `dlState` property in their search params. Based on the `isAvailable` and `isAccessible` fields, these playlists belong to "Available right now" but this is not specified in `dlState` as expected by Vue. When selecting a built-in playlist, the `dlState` UI gets initialized with `undefined`, which means it keeps showing the previous selection even though the scenes were now filtered by "Available right now".

To reproduce:
1. Open XBVR.
2. Note how it shows the "Default" playlist with `dlState` "Available right now".
3. Switch the `dlState` to "Not downloaded".
4. Now load playlist "Default".

Expected result:
- We should see playlist "Default" with `dlState` "Available right now".

Actual result:
- We see playlist "Default" but `dlState` still shows "Not downloaded" even though all scenes in the list have been downloaded.

Tested this change and both the migrations and the UI are correctly fixed with this PR. Note that if #464 or #479 are merged before this PR, the migration index must be updated.