### PR TITLE
projection_fix

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -368,21 +368,23 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		return cuepoints[i].TS < cuepoints[j].TS
 	})
 
-	if videoFiles[0].VideoProjection == "mkx200" ||
-		videoFiles[0].VideoProjection == "mkx220" ||
-		videoFiles[0].VideoProjection == "vrca220" {
-		stereoMode = "sbs"
-		screenType = videoFiles[0].VideoProjection
-	}
+	if len(videoFiles) == 1 {
+		if videoFiles[0].VideoProjection == "mkx200" ||
+			videoFiles[0].VideoProjection == "mkx220" ||
+			videoFiles[0].VideoProjection == "vrca220" {
+			stereoMode = "sbs"
+			screenType = videoFiles[0].VideoProjection
+		}
 
-	if videoFiles[0].VideoProjection == "180_sbs" {
-		stereoMode = "sbs"
-		screenType = "dome"
-	}
+		if videoFiles[0].VideoProjection == "180_sbs" {
+			stereoMode = "sbs"
+			screenType = "dome"
+		}
 
-	if videoFiles[0].VideoProjection == "360_tb" {
-		stereoMode = "tb"
-		screenType = "sphere"
+		if videoFiles[0].VideoProjection == "360_tb" {
+			stereoMode = "tb"
+			screenType = "sphere"
+		}
 	}
 
 	title := scene.Title


### PR DESCRIPTION
Should resolve #708 

This will allow selection of projection mode for scenes that have multiple videos in case they are different. Due to how DeoVR selects the same video from multi-file scenes each time a scene is played, the projection could be wrong, but it can now be changed.