### PR TITLE
consider scripts when sorting by File added date

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -253,6 +253,10 @@ func (o *Scene) UpdateStatus() {
 
 			if files[j].Type == "script" {
 				scripts = scripts + 1
+
+				if files[j].Exists() && (files[j].CreatedTime.After(newestFileDate) || newestFileDate.IsZero()) {
+					newestFileDate = files[j].CreatedTime
+				}
 			}
 
 			if files[j].Type == "video" {


### PR DESCRIPTION
I think it is reasonable that when you add a script, you want the respective scene show up on top of the list sorted by recent additions.