### PR TITLE
Fix cast scraping for VirtualRealPorn

### DIFF
--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -86,7 +86,8 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 			cast := jsonResult["actors"].([]interface{})
 			for _, v := range cast {
 				m := v.(map[string]interface{})
-				tmpCast = append(tmpCast, m["url"].(string))
+				path := m["url"].(string)
+				tmpCast = append(tmpCast, URL+path[1:])
 			}
 		})
 

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -169,7 +169,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 		var name string
 		e.ForEach(`h1.model-title`, func(id int, e *colly.HTMLElement) {
-			name = strings.Split(e.Text, " (")[0]
+			name = strings.TrimSpace(strings.Split(e.Text, " (")[0])
 		})
 
 		var gender string

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -86,8 +86,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 			cast := jsonResult["actors"].([]interface{})
 			for _, v := range cast {
 				m := v.(map[string]interface{})
-				path := m["url"].(string)
-				tmpCast = append(tmpCast, URL+path[1:])
+				tmpCast = append(tmpCast, e.Request.AbsoluteURL(m["url"].(string)))
 			}
 		})
 


### PR DESCRIPTION
Looks like VirtualRealPorn recently switched from full URLs to just paths for actors so scraping is broken, but here's a simple fix.