### PR TITLE
Fix JSON unmarshal error in Default & Recent playlists

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -468,6 +468,26 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0026-playlist-set-lists",
+			Migrate: func(tx *gorm.DB) error {
+				var playlists []models.Playlist
+				db.Find(&playlists)
+				for _, playlist := range playlists {
+					if playlist.IsSystem {
+						var jsonResult RequestSceneList
+						json.Unmarshal([]byte(playlist.SearchParams), &jsonResult)
+
+						if jsonResult.Lists == nil {
+							jsonResult.Lists = []optional.String{}
+							playlist.SearchParams = jsonResult.ToJSON()
+							playlist.Save()
+						}
+					}
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
Fixes a bug where the watchlist/favourite/scripted toggles are not working on the built-in Default and Recent playlists.

**To reproduce:**
- Open XBVR.
- Under "Saved searches", select either "Default" or "Recent".
- Under "Properties", click on one of the buttons, e.g. "Watchlist".
- The list will not reload; the spinner icon does not disappear.
- In the DevTools, the following error is shown: "json: cannot unmarshal bool into Go struct field RequestSceneList.lists of type []optional.String"

**Explanation:**

We use the Buefy component `v-checkbox-button` so that the user can select/deselect the lists. This component is bound to the `lists` state.

When `lists` is an array, the component correctly checks whether the array contains an item, and inserts/removes items. However, on the Default and Recent playlists, `lists` is not an empty array but `null`. Because of this, the component will set `lists` to `true`/`false`, which causes an error in the backend because `lists` is expected to be of type `[]optional.String`.

This PR updates the built-in Default and Recent playlists so that `lists` is set to `[]` instead of `null`.