### PR TITLE
Fix handling of IPv6 addresses

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -109,7 +109,11 @@ func isDeoAuthEnabled() bool {
 }
 
 func setDeoPlayerHost(req *restful.Request) {
-	deoIP := strings.Split(req.Request.RemoteAddr, ":")[0]
+	deoIP := req.Request.RemoteAddr
+	lastColon := strings.LastIndex(deoIP, ":")
+	if lastColon != -1 {
+		deoIP = deoIP[:lastColon]
+	}
 	if deoIP != session.DeoPlayerHost {
 		common.Log.Infof("DeoVR Player connecting from %v", deoIP)
 		session.DeoPlayerHost = deoIP


### PR DESCRIPTION
When DeoVR connects from an IPv6 address, remote mode does not work.

For a connecting address like `[fe80::1]:12345`, XBVR will split on the first colon, in this case `[fe80`, and then try to [connect to `[fe80:23554`](https://github.com/xbapps/xbvr/blob/41faf55ce4def0a2c1b59b29abd895216540e4d3/pkg/session/remote.go#L47), which results in this error:

> dial tcp: address [fe80:23554: missing ']' in address

This PR fixes the colon splitting so it also works with IPv6 addresses.