### PR TITLE
Add button to toggle watched status

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -264,6 +264,10 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 		scene.NeedsUpdate = !scene.NeedsUpdate
 	}
 
+	if r.List == "watched" {
+		scene.IsWatched = !scene.IsWatched
+	}
+
 	scene.Save()
 }
 

--- a/ui/src/components/WatchedButton.vue
+++ b/ui/src/components/WatchedButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <a :class="buttonClass"
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
+     :title="item.is_watched ? 'Mark as unwatched' : 'Mark as watched'">
+    <b-icon pack="mdi" :icon="item.is_watched ? 'eye-check' : 'eye'" size="is-small"/>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'WatchedButton',
+  props: { item: Object },
+  computed: {
+    buttonClass () {
+      if (this.item.is_watched) {
+        return 'button is-dark is-info is-small'
+      }
+      return 'button is-dark is-info is-outlined is-small'
+    }
+  }
+}
+</script>

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -89,6 +89,9 @@ const mutations = {
         if (payload.list === 'favourite') {
           obj.favourite = !obj.favourite
         }
+        if (payload.list == 'watched') {
+          obj.is_watched = !obj.is_watched
+        }
         if (payload.list === 'needs_update') {
           obj.needs_update = !obj.needs_update
         }

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -9,6 +9,7 @@
       @keydown.p="nextScene"
       @keydown.f="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
       @keydown.w="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
+      @keydown.W="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
       @keydown.e="$store.commit('overlay/editDetails', {scene: item.scene})"
       @keydown.g="toggleGallery"
     />
@@ -69,6 +70,7 @@
                     <div class="is-pulled-right">
                       <watchlist-button :item="item"/>&nbsp;
                       <favourite-button :item="item"/>&nbsp;
+                      <watched-button :item="item"/>&nbsp;
                       <edit-button :item="item"/>&nbsp;
                       <refresh-button :item="item"/>
                     </div>
@@ -210,12 +212,13 @@ import GlobalEvents from 'vue-global-events'
 import StarRating from 'vue-star-rating'
 import FavouriteButton from '../../components/FavouriteButton'
 import WatchlistButton from '../../components/WatchlistButton'
+import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import RefreshButton from '../../components/RefreshButton'
 
 export default {
   name: 'Details',
-  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, EditButton, RefreshButton },
+  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton },
   data () {
     return {
       index: 1,

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -9,9 +9,6 @@
         <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}`" autoplay loop></video>
         <div class="overlay align-bottom-left">
           <div style="padding: 5px">
-            <b-tag v-if="item.is_watched">
-              <b-icon pack="mdi" icon="eye" size="is-small"/>
-            </b-tag>
             <b-tag type="is-info" v-if="videoFilesCount > 1 && !item.is_multipart">
               <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
               {{videoFilesCount}}
@@ -33,6 +30,7 @@
 
       <watchlist-button :item="item"/>
       <favourite-button :item="item"/>
+      <watched-button :item="item"/>
       <edit-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneEdit" />
 
       <span class="is-pulled-right" style="font-size:11px;text-align:right;">
@@ -49,12 +47,13 @@
 import { format, parseISO } from 'date-fns'
 import WatchlistButton from '../../components/WatchlistButton'
 import FavouriteButton from '../../components/FavouriteButton'
+import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 
 export default {
   name: 'SceneCard',
   props: { item: Object },
-  components: { WatchlistButton, FavouriteButton, EditButton },
+  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton },
   data () {
     return {
       preview: false,


### PR DESCRIPTION
Adds a button to manually mark a scene as (un)watched in both the scene details view and also in the scene list. Also removes the little eye icon in the bottom right corner of watched scenes' cards, because it makes it redundant. This new look and behavior of the scene list could (but isn't at the moment) be hidden behind an option, just like the edit button.

Looks like this:
![image](https://user-images.githubusercontent.com/85208095/160056072-61f685da-4a5e-49a0-91c0-8fd4dd7c1ca1.png)
![image](https://user-images.githubusercontent.com/85208095/160056214-2e8a3c7d-a13c-456e-b41d-e2ca1470169d.png)