### PR TITLE
SLR / RealJamVR filename fixes

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -576,6 +576,27 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// SLR/RealJam Titles containing ":" creates invalid filenames breaks automatching. fix filenames changing : to _
+			ID: "0028-fix-slr-rj-filenames",
+			Migrate: func(tx *gorm.DB) error {
+				var scenes []models.Scene
+				err := tx.Where("filenames_arr LIKE ?", "%:%").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+
+				for _, scene := range scenes {
+					scene.FilenamesArr = strings.ReplaceAll(scene.FilenamesArr, ":", "_")
+					err = tx.Save(&scene).Error
+					if err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -580,9 +580,9 @@ func Migrate() {
 			// SLR/RealJam Titles containing ":" & "?" creates invalid filenames breaks automatching. fix filenames changing to _
 			ID: "0029-fix-slr-rj-filenames",
 			Migrate: func(tx *gorm.DB) error {
-				filenameRegEx := regexp.MustCompile(`[:?]`)
+				filenameRegEx := regexp.MustCompile(`[:?]|( & )|( \\u0026 )`)
 				var scenes []models.Scene
-				err := tx.Where("filenames_arr LIKE ?", "%:%").Or("filenames_arr LIKE ?", "%?%").Find(&scenes).Error
+				err := tx.Where("filenames_arr LIKE ?", "%:%").Or("filenames_arr LIKE ?", "%?%").Or("filenames_arr LIKE ?", "%\\u0026%").Find(&scenes).Error
 				if err != nil {
 					return err
 				}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -577,17 +577,18 @@ func Migrate() {
 			},
 		},
 		{
-			// SLR/RealJam Titles containing ":" creates invalid filenames breaks automatching. fix filenames changing : to _
+			// SLR/RealJam Titles containing ":" & "?" creates invalid filenames breaks automatching. fix filenames changing to _
 			ID: "0029-fix-slr-rj-filenames",
 			Migrate: func(tx *gorm.DB) error {
+				filenameRegEx := regexp.MustCompile(`[:?]`)
 				var scenes []models.Scene
-				err := tx.Where("filenames_arr LIKE ?", "%:%").Find(&scenes).Error
+				err := tx.Where("filenames_arr LIKE ?", "%:%").Or("filenames_arr LIKE ?", "%?%").Find(&scenes).Error
 				if err != nil {
 					return err
 				}
 
 				for _, scene := range scenes {
-					scene.FilenamesArr = strings.ReplaceAll(scene.FilenamesArr, ":", "_")
+					scene.FilenamesArr = filenameRegEx.ReplaceAllString(scene.FilenamesArr, "_")
 					err = tx.Save(&scene).Error
 					if err != nil {
 						return err

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -578,7 +578,7 @@ func Migrate() {
 		},
 		{
 			// SLR/RealJam Titles containing ":" creates invalid filenames breaks automatching. fix filenames changing : to _
-			ID: "0028-fix-slr-rj-filenames",
+			ID: "0029-fix-slr-rj-filenames",
 			Migrate: func(tx *gorm.DB) error {
 				var scenes []models.Scene
 				err := tx.Where("filenames_arr LIKE ?", "%:%").Find(&scenes).Error

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -80,7 +80,7 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 			}
 		})
 		for f := range set {
-			sc.Filenames = append(sc.Filenames, strings.ReplaceAll(f, " ", "_"))
+			sc.Filenames = append(sc.Filenames, strings.ReplaceAll(strings.ReplaceAll(f, " ", "_"), ":", "_"))
 		}
 
 		out <- sc

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -25,6 +25,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	coverRegEx := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
 	durationRegExForSceneCard := regexp.MustCompile(`^(?:(\d{2}):)?(\d{2}):(\d{2})$`)
 	durationRegExForScenePage := regexp.MustCompile(`^T(\d{0,2})H?(\d{2})M(\d{2})S$`)
+	filenameRegEx := regexp.MustCompile(`[:?]`)
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
@@ -145,7 +146,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				// Only shown for logged in users so need to generate them
 				// Format: SLR_siteID_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
 				resolutions := []string{"_6400p_", "_3840p_", "_3160p_", "_3072p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
-				baseName := "SLR_" + siteID + "_" + strings.Replace(sc.Title, ":", "_", -1)
+				baseName := "SLR_" + siteID + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
 				switch videotype {
 				case "360°": // Sadly can't determine if TB or MONO so have to add both
 					for i := range resolutions {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -25,7 +25,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	coverRegEx := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
 	durationRegExForSceneCard := regexp.MustCompile(`^(?:(\d{2}):)?(\d{2}):(\d{2})$`)
 	durationRegExForScenePage := regexp.MustCompile(`^T(\d{0,2})H?(\d{2})M(\d{2})S$`)
-	filenameRegEx := regexp.MustCompile(`[:?]`)
+	filenameRegEx := regexp.MustCompile(`[:?]|( & )|( \\u0026 )`)
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -145,7 +145,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				// Only shown for logged in users so need to generate them
 				// Format: SLR_siteID_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
 				resolutions := []string{"_6400p_", "_3840p_", "_3160p_", "_3072p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
-				baseName := "SLR_" + siteID + "_" + sc.Title
+				baseName := "SLR_" + siteID + "_" + strings.Replace(sc.Title, ":", "_", -1)
 				switch videotype {
 				case "360°": // Sadly can't determine if TB or MONO so have to add both
 					for i := range resolutions {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -71,7 +71,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		// ...a lot of these are shared with RealJamVR which uses the same tags though.
 		// Could split by / but would run into issues with "f/f/m" and "shorts / skirts"
 		var videotype string
-		var FB360 = ".mp4"
+		var FB360 string
 		e.ForEach(`ul.c-meta--scene-tags li a`, func(id int, e *colly.HTMLElement) {
 			if !skiptags[e.Attr("title")] {
 				sc.Tags = append(sc.Tags, e.Attr("title"))
@@ -82,7 +82,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				videotype = e.Attr("title")
 			}
 			if e.Attr("title") == "Spatial audio" {
-				FB360 = "_FB360.MP4"
+				FB360 = "_FB360.MKV"
 			}
 
 		})
@@ -154,14 +154,22 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 					}
 				case "Fisheye": // 200° videos named with MKX200
 					for i := range resolutions {
-						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX200"+FB360)
-						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX220"+FB360)
-						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_VRCA220"+FB360)
+						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX200.mp4")
+						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX220.mp4")
+						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_VRCA220.mp4")
 					}
 				default: // Assuming everything else is 180 and LR, yet to find a TB_180
 					for i := range resolutions {
 						sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_LR_180.mp4")
 					}
+				}
+				if FB360 != "" {
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_LR_180"+FB360)
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MKX200"+FB360)
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MKX220"+FB360)
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_VRCA220"+FB360)
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MONO_360"+FB360)
+					sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_TB_360"+FB360)
 				}
 			}
 

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -189,7 +189,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			fl.UpdatedTime = fTimes.ModTime()
 			fl.VolumeID = vol.ID
 
-			ffdata, err := ffprobe.GetProbeData(path, time.Second*3)
+			ffdata, err := ffprobe.GetProbeData(path, time.Second*5)
 			if err != nil {
 				tlog.Error("Error running ffprobe", path, err)
 			} else {


### PR DESCRIPTION
Titles with ":" created invalid filenames. This replaces the ":" in filesnames to "_" as the source sites intended. 