### PR TITLE
vrconk_remove_implicit_scraping

### DIFF
--- a/pkg/scrape/vrconk.go
+++ b/pkg/scrape/vrconk.go
@@ -147,22 +147,6 @@ func VRCONK(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 	siteCollector.Visit("https://vrconk.com/videos/?sort=latest&bonus-video=1")
 
-	// Edge-cases: Some early scenes are unlisted in both scenes and model index
-	// #1-10 + 15 by FantAsia, #11-14, 19, 23 by Miss K. #22, 25 by Emi.
-	// Unlisted but not added here: #86 by CumCoders (7 scenes on SLR) & some recent ones are WankzVR scenes from covid partnership.
-	unlistedscenes := [19]string{"sex-with-slavic-chick-1", "only-for-your-eyes-2", "looking-for-your-cock-3",
-		"finger-warm-up-4", "fun-with-sex-toy-5", "may-i-suck-it-6", "my-pleasure-in-your-hands-7", "take-me-baby-8",
-		"breakfast-on-the-table-9", "united-boobs-of-desire-10", "i-change-my-lingerie-three-times-for-you-15",
-		"take-care-of-the-bunny-11", "pussy-wide-open-12", "want-to-know-whats-for-dinner-13", "your-eastern-maid-14",
-		"fun-with-real-vr-amateur-19", "juicy-holes-22", "rabbit-fuck-23", "amateur-chick-in-the-kitchen-25"}
-
-	for _, scene := range unlistedscenes {
-		sceneURL := "https://vrconk.com/videos/" + scene
-		if !funk.ContainsString(knownScenes, sceneURL) {
-			sceneCollector.Visit(sceneURL)
-		}
-	}
-
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
 	}


### PR DESCRIPTION
removed implicit scraping of nonexistent scenes (nothing to scrape) on VRCONK