### PR TITLE
Update github workflows to build docker containers and build arm7, arm8 and x86_64 containers.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,3 +27,26 @@ jobs:
       
     - name: Check code formatting using gofmt
       uses: Jerome1337/gofmt-action@v1.0.4
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Checkout
+      run: git fetch --prune --unshallow --tags
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Development Docker
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      env:
+        DOCKER_CLI_EXPERIMENTAL: enabled
+      run: |
+        docker run --privileged --rm tonistiigi/binfmt --install all
+        docker info
+        docker buildx create --name builder --use
+        docker buildx inspect --bootstrap
+        docker buildx ls
+        docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f Dockerfile --push --output=type=image,name=xbapps/xbvr,push=true .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM node:12 as build-env
 
 ### Install Go ###
+ARG TARGETPLATFORM
 ENV GO_VERSION=1.13.15 \
     GOPATH=$HOME/go-packages \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -xzv \
-    && GO111MODULE=on go get -u -v \
+RUN if [ "$TARGETPLATFORM" = "linux/arm/v6" ]; then curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-armv6l.tar.gz | tar -xzv ; elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-armv6l.tar.gz  | tar -xzv ; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-arm64.tar.gz | tar -xzv; elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then  curl -fsSL https://dl.google.com/go/go$GO_VERSION.linux-amd64.tar.gz  | tar -xzv;  fi;
+RUN GO111MODULE=on go get -u -v \
         github.com/UnnoTed/fileb0x
 
 WORKDIR /app


### PR DESCRIPTION
This updates the github actions and creates a docker build action.
This uses buildx to build the container for arm7, arm 8 and x86_64 in parallel and pushes this to the docker hub.
 This should resolve #252

To use this you need to configure secrets in github to pass the username and password to login to the docker hub.
To configure this under the github repository settings > Secrets > Action Secrets, and create 2 new secrets.
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN