### PR TITLE
Manual scene creation for XBVR

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -134,7 +134,7 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 	scene_id := req.QueryParameter("scene_id")
 	if (scene_id == "") {
 		log.Infof("SceneID missing from request!")
-		CustomID = "Custom-" + time.Now().Format("20060102150405")
+		CustomID = "Custom-" + time.Now().Format("2006010215040506")
 	} else {
 		CustomID = scene_id
 	}

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -132,9 +132,10 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 
 	var CustomID string
 	scene_id := req.QueryParameter("scene_id")
+	currentTime := time.Now()
 	if (scene_id == "") {
 		log.Infof("SceneID missing from request!")
-		CustomID = "Custom-" + time.Now().Format("2006010215040506")
+		CustomID = "Custom-" + currentTime.Format("2006010215040506")
 	} else {
 		CustomID = scene_id
 	}
@@ -147,6 +148,7 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 	scene.Site = "CustomVR"
 	scene.HomepageURL = "http://localhost/" + scene.SceneID
 	scene.Covers = append(scene.Covers, "http://localhost/dont_cause_errors")
+	scene.Released = currentTime.Format("2006-01-02")
 
 	log.Infof("Creating custom scene: %v %v", scene.SceneID, scene.Title)
 

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -87,7 +87,8 @@ func (i SceneResource) WebService() *restful.WebService {
 		Writes(ResponseGetScenes{}))
 
 	ws.Route(ws.POST("/create").To(i.createCustomScene).
-		Metadata(restfulspec.KeyOpenAPITags, tags))
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
 
 	ws.Route(ws.POST("/{scene-id}/cuepoint").To(i.addSceneCuepoint).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
@@ -124,24 +125,27 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 	db, _ := models.GetDB()
 	defer db.Close()
 
+	//Get scene title
 	title := req.QueryParameter("title")
 	if (title == "") {
 		log.Error("Title is missing from request!")
 		return
 	}
 
-	var CustomID string
+	//Get scene id
+	var customID string
 	scene_id := req.QueryParameter("scene_id")
 	currentTime := time.Now()
 	if (scene_id == "") {
 		log.Infof("SceneID missing from request!")
-		CustomID = "Custom-" + currentTime.Format("2006010215040506")
+		customID = "Custom-" + currentTime.Format("2006010215040506")
 	} else {
-		CustomID = scene_id
+		customID = scene_id
 	}
 
+	//Construct custom scene
 	var scene models.ScrapedScene
-	scene.SceneID = CustomID
+	scene.SceneID = customID
 	scene.SceneType = "VR"
 	scene.Title = title
 	scene.Studio = "Custom"
@@ -152,8 +156,19 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 
 	log.Infof("Creating custom scene: %v %v", scene.SceneID, scene.Title)
 
+	//Create custom scene
 	models.SceneCreateUpdateFromExternal(db, scene)
 	tasks.SearchIndex()
+
+	//Return resulting scene
+	var resultingScene models.Scene
+	err := resultingScene.GetIfExist(customID)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	resp.WriteHeaderAndEntity(http.StatusOK, resultingScene)
 }
 
 func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) {

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -159,6 +159,8 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 	scene.HomepageURL = "http://localhost"
 	scene.Covers = append(scene.Covers, "http://localhost/dont_cause_errors")
 
+	log.Infof("Creating custom scene: %v %v", scene.SceneID, scene.Title)
+
 	models.SceneCreateUpdateFromExternal(db, scene)
 	tasks.SearchIndex()
 }

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-	"strings"
 
 	"github.com/go-test/deep"
 	"github.com/jinzhu/gorm"
@@ -131,32 +130,22 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 		return
 	}
 
-	var unusedCustomID string
-
-	var lastScene models.Scene
-	err := db.Where("site = ?", "CustomVR").Order("SceneID").Last(&lastScene)
-
-	if (err.Error == gorm.ErrRecordNotFound) {
-		unusedCustomID = "0"
+	var CustomID string
+	scene_id := req.QueryParameter("scene_id")
+	if (scene_id == "") {
+		log.Infof("SceneID missing from request!")
+		CustomID = "Custom-" + time.Now().Format("20060102150405")
 	} else {
-		lastID := strings.Replace(lastScene.SceneID, "Custom-", "", 1)
-		lastIDInt, err := strconv.Atoi(lastID)
-
-		if (err != nil) {
-			log.Error("Invalid custom scene id found: ", lastID)
-			return
-		}
-
-		unusedCustomID = strconv.Itoa(lastIDInt + 1)
+		CustomID = scene_id
 	}
 
 	var scene models.ScrapedScene
-	scene.SceneID = "Custom-" + unusedCustomID
+	scene.SceneID = CustomID
 	scene.SceneType = "VR"
 	scene.Title = title
 	scene.Studio = "Custom"
 	scene.Site = "CustomVR"
-	scene.HomepageURL = "http://localhost"
+	scene.HomepageURL = "http://localhost/" + scene.SceneID
 	scene.Covers = append(scene.Covers, "http://localhost/dont_cause_errors")
 
 	log.Infof("Creating custom scene: %v %v", scene.SceneID, scene.Title)

--- a/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
@@ -17,6 +17,17 @@
         {{$t('If you already have scraped scene data, you can export it below.')}}
       </p>
       <b-button type="is-primary" @click="exportContent">{{$t('Export content bundle')}}</b-button>
+      <hr/>
+    </div>
+    <div class="content">
+      <h3>{{$t("Add custom scene")}}</h3>
+      <p>
+        {{$t("You can add a custom scene with a specific title.")}}
+      </p>
+      <b-field grouped>
+        <b-input v-model="sceneTitle" :placeholder="$t('Scene title')" type="search" icon="plus"></b-input>
+        <div class="button is-button is-primary" v-on:click="addScene">{{$t('Add custom scene')}}</div>
+      </b-field>
     </div>
   </div>
 </template>
@@ -39,7 +50,12 @@ export default {
     },
     exportContent () {
       ky.get('/api/task/bundle/export')
-    }
+    },
+	addScene() {
+      if (this.sceneTitle !== '') {
+        ky.post('/api/scene/create', { searchParams: { title: this.sceneTitle }, json: {} })
+      }
+	}
   }
 }
 </script>

--- a/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
@@ -17,24 +17,12 @@
         {{$t('If you already have scraped scene data, you can export it below.')}}
       </p>
       <b-button type="is-primary" @click="exportContent">{{$t('Export content bundle')}}</b-button>
-      <hr/>
-    </div>
-    <div class="content">
-      <h3>{{$t("Add custom scene")}}</h3>
-      <p>
-        {{$t("You can add a custom scene with a specific title.")}}
-      </p>
-      <b-field grouped>
-        <b-input v-model="sceneTitle" :placeholder="$t('Scene title')" type="search" icon="plus"></b-input>
-        <div class="button is-button is-primary" v-on:click="addScene">{{$t('Add custom scene')}}</div>
-      </b-field>
     </div>
   </div>
 </template>
 
 <script>
 import ky from 'ky'
-
 export default {
   name: 'OptionsSceneDataImportExport',
   data () {
@@ -50,12 +38,7 @@ export default {
     },
     exportContent () {
       ky.get('/api/task/bundle/export')
-    },
-	addScene() {
-      if (this.sceneTitle !== '') {
-        ky.post('/api/scene/create', { searchParams: { title: this.sceneTitle }, json: {} })
-      }
-	}
+    }
   }
 }
 </script>

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -52,15 +52,27 @@
         </div>
       </div>
     </div>
-    <h3 class="title">{{$t('JAVR scraper')}}</h3>
     <div class="columns is-multiline">
       <div class="column is-multiline is-one-third">
+        <h3 class="title">{{$t('JAVR scraper')}}</h3>
         <div class="card">
           <div class="card-content content">
             <h5 class="title">R18</h5>
             <b-field grouped>
               <b-input v-model="javrQuery" placeholder="URL or ID (XXXX-001)" type="search"></b-input>
               <b-button class="button is-primary" v-on:click="scrapeJAVR()">{{$t('Go')}}</b-button>
+            </b-field>
+          </div>
+        </div>
+      </div>
+      <div class="column is-multiline is-one-third">
+        <h3 class="title">{{$t('Custom scene')}}</h3>
+        <div class="card">
+          <div class="card-content content">
+            <h5 class="title">Manual entry</h5>
+            <b-field grouped>
+              <b-input v-model="customSceneTitle" placeholder="Scene title" type="search"></b-input>
+              <b-button class="button is-primary" v-on:click="addScene()">{{$t('Add')}}</b-button>
             </b-field>
           </div>
         </div>
@@ -91,6 +103,11 @@ export default {
         return '/img/128x/' + u.replace('://', ':/')
       } else {
         return u
+      }
+    },
+    addScene() {
+      if (this.customSceneTitle !== '') {
+        ky.post('/api/scene/create', { searchParams: { title: this.customSceneTitle }, json: {} })
       }
     },
     taskScrape (site) {

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -69,9 +69,13 @@
         <h3 class="title">{{$t('Custom scene')}}</h3>
         <div class="card">
           <div class="card-content content">
-            <h5 class="title">Manual entry</h5>
-            <b-field grouped>
-              <b-input v-model="customSceneTitle" placeholder="Scene title" type="search"></b-input>
+            <b-field label="Scene title" label-position="on-border">
+              <b-input v-model="customSceneTitle" placeholder="Stepsis get stuck in washing machine" type="search"></b-input>
+            </b-field>
+            <b-field label="Scene ID" label-position="on-border">
+              <b-input v-model="customSceneID" placeholder="Can be empty" type="search"></b-input>
+            </b-field>
+            <b-field label-position="on-border">
               <b-button class="button is-primary" v-on:click="addScene()">{{$t('Add')}}</b-button>
             </b-field>
           </div>
@@ -107,7 +111,7 @@ export default {
     },
     addScene() {
       if (this.customSceneTitle !== '') {
-        ky.post('/api/scene/create', { searchParams: { title: this.customSceneTitle }, json: {} })
+        ky.post('/api/scene/create', { json: { title: this.customSceneTitle, id: this.customSceneID } })
       }
     },
     taskScrape (site) {

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -70,7 +70,7 @@
         <div class="card">
           <div class="card-content content">
             <b-field label="Scene title" label-position="on-border">
-              <b-input v-model="customSceneTitle" placeholder="Stepsis get stuck in washing machine" type="search"></b-input>
+              <b-input v-model="customSceneTitle" placeholder="Stepsis stuck in washing machine" type="search"></b-input>
             </b-field>
             <b-field label="Scene ID" label-position="on-border">
               <b-input v-model="customSceneID" placeholder="Can be empty" type="search"></b-input>

--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -183,7 +183,10 @@ export default {
         })
       })
       this.scene.images = JSON.stringify(images)
-      this.scene.cover_url = this.scene.covers[0]
+      this.scene.cover_url = ""
+      if (this.scene.length > 0) {
+          this.scene.cover_url = this.scene.covers[0]
+      }
       this.scene.filenames_arr = JSON.stringify(this.scene.files)
 
       ky.post(`/api/scene/edit/${this.scene.id}`, { json: { ...this.scene } })


### PR DESCRIPTION
This is an attempt to address issue #442 regarding adding custom scene entries.

The changes i made was to add a /create endpoint to the scenes api.
The way i did this was to create an imaginary vr site called "CustomVR".
From there it creates and id based on the current time and adds the scene to the db.
It then proceeds to call scene create and search index update.
It only takes a scene title, as i assume the user can edit the rest into the scene.

I also added a ui entry in the "Scrapers" options section for adding said custom scene. This could potentially be moved to scrapers, or elsewhere.

Some potential and actual problems:

- Duration is unchangeable in the EditPanel UI? Im unsure how important it is.
- Its currently placed in the scrapers section instead of a more convenient place like in the matching ui. This is mainly to discourage its usage, as i assume we'd rather have the scraper actually find the scenes instead of users creating new ones.
- Having a fixed "CustomVR" assumes nobody ever creates an actual "CustomVR" studio.
- Unrelated: The first added scene doesn't get added to the search index? I dont know what thats about, but it needs to be solved.
- Fixed: The Edit panel breaks if there are no cover urls, so in my infinite wisdom i added a fake one, but that also needs to be fixed.
- Fixed: Custom ID generation

Any complaints or improvements are appreciated, i've never written in GO before this.