### PR TITLE
Add funcsript speed features

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -385,20 +385,24 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		screenType = "sphere"
 	}
 
-	// title := scene.Title
+	title := scene.Title
 	thumbnailURL := session.DeoRequestHost + "/img/700x/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 
-	// if scene.IsScripted {
-	// 	title = scene.GetFunscriptTitle()
-	// 	if config.Config.Interfaces.DeoVR.RenderHeatmaps {
-	// 		thumbnailURL = session.DeoRequestHost + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
-	// 	}
-	// }
+	if scene.IsScripted {
+		if config.Config.Interfaces.DeoVR.FunscriptSpeeds {
+			title = fmt.Sprintf("%d - %s", scene.FunscriptSpeed, scene.Title)
+		} else {
+			title = scene.GetFunscriptTitle()
+		}
+		if config.Config.Interfaces.DeoVR.RenderHeatmaps {
+			thumbnailURL = session.DeoRequestHost + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
+		}
+	}
 
 	deoScene := DeoScene{
 		ID:               scene.ID,
 		Authorized:       1,
-		Title:            fmt.Sprintf("%d - %s", scene.FunscriptSpeed, scene.Title),
+		Title:            title,
 		Description:      scene.Synopsis,
 		Actors:           actors,
 		Paysite:          DeoScenePaysite{ID: 1, Name: scene.Site, Is3rdParty: true},
@@ -490,7 +494,7 @@ func scenesToDeoList(req *restful.Request, scenes []models.Scene) []DeoListItem 
 		}
 
 		item := DeoListItem{
-			Title:        fmt.Sprintf("%d - %s", scenes[i].FunscriptSpeed, scenes[i].Title),
+			Title:        scenes[i].Title,
 			VideoLength:  scenes[i].Duration * 60,
 			ThumbnailURL: thumbnailURL,
 			VideoURL:     fmt.Sprintf("%v/deovr/%v", session.DeoRequestHost, scenes[i].ID),

--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -385,20 +385,20 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		screenType = "sphere"
 	}
 
-	title := scene.Title
+	// title := scene.Title
 	thumbnailURL := session.DeoRequestHost + "/img/700x/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 
-	if scene.IsScripted {
-		title = scene.GetFunscriptTitle()
-		if config.Config.Interfaces.DeoVR.RenderHeatmaps {
-			thumbnailURL = session.DeoRequestHost + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
-		}
-	}
+	// if scene.IsScripted {
+	// 	title = scene.GetFunscriptTitle()
+	// 	if config.Config.Interfaces.DeoVR.RenderHeatmaps {
+	// 		thumbnailURL = session.DeoRequestHost + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
+	// 	}
+	// }
 
 	deoScene := DeoScene{
 		ID:               scene.ID,
 		Authorized:       1,
-		Title:            title,
+		Title:            fmt.Sprintf("%d - %s", scene.FunscriptSpeed, scene.Title),
 		Description:      scene.Synopsis,
 		Actors:           actors,
 		Paysite:          DeoScenePaysite{ID: 1, Name: scene.Site, Is3rdParty: true},

--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -490,7 +490,7 @@ func scenesToDeoList(req *restful.Request, scenes []models.Scene) []DeoListItem 
 		}
 
 		item := DeoListItem{
-			Title:        scenes[i].Title,
+			Title:        fmt.Sprintf("%d - %s", scenes[i].FunscriptSpeed, scenes[i].Title),
 			VideoLength:  scenes[i].Duration * 60,
 			ThumbnailURL: thumbnailURL,
 			VideoURL:     fmt.Sprintf("%v/deovr/%v", session.DeoRequestHost, scenes[i].ID),

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -50,12 +50,13 @@ type RequestSaveOptionsDLNA struct {
 }
 
 type RequestSaveOptionsDeoVR struct {
-	Enabled        bool   `json:"enabled"`
-	AuthEnabled    bool   `json:"auth_enabled"`
-	Username       string `json:"username"`
-	Password       string `json:"password"`
-	RemoteEnabled  bool   `json:"remote_enabled"`
-	RenderHeatmaps bool   `json:"render_heatmaps"`
+	Enabled         bool   `json:"enabled"`
+	AuthEnabled     bool   `json:"auth_enabled"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	RemoteEnabled   bool   `json:"remote_enabled"`
+	RenderHeatmaps  bool   `json:"render_heatmaps"`
+	FunscriptSpeeds bool   `json:"funscript_speeds"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -231,6 +232,7 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.DeoVR.Enabled = r.Enabled
 	config.Config.Interfaces.DeoVR.AuthEnabled = r.AuthEnabled
 	config.Config.Interfaces.DeoVR.RenderHeatmaps = r.RenderHeatmaps
+	config.Config.Interfaces.DeoVR.FunscriptSpeeds = r.FunscriptSpeeds
 	config.Config.Interfaces.DeoVR.RemoteEnabled = r.RemoteEnabled
 	config.Config.Interfaces.DeoVR.Username = r.Username
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -412,6 +412,7 @@ func (i SceneResource) selectScript(req *restful.Request, resp *restful.Response
 
 	var scene models.Scene
 	var files []models.File
+	var newFunscriptSpeed int
 	db, _ := models.GetDB()
 	err = scene.GetIfExistByPK(uint(sceneId))
 	if err == nil {
@@ -421,6 +422,7 @@ func (i SceneResource) selectScript(req *restful.Request, resp *restful.Response
 				if file.ID == r.FileID && !file.IsSelectedScript {
 					file.IsSelectedScript = true
 					file.Save()
+					newFunscriptSpeed = file.FunscriptSpeed
 				} else if file.ID != r.FileID && file.IsSelectedScript {
 					file.IsSelectedScript = false
 					file.Save()
@@ -428,6 +430,10 @@ func (i SceneResource) selectScript(req *restful.Request, resp *restful.Response
 			}
 		}
 		err = scene.GetIfExistByPK(uint(sceneId))
+	}
+	if newFunscriptSpeed > 0 {
+		scene.FunscriptSpeed = newFunscriptSpeed
+		scene.Save()
 	}
 	db.Close()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,12 +29,13 @@ type ObjectConfig struct {
 			AllowedIP    []string `default:"[]" json:"allowedIp"`
 		} `json:"dlna"`
 		DeoVR struct {
-			Enabled        bool   `default:"true" json:"enabled"`
-			AuthEnabled    bool   `default:"false" json:"auth_enabled"`
-			RenderHeatmaps bool   `default:"false" json:"render_heatmaps"`
-			RemoteEnabled  bool   `default:"false" json:"remote_enabled"`
-			Username       string `default:"" json:"username"`
-			Password       string `default:"" json:"password"`
+			Enabled         bool   `default:"true" json:"enabled"`
+			AuthEnabled     bool   `default:"false" json:"auth_enabled"`
+			RenderHeatmaps  bool   `default:"false" json:"render_heatmaps"`
+			FunscriptSpeeds bool   `default:"false" json:"funscript_speeds"`
+			RemoteEnabled   bool   `default:"false" json:"remote_enabled"`
+			Username        string `default:"" json:"username"`
+			Password        string `default:"" json:"password"`
 		} `json:"deovr"`
 	} `json:"interfaces"`
 	Library struct {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -39,6 +39,8 @@ type RequestSceneList struct {
 	Volume       optional.Int      `json:"volume"`
 	Released     optional.String   `json:"releaseMonth"`
 	Sort         optional.String   `json:"sort"`
+	MinFunscript optional.Int      `json:"minFunscript"`
+	MaxFunscript optional.Int      `json:"maxFunscript"`
 }
 
 func (i *RequestSceneList) ToJSON() string {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/markphelps/optional"
 	"github.com/mozillazg/go-slugify"
+	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/models"
@@ -572,6 +573,48 @@ func Migrate() {
 
 				// since scenes have new IDs, we need to re-index them
 				tasks.SearchIndex()
+
+				return nil
+			},
+		},
+		{
+			ID: "0028-file-funscript-speed",
+			Migrate: func(tx *gorm.DB) error {
+				type File struct {
+					FunscriptSpeed int `json:"funscript_speed" gorm:"default:0"`
+				}
+				err := tx.AutoMigrate(File{}).Error
+				if err != nil {
+					return err
+				}
+				tlog := common.Log.WithFields(logrus.Fields{"task": "migrate"})
+				tasks.GenerateFunscriptSpeeds(tlog)
+				return nil
+			},
+		},
+		{
+			ID: "0029-scene-funscript-speed",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					FunscriptSpeed int `json:"funscript_speed" gorm:"default:0"`
+				}
+				err := tx.AutoMigrate(Scene{}).Error
+				if err != nil {
+					return err
+				}
+
+				var scenes []models.Scene
+
+				db.Model(&models.Scene{}).Find(&scenes)
+
+				tlog := common.Log.WithFields(logrus.Fields{"task": "migrate"})
+
+				for i := range scenes {
+					scenes[i].UpdateStatus()
+					if (i % 70) == 0 {
+						tlog.Infof("Update status of Scenes (%v/%v)", i+1, len(scenes))
+					}
+				}
 
 				return nil
 			},

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -38,6 +38,7 @@ type File struct {
 	VideoProjection      string  `json:"projection"`
 
 	HasHeatmap       bool `json:"has_heatmap"`
+	FunscriptSpeed   int  `json:"funscript_speed" gorm:"default:0"`
 	IsSelectedScript bool `json:"is_selected_script"`
 	IsExported       bool `json:"is_exported"`
 }

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -488,6 +488,8 @@ type RequestSceneList struct {
 	Volume       optional.Int      `json:"volume"`
 	Released     optional.String   `json:"releaseMonth"`
 	Sort         optional.String   `json:"sort"`
+	MinFunscript optional.Int      `json:"minFunscript"`
+	MaxFunscript optional.Int      `json:"maxFunscript"`
 }
 
 type ResponseSceneList struct {
@@ -540,6 +542,14 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 
 	if r.IsWatched.Present() {
 		tx = tx.Where("is_watched = ?", r.IsWatched.OrElse(true))
+	}
+
+	if r.MinFunscript.Present() {
+		tx = tx.Where("funscript_speed > ?", r.MinFunscript.OrElse(0))
+	}
+
+	if r.MaxFunscript.Present() {
+		tx = tx.Where("funscript_speed < ?", r.MaxFunscript.OrElse(0))
 	}
 
 	if r.Volume.Present() && r.Volume.OrElse(0) != 0 {

--- a/pkg/tasks/heatmap.go
+++ b/pkg/tasks/heatmap.go
@@ -39,6 +39,9 @@ type Action struct {
 
 	Slope     float64
 	Intensity int64
+
+	// Used in funscript speed task
+	Speed float64
 }
 
 type GradientTable []struct {

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -83,6 +83,9 @@ func RescanVolumes() {
 			}
 		}
 
+		tlog.Infof("Generating funscript speeds")
+		GenerateFunscriptSpeeds(tlog)
+
 		// Update scene statuses
 		tlog.Infof("Update status of Scenes")
 		db.Model(&models.Scene{}).Find(&scenes)

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -13,6 +13,7 @@
   "Scene updated date": "Scene updated date",
   "Rating": "Rating",
   "Recently viewed": "Recently viewed",
+  "Funscript speed": "Funscript speed",
   "Random": "Random",
   "File": "File",
   "Created": "Created",

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -6,6 +6,7 @@ const state = {
     enabled: false,
     auth_enabled: false,
     render_heatmaps: false,
+    funscript_speeds: false,
     remote_enabled: false,
     username: '',
     password: '',
@@ -24,6 +25,7 @@ const actions = {
         state.deovr.enabled = data.config.interfaces.deovr.enabled
         state.deovr.auth_enabled = data.config.interfaces.deovr.auth_enabled
         state.deovr.render_heatmaps = data.config.interfaces.deovr.render_heatmaps
+        state.deovr.funscript_speeds = data.config.interfaces.deovr.funscript_speeds
         state.deovr.remote_enabled = data.config.interfaces.deovr.remote_enabled
         state.deovr.username = data.config.interfaces.deovr.username
         state.deovr.password = data.config.interfaces.deovr.password

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -22,7 +22,9 @@ const defaultFilterState = {
   tags: [],
   cuepoint: [],
   volume: 0,
-  sort: 'release_desc'
+  sort: 'release_desc',
+  minFunscript: null,
+  maxFunscript: null
 }
 
 const state = {

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -53,6 +53,17 @@
                   instructions in DeoVR documentation</a>.
                 </p>
               </div>
+              <div class="block">
+                <b-field label="Funscript Speeds">
+                  <b-switch v-model="funscriptSpeeds">
+                    Enabled
+                  </b-switch>
+                </b-field>
+                <p>
+                  Prepend the scenes funscript speed to the title.<br/>
+                  <b>Warning:</b> only works with dynamically served funscripts. Breaks matching for locally exported scripts.
+                </p>
+              </div>
             </div>
           </section>
         </div>
@@ -123,6 +134,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.deovr.render_heatmaps = value
+      }
+    },
+    funscriptSpeeds: {
+      get () {
+        return this.$store.state.optionsDeoVR.deovr.funscript_speeds
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.deovr.funscript_speeds = value
       }
     },
     remoteEnabled: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -374,6 +374,7 @@ export default {
         }
       }).json().then(data => {
           this.$store.commit('overlay/showDetails', { scene: data })
+          this.$store.commit('sceneList/updateScene', data)
       })
     },
     getImageURL (u, size) {

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -47,6 +47,8 @@
             <option value="scene_updated_desc">↓ {{ $t("Scene updated date") }}</option>
             <option value="last_opened_desc">↓ {{ $t("Last viewed date") }}</option>
             <option value="last_opened_asc">↑ {{ $t("Last viewed date") }}</option>
+            <option value="funscript_speed_desc">↓ {{ $t("Funscript speed") }}</option>
+            <option value="funscript_speed_asc">↑ {{ $t("Funscript speed") }}</option>
             <option value="random">↯ {{ $t("Random") }}</option>
           </select>
         </div>

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -130,6 +130,14 @@
         </b-taginput>
       </b-field>
 
+      <b-field label="Funscript speed" label-position="on-border" grouped>
+        <b-field class="field-extra" expanded>
+          <b-numberinput v-model="minFunscript" :controls="false"></b-numberinput>
+        </b-field>
+        <b-field class="field-extra" expanded>
+          <b-numberinput v-model="maxFunscript" :controls="false"></b-numberinput>
+        </b-field>
+      </b-field>
     </div>
   </div>
 </template>
@@ -268,6 +276,24 @@ export default {
       },
       set (value) {
         this.$store.state.sceneList.filters.isWatched = value
+        this.reloadList()
+      }
+    },
+    minFunscript: {
+      get () {
+        return this.$store.state.sceneList.filters.minFunscript
+      },
+      set (value) {
+        this.$store.state.sceneList.filters.minFunscript = value
+        this.reloadList()
+      }
+    },
+    maxFunscript: {
+      get () {
+        return this.$store.state.sceneList.filters.maxFunscript
+      },
+      set (value) {
+        this.$store.state.sceneList.filters.maxFunscript = value
         this.reloadList()
       }
     }

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -19,6 +19,8 @@
             <b-tag type="is-info" v-if="item.is_scripted">
               <b-icon pack="mdi" icon="pulse" size="is-small"/>
               <span v-if="scriptFilesCount > 1">{{scriptFilesCount}}</span>
+              <b-icon v-if="item.funscript_speed > 0" pack="mdi" icon="speedometer" size="is-small"/>
+                <span v-if="item.funscript_speed > 0">{{item.funscript_speed}}</span>
             </b-tag>
             <b-tag type="is-warning" v-if="item.star_rating > 0">
               <b-icon pack="mdi" icon="star" size="is-small"/>
@@ -80,6 +82,20 @@ export default {
         }
       })
       return count
+    },
+    scriptSpeed () {
+      let first_speed, selected_speed
+      this.item.file.forEach(obj => {
+        if (obj.type === 'script') {
+          if (!first_speed) {
+            first_speed = obj.funscript_speed
+          }
+        }
+        if (obj.is_selected_script === true) {
+          selected_speed = obj.funscript_speed
+        }
+      })
+      return selected_speed ? selected_speed : first_speed
     }
   },
   methods: {


### PR DESCRIPTION
Calculates median speed of each script file and saves it on the file model. 
Finds selected script on scene and saves speed on the model. 

Adds funscript speed desc/asc and range filters. 
![Screenshot from 2021-12-05 14-45-10](https://user-images.githubusercontent.com/85076203/144749130-2fae2076-00e5-409b-aaba-b150724eafe1.png)
![Screenshot from 2021-12-05 14-44-57](https://user-images.githubusercontent.com/85076203/144749128-05f585d9-2865-4f92-bc8e-0288ea6d8de6.png)

Displays scenes speed on the card.
![Screenshot from 2021-12-05 14-46-47](https://user-images.githubusercontent.com/85076203/144749142-5ecfdd66-8168-4a01-a3c6-96c02085a816.png)
Not sure about the look of this one.

Adds option to prepend speed to title in DeoVR API, at the loss of matching local exported scripts.
![Screenshot from 2021-12-05 14-44-25](https://user-images.githubusercontent.com/85076203/144749145-868e599c-f2d4-414e-af5d-6d07e5372196.png)

