### PR TITLE
Configurable title format for DeoVR

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -301,7 +301,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 					Height:     height,
 					Width:      width,
 					Size:       file.Size,
-					URL:        fmt.Sprintf("%v/api/dms/file/%v/%v%v", session.DeoRequestHost, file.ID, scene.GetFunscriptTitle(), dnt),
+					URL:        fmt.Sprintf("%v/api/dms/file/%v/%v%v", session.DeoRequestHost, file.ID, scene.GetFunscriptTitle(config.Config.Interfaces.DeoVR.TitleFormat), dnt),
 				},
 			},
 		})
@@ -337,11 +337,11 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		screenType = "sphere"
 	}
 
-	title := scene.Title
+	title := scene.GetDeoFormattedTitle(config.Config.Interfaces.DeoVR.TitleFormat)
 	thumbnailURL := session.DeoRequestHost + "/img/700x/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 
 	if scene.IsScripted {
-		title = scene.GetFunscriptTitle()
+		title = scene.GetFunscriptTitle(config.Config.Interfaces.DeoVR.TitleFormat)
 		if config.Config.Interfaces.DeoVR.RenderHeatmaps {
 			thumbnailURL = session.DeoRequestHost + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 		}
@@ -435,9 +435,8 @@ func scenesToDeoList(req *restful.Request, scenes []models.Scene) []DeoListItem 
 		if config.Config.Interfaces.DeoVR.RenderHeatmaps && scenes[i].IsScripted {
 			thumbnailURL = fmt.Sprintf("%v/imghm/%d/%v", session.DeoRequestHost, scenes[i].ID, strings.Replace(scenes[i].CoverURL, "://", ":/", -1))
 		}
-
 		item := DeoListItem{
-			Title:        scenes[i].Title,
+			Title:        scenes[i].GetDeoFormattedTitle(config.Config.Interfaces.DeoVR.TitleFormat),
 			VideoLength:  scenes[i].Duration * 60,
 			ThumbnailURL: thumbnailURL,
 			VideoURL:     fmt.Sprintf("%v/deovr/%v", session.DeoRequestHost, scenes[i].ID),

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -56,6 +56,7 @@ type RequestSaveOptionsDeoVR struct {
 	Password       string `json:"password"`
 	RemoteEnabled  bool   `json:"remote_enabled"`
 	RenderHeatmaps bool   `json:"render_heatmaps"`
+	TitleFormat    string `json:"title_format"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -233,6 +234,7 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.DeoVR.RenderHeatmaps = r.RenderHeatmaps
 	config.Config.Interfaces.DeoVR.RemoteEnabled = r.RemoteEnabled
 	config.Config.Interfaces.DeoVR.Username = r.Username
+	config.Config.Interfaces.DeoVR.TitleFormat = r.TitleFormat
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type ObjectConfig struct {
 			RemoteEnabled  bool   `default:"false" json:"remote_enabled"`
 			Username       string `default:"" json:"username"`
 			Password       string `default:"" json:"password"`
+			TitleFormat    string `default:"{{.Title}}" json:"title_format"`
 		} `json:"deovr"`
 	} `json:"interfaces"`
 	Library struct {

--- a/pkg/tasks/funscripts.go
+++ b/pkg/tasks/funscripts.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -39,7 +40,7 @@ func ExportFunscripts(w http.ResponseWriter, updatedOnly bool) {
 			if i == 0 {
 				if file.Exists() {
 					if !file.IsExported || !updatedOnly {
-						funscriptName := fmt.Sprintf("%s.funscript", scene.GetFunscriptTitle())
+						funscriptName := fmt.Sprintf("%s.funscript", scene.GetFunscriptTitle(config.Config.Interfaces.DeoVR.TitleFormat))
 
 						if err = AddFileToZip(zipWriter, file.GetPath(), funscriptName); err != nil {
 							log.Infof("Error when adding file to zip: %v (%s)", err, funscriptName)

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -9,6 +9,7 @@ const state = {
     remote_enabled: false,
     username: '',
     password: '',
+    title_format: '',
     boundIp: []
   }
 }
@@ -27,6 +28,7 @@ const actions = {
         state.deovr.remote_enabled = data.config.interfaces.deovr.remote_enabled
         state.deovr.username = data.config.interfaces.deovr.username
         state.deovr.password = data.config.interfaces.deovr.password
+        state.deovr.title_format = data.config.interfaces.deovr.title_format
         state.deovr.boundIp = data.currentState.server.bound_ip
         state.loading = false
       })

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -53,6 +53,19 @@
                   instructions in DeoVR documentation</a>.
                 </p>
               </div>
+              <hr/>
+              <div class="block">
+                <b-field label="Title Format">
+                  <b-input v-model="titleFormat"></b-input>
+                </b-field>
+                <p>
+                  Custom Title format to use in DeoVR, following Golang's template <a href="https://golang.org/pkg/text/template/" target="_blank" rel="noreferrer">format</a>.
+                  Examples:
+                </p>
+                <ul>
+                  <pre v-pre><li>{{.Studio}} - {{.Title}}</li><li>{{.Title}} ({{.ReleaseDate.Format "2006"}})</li></pre>
+                </ul>
+              </div>
             </div>
           </section>
         </div>
@@ -147,6 +160,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.deovr.password = value
+      }
+    },
+    titleFormat: {
+      get () {
+        return this.$store.state.optionsDeoVR.deovr.title_format
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.deovr.title_format = value
       }
     },
     boundIp: {


### PR DESCRIPTION
This PR adds the ability for users to specify custom format for DeoVR titles. For example, they can add the release date, or the studio for any particular scene. This uses Golang's template format to achieve this, and uses `models.Scene` as the data source that get inserted into the template. For example:

- `{{.Title}}`: the default, it just uses the scene title as DeoVR title, .i.e: `Scene Title`
- `{{.Title}} ({{.ReleaseDate.Format "2006"}})`: `Scene Title (2020)`
- `{{.Studio}} - {{.Title}}`: `Studio - Scene Title`

This also supports the Funscript export work that was merged recently.