### PR TITLE
prevent crash in VRBangers scraper

### DIFF
--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -29,6 +29,7 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 
 		if e.ChildAttr(`link[rel=shortlink]`, "href") == "" {
+			log.Printf("Skipping %s because it is not a valid scene.", e.Request.URL.String())
 			return
 		}
 		// Scene ID - get from URL

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -28,6 +28,9 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 
+		if e.ChildAttr(`link[rel=shortlink]`, "href") == "" {
+			return
+		}
 		// Scene ID - get from URL
 		sc.SiteID = strings.Split(e.ChildAttr(`link[rel=shortlink]`, "href"), "?p=")[1]
 		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID


### PR DESCRIPTION
For some reason the scraper request to https://vrbangers.com/video/final-sexam/ gets the content for https://vrbangers.com/japanese/. I couldn't figure out why and couldn't reproduce it in the brower. This PR at least prevents the resulting crash.