### PR TITLE
Add error handling to heatmap generation

### DIFF
--- a/pkg/tasks/heatmap.go
+++ b/pkg/tasks/heatmap.go
@@ -99,14 +99,20 @@ func LoadFunscriptData(path string) (Script, error) {
 		return Script{}, fmt.Errorf("actions list missing in %s", path)
 	}
 
+	if len(funscript.Actions) == 0 {
+		return Script{}, fmt.Errorf("actions list empty in %s", path)
+	}
+
 	sort.SliceStable(funscript.Actions, func(i, j int) bool { return funscript.Actions[i].At < funscript.Actions[j].At })
 
 	return funscript, nil
 }
 
 func RenderHeatmap(inputFile string, destFile string, width, height, numSegments int) error {
-
 	funscript, err := LoadFunscriptData(inputFile)
+	if err != nil {
+		return err
+	}
 
 	funscript.UpdateIntensity()
 	gradient := funscript.getGradientTable(numSegments)


### PR DESCRIPTION
Fixes #544

Errors returned by `LoadFunscriptData` are no longer ignored, and adds an additional check that the actions array is not empty.