### PR TITLE
vrporn_scraper_redirect

### DIFF
--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -111,7 +111,7 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.OnHTML(`article.post div.tube-post a`, func(e *colly.HTMLElement) {
+	siteCollector.OnHTML(`article.tax-studio div.tube-post a`, func(e *colly.HTMLElement) {
 		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 		// If scene exists in database, there's no need to scrape
 		if !funk.ContainsString(knownScenes, sceneURL) {


### PR DESCRIPTION
Removal of EvilEyeVR from VRPORN uncovered front page videos being scraped due to a redirect.