### PR TITLE
Add FB360 to common words

### DIFF
--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -88,8 +88,8 @@ export default {
     initView () {
       const commonWords = [
         '180', '180x180', '30fps', '30m', '360', '3dh', '4k', '5k', '60fps', '6k', '7k',
-        '8k', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv', 'mkx200',
-        'mkx220', 'mono', 'mp4', 'oculus', 'oculus5k', 'oculusrift', 'original',
+        '8k', 'fb360', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv',
+        'mkx200', 'mkx220', 'mono', 'mp4', 'oculus', 'oculus5k', 'oculusrift', 'original',
         'smartphone', 'tb', 'vrca220', 'vp9'
       ]
       const isNotCommonWord = word => !commonWords.includes(word.toLowerCase()) && !/^[0-9]+p$/.test(word)


### PR DESCRIPTION
Adds ["FB360"](https://facebook360.fb.com/spatial-workstation/) to list of common words, which is used for SLR Originals' new spatial audio videos.