### PR TITLE
Fixed scene presence selector going out of bounds

### DIFF
--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -7,7 +7,7 @@
         <strong>{{total}} results</strong>
       </div>
       <div class="column">
-        <b-field>
+        <div class="columns is-gapless">
           <b-radio-button v-model="dlState" native-value="any" size="is-small">
             {{$t("Any")}} ({{counts.any}})
           </b-radio-button>
@@ -20,7 +20,7 @@
           <b-radio-button v-model="dlState" native-value="missing" size="is-small">
             {{$t("Not downloaded")}} ({{counts.not_downloaded}})
           </b-radio-button>
-        </b-field>
+        </div>
       </div>
       <div class="column">
         <div class="is-pulled-right">


### PR DESCRIPTION
In the VueJS ui for listing scenes, if said device is too small (mobile), the scene presence selector will go out of bounds, this commit fixes said issue.
Now, if said device is too small, the selector goes vertical instead of horizontal.

Full size device:
![image](https://user-images.githubusercontent.com/75137537/153759630-5da3ccea-82b2-41a5-a793-0fee031c0ffc.png)
Mobile device:
![image](https://user-images.githubusercontent.com/75137537/153759651-9d78cc35-9d94-4ef5-8ce3-1d0af2997524.png)
