### PR TITLE
GO111MODULE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,7 @@ ENV GO_VERSION=1.13.15 \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -xzv \
-    && go get -u -v \
-        github.com/acroca/go-symbols \
-        github.com/cweill/gotests/... \
-        github.com/davidrjenni/reftools/cmd/fillstruct \
-        github.com/fatih/gomodifytags \
-        github.com/haya14busa/goplay/cmd/goplay \
-        github.com/josharian/impl \
-        github.com/nsf/gocode \
-        github.com/ramya-rao-a/go-outline \
-        github.com/rogpeppe/godef \
-        github.com/uudashr/gopkgs/cmd/gopkgs \
-        github.com/zmb3/gogetdoc \
-        golang.org/x/lint/golint \
-        golang.org/x/tools/cmd/godoc \
-        golang.org/x/tools/cmd/gorename \
-        golang.org/x/tools/cmd/guru \
-        sourcegraph.com/sqs/goreturns \
+    && GO111MODULE=on go get -u -v \
         github.com/UnnoTed/fileb0x
 
 WORKDIR /app


### PR DESCRIPTION
doublestar module upgraded to v4 requires go 1.16. Added GO111MODULE to grab correct version of doublestar (v1) required by fileb0x. removed all other "go get" entries.