### PR TITLE
Wait up to one minute for scene match searches

### DIFF
--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -120,7 +120,8 @@ export default {
       const resp = await ky.get('/api/scene/search', {
         searchParams: {
           q: this.queryString
-        }
+        },
+        timeout: 60000
       }).json()
 
       if (requestIndex >= this.dataNumResponses) {


### PR DESCRIPTION
For people with more scrapers selected, their search queries can take longer to get a response.

Should fix https://github.com/xbapps/xbvr/issues/599.