### PR TITLE
Fix VirtualTaboo scenes missing descriptions

### DIFF
--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -60,7 +60,7 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 		})
 
 		// Synopsis
-		e.ForEach(`div.description span.full`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div.video-detail div.description`, func(id int, e *colly.HTMLElement) {
 			sc.Synopsis = strings.TrimSpace(e.Text)
 		})
 


### PR DESCRIPTION
I suppose VirtualTaboo updated their website recently... either that or nobody cares about descriptions. In any case, the scraper doesn't pick up descriptions.