### PR TITLE
Drop actions_old table

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -414,6 +414,12 @@ func Migrate() {
 				return tx.AutoMigrate(File{}).Error
 			},
 		},
+		{
+			ID: "0024-drop-actions-old",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec("DROP TABLE IF EXISTS actions_old").Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
The `actions_old` table is created as a backup during migration `0016-action-value-size` but the original PR (#374) forgot to delete the table afterwards.