### PR TITLE
Add 3dv to list of common words

### DIFF
--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -89,8 +89,8 @@ export default {
   methods: {
     initView () {
       const commonWords = [
-        '180', '180x180', '30fps', '30m', '360', '3dh', '4k', '5k', '60fps', '6k', '7k',
-        '8k', 'fb360', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv',
+        '180', '180x180', '30fps', '30m', '360', '3dh', '3dv', '4k', '5k', '60fps', '6k',
+        '7k', '8k', 'fb360', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv',
         'mkx200', 'mkx220', 'mono', 'mp4', 'oculus', 'oculus5k', 'oculusrift', 'original',
         'smartphone', 'tb', 'vrca220', 'vp9'
       ]


### PR DESCRIPTION
Adds `3dv` to the list of common words to improve matching. `3dv` is used for some older BadoinkVR and KinkVR filenames.