### PR TITLE
Enhancements for Update Prompt

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -38,8 +38,9 @@ type VersionCheckResponse struct {
 }
 
 type RequestSaveOptionsWeb struct {
-	TagSort   string `json:"tagSort"`
-	SceneEdit bool   `json:"sceneEdit"`
+	TagSort     string `json:"tagSort"`
+	SceneEdit   bool   `json:"sceneEdit"`
+	UpdateCheck bool   `json:"updateCheck"`
 }
 
 type RequestSaveOptionsDLNA struct {
@@ -152,7 +153,7 @@ func (i ConfigResource) WebService() *restful.WebService {
 func (i ConfigResource) versionCheck(req *restful.Request, resp *restful.Response) {
 	out := VersionCheckResponse{LatestVersion: common.CurrentVersion, CurrentVersion: common.CurrentVersion, UpdateNotify: false}
 
-	if common.CurrentVersion != "CURRENT" {
+	if config.Config.Web.UpdateCheck && common.CurrentVersion != "CURRENT" {
 		r, err := resty.R().
 			SetHeader("User-Agent", "XBVR/"+common.CurrentVersion).
 			Get("https://updates.xbvr.app/latest.json")
@@ -215,6 +216,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 
 	config.Config.Web.TagSort = r.TagSort
 	config.Config.Web.SceneEdit = r.SceneEdit
+	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.SaveConfig()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, r)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,8 +18,9 @@ type ObjectConfig struct {
 		Password string `default:"" json:"password"`
 	} `json:"security"`
 	Web struct {
-		TagSort   string `default:"by-tag-count" json:"tagSort"`
-		SceneEdit bool   `default:"false" json:"sceneEdit"`
+		TagSort     string `default:"by-tag-count" json:"tagSort"`
+		SceneEdit   bool   `default:"false" json:"sceneEdit"`
+		UpdateCheck bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Interfaces struct {
 		DLNA struct {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -12,8 +12,9 @@ type ObjectState struct {
 		BoundIP []string `json:"bound_ip"`
 	} `json:"server"`
 	Web struct {
-		TagSort   string `json:"tagSort"`
-		SceneEdit bool   `json:"sceneEdit"`
+		TagSort     string `json:"tagSort"`
+		SceneEdit   bool   `json:"sceneEdit"`
+		UpdateCheck bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {
 		Running  bool     `json:"running"`

--- a/ui/src/Navbar.vue
+++ b/ui/src/Navbar.vue
@@ -69,7 +69,7 @@ export default {
         this.$buefy.snackbar.open({
           message: `Version ${this.latestVersion} available!`,
           type: 'is-warning',
-          position: 'is-top',
+          position: 'is-bottom-right',
           actionText: this.$t('Download now'),
           indefinite: true,
           onAction: () => {

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -4,7 +4,8 @@ const state = {
   loading: false,
   web: {
     tagSort: 'By Tag Count',
-    sceneEdit: false
+    sceneEdit: false,
+    updateCheck: true
   }
 }
 
@@ -18,6 +19,7 @@ const actions = {
       .then(data => {
         state.web.tagSort = data.config.web.tagSort
         state.web.sceneEdit = data.config.web.sceneEdit
+        state.web.updateCheck = data.config.web.updateCheck
         state.loading = false
       })
   },
@@ -28,6 +30,7 @@ const actions = {
       .then(data => {
         state.web.tagSort = data.tagSort
         state.web.sceneEdit = data.sceneEdit
+        state.web.updateCheck = data.updateCheck
         state.loading = false
       })
   }

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -24,6 +24,12 @@
               </b-switch>
             </b-field>
 
+            <b-field label="Automatically Check for Updates">
+              <b-switch v-model="updateCheck">
+                Enabled
+              </b-switch>
+            </b-field>
+
             <b-field>
               <b-button type="is-primary" @click="save">Save</b-button>
             </b-field>
@@ -60,6 +66,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.sceneEdit = value
+      }
+    },
+    updateCheck: {
+      get () {
+        return this.$store.state.optionsWeb.web.updateCheck
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.updateCheck = value
       }
     },
     isLoading: function () {


### PR DESCRIPTION
Currently the update prompt obstructs important actions, and there's no way to dismiss it. This PR does 2 things that makes this a bit more user friendly:

1. Moves the update prompt from `top` position to `bottom-right` position. It is still not dismissable, but this position will obstruct fewer actions.

  Once https://github.com/xbapps/xbvr/pull/653 is merged, we can use the `cancelText` property on the Snackbar component to offer a way to dismiss this notification as well.

2. It offers users the ability to disable automatic update checking. I think this is important if we forget to update xbvr website with the latest version, and also for snapshot builds.  This option is configurable under Options/Interfaces/Web UI.