### PR TITLE
Implement cuepoint deletion, add tooltips

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -315,6 +316,9 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 			Name: scene.Cuepoints[i].Name,
 		})
 	}
+	sort.Slice(cuepoints, func(i, j int) bool {
+		return cuepoints[i].TS < cuepoints[j].TS
+	})
 
 	if videoFiles[0].VideoProjection == "mkx200" ||
 		videoFiles[0].VideoProjection == "mkx220" ||

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/jinzhu/gorm"
 	"github.com/xbapps/xbvr/pkg/tasks"
 
 	"github.com/blevesearch/bleve"
@@ -85,7 +86,11 @@ func (i SceneResource) WebService() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(ResponseGetScenes{}))
 
-	ws.Route(ws.POST("/cuepoint/{scene-id}").To(i.addSceneCuepoint).
+	ws.Route(ws.POST("/{scene-id}/cuepoint").To(i.addSceneCuepoint).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+
+	ws.Route(ws.DELETE("/{scene-id}/cuepoint/{cuepoint-id}").To(i.deleteSceneCuepoint).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(models.Scene{}))
 
@@ -324,6 +329,39 @@ func (i SceneResource) addSceneCuepoint(req *restful.Request, resp *restful.Resp
 		scene.GetIfExistByPK(uint(sceneId))
 	}
 	db.Close()
+
+	resp.WriteHeaderAndEntity(http.StatusOK, scene)
+}
+
+func (i SceneResource) deleteSceneCuepoint(req *restful.Request, resp *restful.Response) {
+	sceneId, err := strconv.Atoi(req.PathParameter("scene-id"))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	cuepointId, err := strconv.Atoi(req.PathParameter("cuepoint-id"))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	db, _ := models.GetDB()
+
+	cuepoint := models.SceneCuepoint{}
+	err = db.First(&cuepoint, cuepointId).Error
+
+	if err == gorm.ErrRecordNotFound {
+		resp.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	db.Where("id = ? AND scene_id = ?", cuepointId, sceneId).Delete(models.SceneCuepoint{})
+	db.Delete(&cuepoint)
+
+	var scene models.Scene
+	err = scene.GetIfExistByPK(uint(sceneId))
+	defer db.Close()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)
 }

--- a/ui/src/components/EditButton.vue
+++ b/ui/src/components/EditButton.vue
@@ -1,6 +1,7 @@
 <template>
   <a class="button is-dark is-outlined is-small"
-    @click="editScene(item)">
+    @click="editScene(item)"
+    title="Edit scene details">
     <b-icon pack="mdi" icon="lead-pencil" size="is-small" />
   </a>
 </template>

--- a/ui/src/components/FavouriteButton.vue
+++ b/ui/src/components/FavouriteButton.vue
@@ -1,6 +1,7 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})">
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
+     :title="item.favourite ? 'Remove from favourites' : 'Add to favourites'">
     <b-icon pack="mdi" :icon="item.favourite ? 'heart' : 'heart-outline'" size="is-small"/>
   </a>
 </template>

--- a/ui/src/components/WatchlistButton.vue
+++ b/ui/src/components/WatchlistButton.vue
@@ -1,6 +1,7 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})">
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
+     :title="item.watchlist ? 'Remove from watchlist' : 'Add to watchlist'">
     <b-icon pack="mdi" :icon="item.watchlist ? 'calendar-check' : 'calendar-blank'" size="is-small"/>
   </a>
 </template>

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -90,7 +90,7 @@
   "Run selected scrapers": "Run selected scrapers",
   "Never scraped": "Never scraped",
   "Scraping now...": "Scraping now...",
-  "Scrape this site": "Scrape this site",
+  "Run this scraper": "Run this scraper",
   "Force update scenes": "Force update scenes",
   "JAVR scraper": "JAVR scraper",
   "Go": "Go"

--- a/ui/src/views/files/List.vue
+++ b/ui/src/views/files/List.vue
@@ -49,7 +49,7 @@
               </div>
             </b-table-column>
             <b-table-column style="white-space: nowrap;">
-              <button class="button is-danger is-outlined" @click='removeFile(props.row)'>
+              <button class="button is-danger is-outlined" @click='removeFile(props.row)' title='Delete file from disk'>
                 <b-icon pack="fas" icon="trash"></b-icon>
               </button>
             </b-table-column>

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -38,7 +38,7 @@
                   <b-icon icon="dots-vertical"></b-icon>
                 </template>
                 <b-dropdown-item aria-role="listitem" @click="taskScrape(item.id)">
-                  {{$t('Scrape this site')}}
+                  {{$t('Run this scraper')}}
                 </b-dropdown-item>
                 <b-dropdown-item aria-role="listitem" @click="forceSiteUpdate(item.name)">
                   {{$t('Force update scenes')}}

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -192,7 +192,7 @@
 <script>
 import ky from 'ky'
 import videojs from 'video.js'
-import vr from 'videojs-vr/dist/videojs-vr.min.js'
+import 'videojs-vr/dist/videojs-vr.min.js'
 import { format, formatDistance, parseISO } from 'date-fns'
 import prettyBytes from 'pretty-bytes'
 import VueLoadImage from 'vue-load-image'
@@ -304,7 +304,7 @@ export default {
     updatePlayer (src, projection) {
       this.player.reset()
 
-      const vr = this.player.vr({
+      /* const vr = */ this.player.vr({
         projection: projection,
         forceCardboard: false
       })

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -140,11 +140,14 @@
                         <b-button @click="addCuepoint">Add cuepoint</b-button>
                       </b-field>
                     </div>
-                    <div class="content is-small">
+                    <div class="content cuepoint-list">
                       <ul>
                         <li v-for="(c, idx) in sortedCuepoints" :key="idx">
                           <code>{{ humanizeSeconds(c.time_start) }}</code> -
                           <a @click="playCuepoint(c)"><strong>{{ c.name }}</strong></a>
+                          <button class="button is-danger is-outlined is-small" @click="deleteCuepoint(c)" title="Delete cuepoint">
+                            <b-icon pack="fas" icon="trash" />
+                          </button>
                         </li>
                       </ul>
                     </div>
@@ -402,7 +405,7 @@ export default {
       if (this.tagPosition !== '' && this.tagAct !== '') {
         name = `${this.tagPosition}-${this.tagAct}`
       }
-      ky.post(`/api/scene/cuepoint/${this.item.id}`, {
+      ky.post(`/api/scene/${this.item.id}/cuepoint`, {
         json: {
           name: name,
           time_start: this.player.currentTime()
@@ -410,6 +413,12 @@ export default {
       }).json().then(data => {
         this.$store.commit('overlay/showDetails', { scene: data })
       })
+    },
+    deleteCuepoint (cuepoint) {
+      ky.delete(`/api/scene/${this.item.id}/cuepoint/${cuepoint.id}`)
+        .json().then(data => {
+          this.$store.commit('overlay/showDetails', { scene: data })
+        })
     },
     close () {
       this.player.dispose()
@@ -561,6 +570,10 @@ span.is-active img {
 
 .pathDetails {
   color: #b0b0b0;
+}
+
+.cuepoint-list li > button {
+  margin-left: 7px;
 }
 
 .heatmapFunscript {

--- a/ui/src/views/scenes/SavedSearch.vue
+++ b/ui/src/views/scenes/SavedSearch.vue
@@ -14,7 +14,7 @@
         </optgroup>
       </b-select>
 
-      <b-tooltip position="is-bottom" label="Save" :delay="200">
+      <b-tooltip position="is-bottom" label="Save as new" :delay="200">
         <button class="button is-small is-outlined" @click="showNewDialog">
           <b-icon pack="mdi" icon="content-save-outline"></b-icon>
         </button>


### PR DESCRIPTION
Adds a button for deleting cuepoints.

![delete-cuepoint](https://user-images.githubusercontent.com/51096617/115965542-0ec60500-a52a-11eb-8e42-bf5c8375c516.png)

Also adds tooltips to various buttons.

Finally, sorts the cuepoints in the DeoVR API. The cuepoints are already sorted chronologically in the XBVR UI, so the user has every reason to believe they'll be sorted the same way in DeoVR.