### PR TITLE
Fix duration scraping for multiple sites

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -82,11 +83,11 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		})
 
 		// Duration
+		durationRegex := regexp.MustCompile(`Duration: ([0-9]+) min`)
 		e.ForEach(`p.video-duration`, func(id int, e *colly.HTMLElement) {
-			content := strings.Replace(strings.Split(e.Attr("content"), "M")[0], "PT", "", -1)
-			tmpDuration, err := strconv.Atoi(content)
-			if err == nil {
-				sc.Duration = tmpDuration
+			m := durationRegex.FindStringSubmatch(e.Text)
+			if len(m) == 2 {
+				sc.Duration, _ = strconv.Atoi(m[1])
 			}
 		})
 

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -2,6 +2,7 @@ package scrape
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -38,6 +39,14 @@ func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string
 
 		// Release date
 		sc.Released = e.Request.Ctx.Get("released")
+
+		// Duration
+		e.ForEach(`.table-plain td:contains("Duration:") ~ td`, func(id int, e *colly.HTMLElement) {
+			tmpDuration, err := strconv.Atoi(strings.Split(e.Text, ":")[0])
+			if err == nil {
+				sc.Duration = tmpDuration
+			}
+		})
 
 		// Cast
 		e.ForEach(`a[itemprop="actor"]`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -79,9 +79,17 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 
 		// Duration
 		e.ForEach(`div.video-additional div.grid-one-time span`, func(id int, e *colly.HTMLElement) {
-			tmpDuration, err := strconv.Atoi(strings.TrimSpace(strings.Replace(e.DOM.Parent().Text(), "min.", "", -1)))
+			durationText := strings.TrimSpace(strings.Replace(e.DOM.Parent().Text(), "min.", "", -1))
+			tmpDuration, err := strconv.Atoi(durationText)
 			if err == nil {
 				sc.Duration = tmpDuration
+			} else {
+				tmpParts := strings.Split(durationText, ":")
+				if len(tmpParts) == 3 {
+					hours, _ := strconv.Atoi(tmpParts[0])
+					minutes, _ := strconv.Atoi(tmpParts[1])
+					sc.Duration = hours*60 + minutes
+				}
 			}
 		})
 

--- a/pkg/scrape/sinsvr.go
+++ b/pkg/scrape/sinsvr.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,12 @@ func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	sceneCollector := createCollector("xsinsvr.com")
 	siteCollector := createCollector("xsinsvr.com")
+
+	durationRegexes := []*regexp.Regexp{
+		regexp.MustCompile(`(?:(?P<h>\d+):)?(?P<m>\d+):(?P<s>\d+)`),           // e.g. 11:11, 1:11:11
+		regexp.MustCompile(`(?:(?P<h>\d+) h(?:ou)?rs? )?(?P<m>\d+) m(?:i)?n`), // e.g. 11 mn, 11 min, 1 hr 11 mn, 1 hour 11 min
+		regexp.MustCompile(`(?:(?P<h>\d+)')?(?P<m>\d+)"(?P<s>\d+)`),           // e.g. 1"11, 1'11"11
+	}
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
@@ -65,9 +72,16 @@ func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		})
 
 		// Duration
-		tmpDuration, err := strconv.Atoi(strings.Split(e.ChildText(`div.video-player-container__info div.tn-video-props span`), ":")[0])
-		if err == nil {
-			sc.Duration = tmpDuration
+		durationText := e.ChildText(`div.video-player-container__info div.tn-video-props span`)
+		for _, regex := range durationRegexes {
+			match := regex.FindStringSubmatchIndex(durationText)
+			hours, _ := strconv.Atoi(string(regex.ExpandString([]byte{}, "0$h", durationText, match)))
+			minutes, _ := strconv.Atoi(string(regex.ExpandString([]byte{}, "0$m", durationText, match)))
+			duration := hours*60 + minutes
+			if duration != 0 {
+				sc.Duration = duration
+				break
+			}
 		}
 
 		//Tags

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -76,7 +76,17 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 			json.Unmarshal([]byte(e.Text), &jsonResult)
 
 			duration := jsonResult["duration"].(string)
-			sc.Duration, _ = strconv.Atoi(strings.Split(duration, ":")[0])
+			tmpParts := strings.Split(duration, ":")
+			if len(tmpParts) == 2 {
+				sc.Duration, _ = strconv.Atoi(tmpParts[0])
+			} else {
+				tmpParts = strings.Split(duration, "h ")
+				if len(tmpParts) == 2 {
+					hours, _ := strconv.Atoi(tmpParts[0])
+					minutes, _ := strconv.Atoi(tmpParts[1])
+					sc.Duration = hours*60 + minutes
+				}
+			}
 
 			sc.Released = jsonResult["datePublished"].(string)
 

--- a/pkg/scrape/vrconk.go
+++ b/pkg/scrape/vrconk.go
@@ -50,7 +50,7 @@ func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 			if strings.Contains(c, "i-clock") {
 				tmpDuration, err := strconv.Atoi(strings.Split(e.ChildText(`.sub-label`), ":")[0])
 				if err == nil {
-					sc.Duration = tmpDuration
+					sc.Duration = tmpDuration / 60
 				}
 			}
 

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -23,6 +23,7 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 	// RegEx Patterns
 	sceneIDRegEx := regexp.MustCompile(`^post-(\d+)`)
 	dateRegEx := regexp.MustCompile(`(?i)^VideoPosted on (?:Premium )?(.+)$`)
+	durationRegEx := regexp.MustCompile(`var timeAfter="(?:(\d+):)?(\d+):(\d+)";`)
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		if !dateRegEx.MatchString(e.ChildText(`div.content-box.posted-by-box.posted-by-box-sub span.footer-titles`)) {
@@ -90,26 +91,17 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 
 		// Duration
-		var dur string
-		var duration int
-		if e.DOM.Find(`.lengthvideoAfter.premium-post`) != nil {
-			dur = e.DOM.Find(`.lengthvideoAfter.premium-post`).Text()
-		} else {
-			dur = e.DOM.Find(`.lengthvideoBefore.no-premium`).Text()
-		}
-		tmpParts := strings.Split(dur, ":")
-		if len(tmpParts) > 2 {
-			if h, err := strconv.Atoi(tmpParts[0]); err == nil {
-				if m, err := strconv.Atoi(tmpParts[1]); err == nil {
-					duration = h*60 + m
-				}
+		e.ForEachWithBreak(`script`, func(id int, e *colly.HTMLElement) bool {
+			var duration int
+			m := durationRegEx.FindStringSubmatch(e.Text)
+			if len(m) == 4 {
+				hours, _ := strconv.Atoi("0" + m[1])
+				minutes, _ := strconv.Atoi(m[2])
+				duration = hours*60 + minutes
 			}
-		} else {
-			if m, err := strconv.Atoi(tmpParts[0]); err == nil {
-				duration = m
-			}
-		}
-		sc.Duration = duration
+			sc.Duration = duration
+			return duration == 0
+		})
 
 		out <- sc
 	})

--- a/pkg/scrape/wankz.go
+++ b/pkg/scrape/wankz.go
@@ -44,11 +44,9 @@ func WankzVRSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Duration
 		e.ForEach(`div.detail__date_time span.time`, func(id int, e *colly.HTMLElement) {
-			if id == 1 {
-				tmpDuration, err := strconv.Atoi(strings.TrimSpace(strings.Replace(e.Text, "minutes", "", -1)))
-				if err == nil {
-					sc.Duration = tmpDuration
-				}
+			tmpDuration, err := strconv.Atoi(strings.Split(strings.TrimSpace(e.Text), " ")[0])
+			if err == nil {
+				sc.Duration = tmpDuration
 			}
 		})
 


### PR DESCRIPTION
For some scrapers this is completely broken, some only support durations under an hour, some use the wrong units. I'm not sure I caught them all, but this should fix a lot/most of them.