### PR TITLE
Append Site query parameter to url for CzechVRNetwork sites

### DIFF
--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -116,7 +116,7 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 	})
 
 	siteCollector.OnHTML(`div#StrankovaniDesktop span.stred a,div#StrankovaniDesktopHome span.stred a`, func(e *colly.HTMLElement) {
-		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
+		pageURL := e.Request.AbsoluteURL(e.Attr("href") + "&sites=" + nwID)
 		siteCollector.Visit(pageURL)
 	})
 


### PR DESCRIPTION
When scrapping the multiple czech vr sites from the www.czechvrnetwork.com, there can be issues getting scenes duplicated across the 4 sites and some scenes missing.  This first page of each sub site listing the first 16 videos available is fine, but pages 2 onwards are not.  This is because the URL for pages 2 onwards for all 4 different sites is the same. So when page 2 is requested for the 2nd, 3rd & 4th site, they get the data for the first site scrapped from the cache.  
The problem may not be noticed on most systems, as it would not occur on the first page of 16 videos, so it is more noticeable on scrapping the first time on a clean system.

I have appended the site query parameter to the URL, this ensure the data from the correct site (czechvr, czechcasting, etc) is returned and creates a unique URL so the XBVR caching works properly