### PR TITLE
Implement "skip intro" feature

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -57,6 +57,7 @@ type DeoScene struct {
 	VideoThumbnail string              `json:"videoThumbnail"`
 	VideoPreview   string              `json:"videoPreview,omitempty"`
 	Encodings      []DeoSceneEncoding  `json:"encodings"`
+	SkipIntro      float64             `json:"skipIntro"`
 	Timestamps     []DeoSceneTimestamp `json:"timeStamps"`
 	Actors         []DeoSceneActor     `json:"actors"`
 	FullVideoReady bool                `json:"fullVideoReady"`
@@ -360,6 +361,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		ScreenType:     screenType,
 		Encodings:      sources,
 		VideoLength:    int(videoLength),
+		SkipIntro:      scene.IntroLength,
 		Timestamps:     cuepoints,
 	}
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -468,6 +468,15 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0026-scene-has-intro-length",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					IntroLength float64 `json:"intro_length" gorm:"default:0.0"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -81,6 +81,7 @@ type Scene struct {
 	IsAccessible   bool            `json:"is_accessible" gorm:"default:false"`
 	IsWatched      bool            `json:"is_watched" gorm:"default:false"`
 	IsScripted     bool            `json:"is_scripted" gorm:"default:false"`
+	IntroLength    float64         `json:"intro_length" gorm:"default:0.0"`
 	Cuepoints      []SceneCuepoint `json:"cuepoints"`
 	History        []History       `json:"history"`
 	AddedDate      time.Time       `json:"added_date"`
@@ -89,7 +90,6 @@ type Scene struct {
 	TotalWatchTime int             `json:"total_watch_time" gorm:"default:0"`
 
 	HasVideoPreview bool `json:"has_preview" gorm:"default:false"`
-	// HasVideoThumbnail bool `json:"has_video_thumbnail" gorm:"default:false"`
 
 	NeedsUpdate bool `json:"needs_update"`
 
@@ -362,6 +362,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	if ext.Covers != nil {
 		o.CoverURL = ext.Covers[0]
 	}
+	o.IntroLength = ext.IntroLength
 	o.SceneURL = ext.HomepageURL
 
 	if ext.Released != "" {

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -29,6 +29,7 @@ type ScrapedScene struct {
 	Cast        []string `json:"cast"`
 	Filenames   []string `json:"filename"`
 	Duration    int      `json:"duration"`
+	IntroLength float64  `json:"intro_length"`
 	Synopsis    string   `json:"synopsis"`
 	Released    string   `json:"released"`
 	HomepageURL string   `json:"homepage_url"`

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -90,6 +90,10 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			}
 		})
 
+		// Intro length, based on Studio and ID
+		sc.IntroLength = 5.0
+		// 18VR: no intro on 1-25, 6s intro on 26-50, 5s intro on 51-151, 7s intro on 152-current
+
 		ctx := colly.NewContext()
 		ctx.Put("scene", sc)
 

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -136,6 +136,11 @@ func ReapplyEdits() {
 			}
 			continue
 		}
+		if a.ChangedColumn == "intro_length" {
+			val, _ := strconv.ParseFloat(a.NewValue, 64)
+			db.Model(&scene).Update(a.ChangedColumn, val)
+			continue
+		}
 		// Reapply other edits
 		db.Model(&scene).Update(a.ChangedColumn, a.NewValue)
 		if a.ChangedColumn == "release_date_text" {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -142,6 +142,17 @@
                     </div>
                     <div class="content cuepoint-list">
                       <ul>
+                        <li>
+                          <b-field>
+                            <b-numberinput v-model="introLength" min="0" step="0.1" size="is-small" expanded :controls="false" />
+                            <div class="control">
+                              <b-button @click="updateIntroLength" icon-pack="fas" icon-left="save" size="is-small" type="is-dark" outlined title="Save intro length" />
+                            </div>
+                            <div class="control cuepoint-intro">
+                              - <a @click="playCuepoint({ time_start: introLength })"><strong>intro</strong></a>
+                            </div>
+                          </b-field>
+                        </li>
                         <li v-for="(c, idx) in sortedCuepoints" :key="idx">
                           <code>{{ humanizeSeconds(c.time_start) }}</code> -
                           <a @click="playCuepoint(c)"><strong>{{ c.name }}</strong></a>
@@ -218,6 +229,7 @@ export default {
       tagPosition: '',
       cuepointPositionTags: ['', 'standing', 'sitting', 'laying', 'kneeling'],
       cuepointActTags: ['', 'handjob', 'blowjob', 'doggy', 'cowgirl', 'revcowgirl', 'missionary', 'titfuck', 'anal', 'cumshot', '69', 'facesit'],
+      introLength: this.$store.state.overlay.details.scene.intro_length,
       carouselSlide: 0
     }
   },
@@ -367,10 +379,10 @@ export default {
     selectScript (file) {
       ky.post(`/api/scene/selectscript/${this.item.id}`, {
         json: {
-          file_id: file.id,
+          file_id: file.id
         }
       }).json().then(data => {
-          this.$store.commit('overlay/showDetails', { scene: data })
+        this.$store.commit('overlay/showDetails', { scene: data })
       })
     },
     getImageURL (u, size) {
@@ -412,6 +424,17 @@ export default {
         }
       }).json().then(data => {
         this.$store.commit('overlay/showDetails', { scene: data })
+        this.$store.commit('sceneList/updateScene', data)
+      })
+    },
+    updateIntroLength () {
+      ky.post(`/api/scene/intro/${this.item.id}`, {
+        json: {
+          intro_length: this.introLength
+        }
+      }).json().then(data => {
+        this.$store.commit('overlay/showDetails', { scene: data })
+        this.$store.commit('sceneList/updateScene', data)
       })
     },
     deleteCuepoint (cuepoint) {
@@ -572,6 +595,7 @@ span.is-active img {
   color: #b0b0b0;
 }
 
+.cuepoint-intro,
 .cuepoint-list li > button {
   margin-left: 7px;
 }


### PR DESCRIPTION
With the `skipIntro` property from the DeoVR API, we can skip the studio-specific intro. Users need to enable "skip intro" in their DeoVR settings for this to work. Existing scenes will need to be rescraped in order for the intro length to be set correctly.

Also fixes a bug where when adding a cuepoint, the new cuepoint shows up in the scene popup, but when closing and reopening the scene popup, the cuepoint is gone until the page is reloaded.

This PR is WIP until I get around to adding the intro durations for more studios.