### PR TITLE
Fix POVR titles containing a K

### DIFF
--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -34,7 +34,7 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 		// Title
 		e.ForEach(`h4.title`, func(id int, e *colly.HTMLElement) {
 			// 7K Maid For Play
-			sc.Title = strings.Split(e.Text, "K")[1]
+			sc.Title = e.Text[strings.Index(e.Text, "K")+1:]
 		})
 
 		// Date & Duration


### PR DESCRIPTION
This fixes a bug where titles of POVR scenes would get cut off if they contain a 'K' (e.g. 'Fountain of Knowledge' would become 'Fountain of ').