### PR TITLE
CHANGED: Allow running in local folder

### DIFF
--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,7 +36,21 @@ func DirSize(path string) (int64, error) {
 }
 
 func InitPaths() {
-	AppDir = appdir.New("xbvr").UserConfig()
+
+	enableLocalStorage := flag.Bool("localstorage", false, "Use local folder to store application data")
+	flag.Parse()
+
+	if *enableLocalStorage {
+		executable, err := os.Executable()
+
+		if err != nil {
+			panic(err)
+		}
+
+		AppDir = filepath.Dir(executable)
+	} else {
+		AppDir = appdir.New("xbvr").UserConfig()
+	}
 
 	CacheDir = filepath.Join(AppDir, "cache")
 	BinDir = filepath.Join(AppDir, "bin")


### PR DESCRIPTION
Added commandline flag to run and store all application data relative to the running exe file.
Usage: xbvr.exe -localstorage
Without flag behaves as normal.

Idea behind this is that i like my applications mostly portable. This approach makes it easier to copy the whole folder keeping it all in one place. Backup and restore is easier. Cleanup for test cases is easier (Just delete the whole directory).
Disclaimer: Only tested with windows.