### PR TITLE
R18 - fixes "missing DVD ID" check 

### DIFF
--- a/pkg/scrape/r18.go
+++ b/pkg/scrape/r18.go
@@ -24,7 +24,7 @@ func ScrapeR18(knownScenes []string, out *[]models.ScrapedScene, queryString str
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 		sc.Site = strings.Split(e.ChildText("title"), "-")[0]
 
-		content_id := strings.Split(sc.HomepageURL, "=")[1]
+		content_id := strings.Split(strings.Split(sc.HomepageURL, "=")[1], "/")[0]
 
 		r, _ := resty.R().Get("https://www.r18.com/api/v4f/contents/" + content_id)
 
@@ -93,7 +93,7 @@ func ScrapeR18(knownScenes []string, out *[]models.ScrapedScene, queryString str
 
 		//		})
 
-		if dvdID == "----" {
+		if dvdID == "----" || dvdID == "" {
 			sc.SceneID = content_id
 			sc.SiteID = content_id
 		} else {


### PR DESCRIPTION
resolves #611 

recent website changes possibly broke scene matching for R18 videos that don't have DVD IDs.