### PR TITLE
Tag and Actor count performance improvements

### DIFF
--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -359,7 +359,12 @@ func CountTags() {
 	}
 
 	var results []CountResults
-	db.Model(&models.Tag{}).Select("id, count as existingcnt, count(*) cnt").Group("id, count").Joins("join scene_tags on scene_tags.tag_id = tags.id").Scan(&results)
+	db.Model(&models.Tag{}).
+		Select("tags.id, count as existingcnt, count(*) cnt").
+		Group("tags.id").
+		Joins("join scene_tags on scene_tags.tag_id = tags.id").
+		Joins("join scenes on scenes.id=scene_tags.scene_id and scenes.deleted_at is null").
+		Scan(&results)
 
 	for i := range results {
 		var tag models.Tag
@@ -370,7 +375,12 @@ func CountTags() {
 		}
 	}
 
-	db.Model(&models.Actor{}).Select("id, count as existingcnt, count(*) cnt").Group("id, count").Joins("join scene_cast on scene_cast.actor_id = actors.id").Scan(&results)
+	db.Model(&models.Actor{}).
+		Select("actors.id, count as existingcnt, count(*) cnt").
+		Group("actors.id").
+		Joins("join scene_cast on scene_cast.actor_id = actors.id").
+		Joins("join scenes on scenes.id=scene_cast.scene_id and scenes.deleted_at is null").
+		Scan(&results)
 
 	for i := range results {
 		var actor models.Actor


### PR DESCRIPTION
Changed logic to return counts from the database using a group by query, rather than return scenes and them counting the scenes in code.
Counting Tags and Actors was taking approximately 5 mins on my system (27K scenes), this was quite frustrating when testing an issue with a scrapping and doing a lot of scraps.  But 5 mins at the end of a scrap is probably not a problem for most with normal usage, making this a nice to have change (it ain't broke). However given a drop from 5 minutes to a couple of seconds, may still be worth considering.