### PR TITLE
Added SLR scraper for VRLatina/HoloGirlsVR/VRPFilms/RealityLovers

### DIFF
--- a/pkg/scrape/hologirlsvr.go
+++ b/pkg/scrape/hologirlsvr.go
@@ -13,7 +13,7 @@ import (
 
 func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
 	defer wg.Done()
-	scraperID := "hologirlsvr"
+	scraperID := "hologirlsvr-site"
 	siteID := "HoloGirlsVR"
 	logScrapeStart(scraperID, siteID)
 
@@ -30,7 +30,7 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		// Scene ID - get from URL
 		tmp := strings.Split(sc.HomepageURL, "/")
 		sc.SiteID = tmp[len(tmp)-1]
-		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+		sc.SceneID = slugify.Slugify(sc.Site) + "-site-" + sc.SiteID
 
 		// Title
 		e.ForEach(`div.video-title h3`, func(id int, e *colly.HTMLElement) {
@@ -104,5 +104,5 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func init() {
-	registerScraper("hologirlsvr", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg", HoloGirlsVR)
+	registerScraper("hologirlsvr-site", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg", HoloGirlsVR)
 }

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/gocolly/colly"
-	"github.com/mozillazg/go-slugify"
 	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
 	"github.com/xbapps/xbvr/pkg/models"
@@ -30,7 +29,7 @@ func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string
 
 		// Scene ID
 		sc.SiteID = e.Request.Ctx.Get("id")
-		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+		sc.SceneID = scraperID + "-" + sc.SiteID
 
 		// Cover
 		sc.Covers = append(sc.Covers, strings.Replace(e.Request.Ctx.Get("cover"), "-Small", "-Large", 1))
@@ -120,7 +119,7 @@ func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string
 }
 
 func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return RealityLoversSite(wg, updateSite, knownScenes, out, "realitylovers", "RealityLovers", "https://realitylovers.com/")
+	return RealityLoversSite(wg, updateSite, knownScenes, out, "realitylovers-site", "RealityLovers", "https://realitylovers.com/")
 }
 
 func TSVirtualLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
@@ -128,6 +127,6 @@ func TSVirtualLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, 
 }
 
 func init() {
-	registerScraper("realitylovers", "RealityLovers", "http://static.rlcontent.com/shared/VR/common/favicons/apple-icon-180x180.png", RealityLovers)
+	registerScraper("realitylovers-site", "RealityLovers", "http://static.rlcontent.com/shared/VR/common/favicons/apple-icon-180x180.png", RealityLovers)
 	registerScraper("tsvirtuallovers", "TSVirtualLovers", "http://static.rlcontent.com/shared/TS/common/favicons/apple-icon-180x180.png", TSVirtualLovers)
 }

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string) error {
+func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, slrId string, scraperID string, siteID string, company string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -219,7 +219,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		}
 	})
 
-	siteCollector.Visit("https://www.sexlikereal.com/studios/" + scraperID + "?sort=most_recent")
+	siteCollector.Visit("https://www.sexlikereal.com/studios/" + slrId + "?sort=most_recent")
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -229,6 +229,10 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func addSLRScraper(id string, name string, company string, avatarURL string) {
+	addSLRScraperWithAlternativeId(id, id, name, company, avatarURL)
+}
+
+func addSLRScraperWithAlternativeId(slrId string, id string, name string, company string, avatarURL string) {
 	suffixedName := name
 	if company != "SexLikeReal" {
 		suffixedName += " (SLR)"
@@ -239,7 +243,7 @@ func addSLRScraper(id string, name string, company string, avatarURL string) {
 	}
 
 	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-		return SexLikeReal(wg, updateSite, knownScenes, out, id, name, company)
+		return SexLikeReal(wg, updateSite, knownScenes, out, slrId, id, suffixedName, company)
 	})
 }
 
@@ -280,6 +284,7 @@ func init() {
 	addSLRScraper("hentaivr", "HentaiVR", "HentaiVR", "https://pbs.twimg.com/profile_images/1394712735854874632/ULktf61I_400x400.jpg")
 	addSLRScraper("herfirstvr", "HerFirstVR", "HerFirstVR", "https://www.sexlikereal.com/s/refactor/images/favicons/android-icon-192x192.png")
 	addSLRScraper("holivr", "HoliVR", "HoliVR", "")
+	addSLRScraperWithAlternativeId("hologirlsvr", "hologirlsvr-slr", "HoloGirlsVR", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg")
 	addSLRScraper("hookfer", "Hookfer", "Hookfer", "https://mcdn.vrporn.com/files/20201116170637/400x400-Hookfer-logo.jpg")
 	addSLRScraper("istripper", "iStripper", "TotemCore Ltd", "https://www.istripper.com/favicons/istripper/apple-icon-120x120.png")
 	addSLRScraper("jackandjillvr", "JackandJillVR", "JackandJillVR", "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/367/logo_crop_1645997567.png")
@@ -315,6 +320,7 @@ func init() {
 	addSLRScraper("ps-porn", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg")
 	addSLRScraper("pvrstudio", "PVRStudio", "PVRStudio", "https://pvr.fun/uploads/2019/10/08/084230gbctdepe7kovu4hs.jpg")
 	addSLRScraper("realhotvr", "RealHotVR", "RealHotVR", "https://images.povr.com/assets/logos/channels/0/3/3835/200.svg")
+	addSLRScraperWithAlternativeId("realitylovers", "realitylovers-slr", "RealityLovers", "RealityLovers", "http://static.rlcontent.com/shared/VR/common/favicons/apple-icon-180x180.png")
 	addSLRScraper("screwboxvr", "ScrewBoxVR", "ScrewBox", "https://pbs.twimg.com/profile_images/1137432770936918016/ycL3ag5c_200x200.png")
 	addSLRScraper("sodcreate", "SodCreate", "SodCreate", "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/216/logo_crop_1606869217.png")
 	addSLRScraper("squeeze-vr", "SqueezeVR", "SqueezeVR", "https://mcdn.vrporn.com/files/20210322150700/squeezevr_logo.png")
@@ -342,6 +348,8 @@ func init() {
 	addSLRScraper("vroomed", "VRoomed", "VRoomed", "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/380/logo_crop_1647990015.png")
 	addSLRScraper("vrpfilms", "VRPFilms", "VRPFilms", "https://vrpfilms.com/storage/settings/March2021/Z0krYIQBMwSJ4R1eCnv1.png")
 	addSLRScraper("vrpornjack", "VRPornJack", "VRPornJack", "https://mcdn.vrporn.com/files/20210330121852/VRPORNJACK_Logo-400x400.png")
+	addSLRScraperWithAlternativeId("vrlatina", "vrlatina-slr", "VRLatina", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg")
+	addSLRScraperWithAlternativeId("vrpfilms", "vrpfilms-slr", "VRPFilms", "VRPFilms", "https://vrpfilms.com/storage/settings/March2021/Z0krYIQBMwSJ4R1eCnv1.png")
 	addSLRScraper("vrpussyvision", "VRpussyVision", "VRpussyVision", "https://mcdn.vrporn.com/files/20180313160830/vrpussyvision-square-banner.png")
 	addSLRScraper("vrsexperts", "VRSexperts", "VRSexperts", "https://mcdn.vrporn.com/files/20190812141431/vrsexpertslogo2.jpg")
 	addSLRScraper("vrsolos", "VRSolos", "VRSolos", "https://mcdn.vrporn.com/files/20191226092954/VRSolos_Logo.jpg")

--- a/pkg/scrape/vrlatina.go
+++ b/pkg/scrape/vrlatina.go
@@ -16,7 +16,7 @@ import (
 
 func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
 	defer wg.Done()
-	scraperID := "vrlatina"
+	scraperID := "vrlatina-site"
 	siteID := "VRLatina"
 	logScrapeStart(scraperID, siteID)
 
@@ -98,7 +98,7 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		matches := r.FindStringSubmatch(url)
 		if matches != nil {
 			sc.SiteID = matches[1]
-			sc.SceneID = fmt.Sprintf("vrlatina-%v", sc.SiteID)
+			sc.SceneID = fmt.Sprintf("vrlatina-site-%v", sc.SiteID)
 
 			// save only if we got a SceneID
 			out <- sc
@@ -129,5 +129,5 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("vrlatina", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg", VRLatina)
+	registerScraper("vrlatina-site", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg", VRLatina)
 }


### PR DESCRIPTION
Adding SLR as an alternative source for VRLatina scenes, because there are scenes that are only on SLR and not on VRLatina website. If the user chooses to use both the SLR scraper and the dedicated VRLatina scraper, the scenes that come from SLR will have `vrlatina-slr` prefix in its id, while the scenes from the dedicated scraper will have its existing `vrlatina` prefix.

I had to change the SLR scraper a bit to make this prefix happen, in the current code base it's a convention that SLR scraper always uses the scraper Id in the scene Id, which will lead to `vrlatina` being used for both SLR & dedicated scraper, which might lead to ID duplications.

Edited: I've added support for HoloGirlsVR/VRPFilms/RealityLovers together with this PR, because they fundamentally do the same thing code-wise.