### PR TITLE
Don't match file to scene if ambiguous

### DIFF
--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -65,7 +65,7 @@ func RescanVolumes() {
 				log.Error(err, " when matching "+path.Base(fn))
 			}
 
-			if len(scenes) >= 1 {
+			if len(scenes) == 1 {
 				files[i].SceneID = scenes[0].ID
 				files[i].Save()
 			}


### PR DESCRIPTION
If multiple scenes are found to match a file, one of them is arbitrarily chosen and the association is made. This can lead to a file being associated to the wrong scene, so I think it would be better in that case to leave the file unmatched and let the user match it to the correct scene manually.