### PR TITLE
Add logging to search index creation

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -264,7 +264,11 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 	db, _ := models.GetDB()
 	defer db.Close()
 
-	idx := tasks.NewIndex("scenes")
+	idx, err := tasks.NewIndex("scenes")
+	if err != nil {
+		log.Error(err)
+		return
+	}
 	defer idx.Bleve.Close()
 	query := bleve.NewQueryStringQuery(q)
 


### PR DESCRIPTION
Adds some logging to help with debugging #505, and prefer stopping the search index over crashing XBVR.