### PR TITLE
Add external link to scene in details view

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -57,13 +57,15 @@
                   <span v-else class="missing">(no title)</span>
                   <small class="is-pulled-right">{{ format(parseISO(item.release_date), "yyyy-MM-dd") }}</small>
                 </h3>
-                <small>{{ item.site }}</small>
-                <div class="columns">
-                  <div class="column">
+                <small>
+                  <a :href="item.scene_url" target="_blank" rel="noreferrer">{{ item.site }}</a>
+                </small>
+                <div class="columns mt-0">
+                  <div class="column pt-0">
                     <star-rating :key="item.id" :rating="item.star_rating" @rating-selected="setRating"
                                  :increment="0.5" :star-size="20"/>
                   </div>
-                  <div class="column">
+                  <div class="column pt-0">
                     <div class="is-pulled-right">
                       <watchlist-button :item="item"/>&nbsp;
                       <favourite-button :item="item"/>&nbsp;


### PR DESCRIPTION
For convenience and consistency with scene cards, this makes the site name a link to the scene in the details view.

I had to mess with margins and padding because the row below the site name had a negative margin partially covering the site name, making only the top half of the link clickable. Columns inside had an equivalent padding, so making both 0 yields no visual change.