### PR TITLE
Add common CzechVR words

### DIFF
--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -89,10 +89,11 @@ export default {
   methods: {
     initView () {
       const commonWords = [
-        '180', '180x180', '30fps', '30m', '360', '3dh', '3dv', '4k', '5k', '60fps', '6k',
-        '7k', '8k', 'fb360', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr', 'mkv',
-        'mkx200', 'mkx220', 'mono', 'mp4', 'oculus', 'oculus5k', 'oculusrift', 'original',
-        'smartphone', 'tb', 'vrca220', 'vp9'
+        '180', '180x180', '2880x1440', '3d', '3dh', '3dv', '30fps', '30m', '360',
+        '3840x1920', '4k', '5k', '5400x2700', '60fps', '6k', '7k', '7680x3840',
+        '8k', 'fb360', 'funscript', 'h264', 'h265', 'hevc', 'hq', 'lq', 'lr',
+        'mkv', 'mkx200', 'mkx220', 'mono', 'mp4', 'oculus', 'oculus5k',
+        'oculusrift', 'original', 'smartphone', 'tb', 'uhq', 'vrca220', 'vp9'
       ]
       const isNotCommonWord = word => !commonWords.includes(word.toLowerCase()) && !/^[0-9]+p$/.test(word)
 


### PR DESCRIPTION
Adds some common words from CzechVR scenes to speed up matching: `3d`, `2880x1440`, `3840x1920`, `5400x2700`, `7680x3840` and `uhq`.