### PR TITLE
Create separate searchable fields for id, title, cast, site & description

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "dev:ui": "cd ui && vue-cli-service build --watch --silent"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.15.3",
-    "@fortawesome/fontawesome-svg-core": "1.2.35",
+    "@fortawesome/fontawesome-free": "5.15.4",
+    "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@mdi/font": "5.9.55",
     "buefy": "0.9.4",
     "bulma-extensions": "6.2.7",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@mdi/font": "5.9.55",
-    "buefy": "0.9.4",
+    "buefy": "0.9.20",
     "bulma-extensions": "6.2.7",
     "date-fns": "2.16.1",
     "ky": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "less": "3.12.2",
     "less-loader": "6.2.0",
     "sass": "1.32.12",
-    "sass-loader": "9.0.2",
+    "sass-loader": "9.0.3",
     "simple-progress-webpack-plugin": "1.1.2",
     "vue-cli-plugin-i18n": "1.0.1",
     "vue-i18n-extract": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.3",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
-    "@mdi/font": "5.8.55",
+    "@mdi/font": "5.9.55",
     "buefy": "0.9.4",
     "bulma-extensions": "6.2.7",
     "date-fns": "2.16.1",

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -376,7 +376,7 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 	query := bleve.NewQueryStringQuery(q)
 
 	searchRequest := bleve.NewSearchRequest(query)
-	searchRequest.Fields = []string{"fulltext"}
+	searchRequest.Fields = []string{"Id", "title", "cast", "site", "description"}
 	searchRequest.IncludeLocations = true
 	searchRequest.From = 0
 	searchRequest.Size = 25

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -320,6 +320,10 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 		scene.NeedsUpdate = !scene.NeedsUpdate
 	}
 
+	if r.List == "watched" {
+		scene.IsWatched = !scene.IsWatched
+	}
+
 	scene.Save()
 }
 

--- a/pkg/api/tasks.go
+++ b/pkg/api/tasks.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
 	"github.com/xbapps/xbvr/pkg/tasks"
@@ -8,6 +10,11 @@ import (
 
 type RequestScrapeJAVR struct {
 	Query string `json:"q"`
+}
+
+type RequestScrapeTPDB struct {
+	ApiToken string `json:"apiToken"`
+	SceneUrl string `json:"sceneUrl"`
 }
 
 type TaskResource struct{}
@@ -49,6 +56,9 @@ func (i TaskResource) WebService() *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	ws.Route(ws.POST("/scrape-javr").To(i.scrapeJAVR).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
+	ws.Route(ws.POST("/scrape-tpdb").To(i.scrapeTPDB).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	return ws
@@ -105,5 +115,18 @@ func (i TaskResource) scrapeJAVR(req *restful.Request, resp *restful.Response) {
 
 	if r.Query != "" {
 		go tasks.ScrapeJAVR(r.Query)
+	}
+}
+
+func (i TaskResource) scrapeTPDB(req *restful.Request, resp *restful.Response) {
+	var r RequestScrapeTPDB
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if r.ApiToken != "" && r.SceneUrl != "" {
+		go tasks.ScrapeTPDB(strings.TrimSpace(r.ApiToken), strings.TrimSpace(r.SceneUrl))
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,11 @@ type ObjectConfig struct {
 		SceneEdit   bool   `default:"false" json:"sceneEdit"`
 		UpdateCheck bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
+	Vendor struct {
+		TPDB struct {
+			ApiToken string `default:"" json:"apiToken"`
+		} `json:"tpdb"`
+	} `json:"vendor"`
 	Interfaces struct {
 		DLNA struct {
 			Enabled      bool     `default:"true" json:"enabled"`

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -697,6 +697,20 @@ func Migrate() {
 				return db.Where("site = ?", "VRP Films").Delete(&models.Scene{}).Error
 			},
 		},
+		{
+			// rebuild search indexes with new fields
+			ID: "032-rebuild-new-indexes",			
+			Migrate: func(d *gorm.DB) error {				
+				os.RemoveAll(common.IndexDirV2)
+				os.MkdirAll(common.IndexDirV2, os.ModePerm)
+				// rebuild asynchronously, no need to hold up startup, blocking the UI
+				go func() {
+					tasks.SearchIndex()
+					tasks.CalculateCacheSizes()
+				}()			
+				return nil
+			},
+		}, 
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -699,18 +699,18 @@ func Migrate() {
 		},
 		{
 			// rebuild search indexes with new fields
-			ID: "032-rebuild-new-indexes",			
-			Migrate: func(d *gorm.DB) error {				
+			ID: "032-rebuild-new-indexes",
+			Migrate: func(d *gorm.DB) error {
 				os.RemoveAll(common.IndexDirV2)
 				os.MkdirAll(common.IndexDirV2, os.ModePerm)
 				// rebuild asynchronously, no need to hold up startup, blocking the UI
 				go func() {
 					tasks.SearchIndex()
 					tasks.CalculateCacheSizes()
-				}()			
+				}()
 				return nil
 			},
-		}, 
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -93,7 +93,7 @@ type Scene struct {
 
 	NeedsUpdate bool `json:"needs_update"`
 
-	Fulltext string  `gorm:"-" json:"fulltext"`
+	Description string  `gorm:"-" json:"description"`
 	Score    float64 `gorm:"-" json:"_score"`
 }
 

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -94,7 +94,7 @@ type Scene struct {
 	NeedsUpdate bool `json:"needs_update"`
 
 	Description string  `gorm:"-" json:"description"`
-	Score    float64 `gorm:"-" json:"_score"`
+	Score       float64 `gorm:"-" json:"_score"`
 }
 
 type Image struct {

--- a/pkg/scrape/tpdb.go
+++ b/pkg/scrape/tpdb.go
@@ -1,0 +1,83 @@
+package scrape
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/tidwall/gjson"
+	"github.com/xbapps/xbvr/pkg/models"
+	"gopkg.in/resty.v1"
+)
+
+func ScrapeTPDB(knownScenes []string, out *[]models.ScrapedScene, apiToken string, sceneUrl string) error {
+	sc := models.ScrapedScene{}
+	sc.SceneType = "VR"
+
+	// We accept 2 scene URL syntaxes:
+	// https://metadataapi.net/scenes/scene-title-1
+	// or
+	// https://api.metadataapi.net/scenes/scene-title-1
+	re := regexp.MustCompile("metadataapi.net/scenes/(.+)")
+	subMatches := re.FindStringSubmatch(sceneUrl)
+	if subMatches == nil || len(subMatches) != 2 {
+		return errors.New("TPDB Url is malformed")
+	}
+
+	r, _ := resty.R().
+		SetAuthToken(apiToken).
+		Get(fmt.Sprintf("https://api.metadataapi.net/scenes/%v", subMatches[1]))
+
+	tpdbMetadata := r.String()
+
+	if r.StatusCode() >= 400 {
+		errorMessage := errors.New(gjson.Get(tpdbMetadata, "message").String())
+		return fmt.Errorf("TPDB Error: %v", errorMessage)
+	}
+
+	// Title
+	sc.Title = gjson.Get(tpdbMetadata, "data.title").String()
+
+	// Studio
+	sc.Studio = gjson.Get(tpdbMetadata, "data.site.name").String()
+	sc.Site = sc.Studio
+
+	// Synopsis
+	sc.Synopsis = gjson.Get(tpdbMetadata, "data.description").String()
+
+	// Home Page URL
+	sc.HomepageURL = gjson.Get(tpdbMetadata, "data.url").String()
+
+	// Date
+	sc.Released = gjson.Get(tpdbMetadata, "data.date").String()
+
+	// Covers
+	coverImage := gjson.Get(tpdbMetadata, "data.image").String()
+	sc.Covers = append(sc.Covers, coverImage)
+
+	// Cast
+	performerNames := gjson.Get(tpdbMetadata, "data.performers.#.name")
+	for _, name := range performerNames.Array() {
+		sc.Cast = append(sc.Cast, name.String())
+	}
+
+	// Tags
+	// Skipping some very generic and useless tags
+	skipTags := map[string]bool{
+		"Assorted Additional Tags": true,
+	}
+	tags := gjson.Get(tpdbMetadata, "data.tags.#.tag")
+	for _, tag := range tags.Array() {
+		if !skipTags[tag.String()] {
+			sc.Tags = append(sc.Tags, tag.String())
+		}
+	}
+
+	sc.SiteID = gjson.Get(tpdbMetadata, "data._id").String()
+	siteShortName := gjson.Get(tpdbMetadata, "data.site.short_name")
+	sc.SceneID = fmt.Sprintf("tpdb-%v-%v", siteShortName, sc.SiteID)
+
+	*out = append(*out, sc)
+
+	return nil
+}

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/xbapps/xbvr/pkg/common"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/scrape"
 	"gopkg.in/resty.v1"
@@ -230,6 +231,61 @@ func ScrapeJAVR(queryString string) {
 		scrape.ScrapeR18(knownScenes, &collectedScenes, queryString)
 
 		if len(collectedScenes) > 0 {
+			db, _ := models.GetDB()
+			for i := range collectedScenes {
+				models.SceneCreateUpdateFromExternal(db, collectedScenes[i])
+			}
+			db.Close()
+
+			tlog.Infof("Updating tag counts")
+			CountTags()
+			SearchIndex()
+
+			tlog.Infof("Scraped %v new scenes in %s",
+				len(collectedScenes),
+				time.Now().Sub(t0).Round(time.Second))
+		} else {
+			tlog.Infof("No new scenes scraped")
+		}
+
+	}
+	models.RemoveLock("scrape")
+}
+
+func ScrapeTPDB(apiToken string, sceneUrl string) {
+	if !models.CheckLock("scrape") {
+		models.CreateLock("scrape")
+		t0 := time.Now()
+		tlog := log.WithField("task", "scrape")
+		tlog.Infof("Scraping started at %s", t0.Format("Mon Jan _2 15:04:05 2006"))
+
+		// Get all known scenes
+		var scenes []models.Scene
+		db, _ := models.GetDB()
+		db.Find(&scenes)
+		db.Close()
+
+		var knownScenes []string
+		for i := range scenes {
+			knownScenes = append(knownScenes, scenes[i].SceneURL)
+		}
+
+		// Start scraping
+		var collectedScenes []models.ScrapedScene
+
+		tlog.Infof("Scraping TPDB")
+		err := scrape.ScrapeTPDB(knownScenes, &collectedScenes, apiToken, sceneUrl)
+
+		if err != nil {
+			tlog.Errorf(err.Error())
+		} else if len(collectedScenes) > 0 {
+			// At this point we know the API Token is correct, so we will save
+			// it to the config store
+			if config.Config.Vendor.TPDB.ApiToken != apiToken {
+				config.Config.Vendor.TPDB.ApiToken = apiToken
+				config.SaveConfig()
+			}
+
 			db, _ := models.GetDB()
 			for i := range collectedScenes {
 				models.SceneCreateUpdateFromExternal(db, collectedScenes[i])

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -408,27 +408,43 @@ func CountTags() {
 	var tags []models.Tag
 	db.Model(&models.Tag{}).Find(&tags)
 
-	for i := range tags {
-		var scenes []models.Scene
-		db.Model(tags[i]).Related(&scenes, "Scenes")
+	type CountResults struct {
+		ID          int
+		Cnt         int
+		Existingcnt int
+	}
 
-		if tags[i].Count != len(scenes) {
-			tags[i].Count = len(scenes)
-			tags[i].Save()
+	var results []CountResults
+	db.Model(&models.Tag{}).
+		Select("tags.id, count as existingcnt, count(*) cnt").
+		Group("tags.id").
+		Joins("join scene_tags on scene_tags.tag_id = tags.id").
+		Joins("join scenes on scenes.id=scene_tags.scene_id and scenes.deleted_at is null").
+		Scan(&results)
+
+	for i := range results {
+		var tag models.Tag
+		if results[i].Cnt != results[i].Existingcnt {
+			db.First(&tag, results[i].ID)
+			tag.Count = results[i].Cnt
+			tag.Save()
 		}
 	}
 
-	var cast []models.Actor
-	db.Model(&models.Actor{}).Find(&cast)
-	for i := range cast {
-		var scenes []models.Scene
-		db.Model(cast[i]).Related(&scenes, "Scenes")
+	db.Model(&models.Actor{}).
+		Select("actors.id, count as existingcnt, count(*) cnt").
+		Group("actors.id").
+		Joins("join scene_cast on scene_cast.actor_id = actors.id").
+		Joins("join scenes on scenes.id=scene_cast.scene_id and scenes.deleted_at is null").
+		Scan(&results)
 
-		if cast[i].Count != len(scenes) {
-			cast[i].Count = len(scenes)
-			cast[i].Save()
+	for i := range results {
+		var actor models.Actor
+		if results[i].Cnt != results[i].Existingcnt {
+			db.First(&actor, results[i].ID)
+			actor.Count = results[i].Cnt
+			actor.Save()
 		}
 	}
-
 	// db.Where("count = ?", 0).Delete(&Tag{})
 }

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -17,7 +17,11 @@ type Index struct {
 }
 
 type SceneIndexed struct {
-	Fulltext string `json:"fulltext"`
+	Description string `json:"description"`
+	Title    string `json:"title"`
+	Cast     string `json:"cast"`
+	Site     string `json:"site"`
+	Id       string `json:"id"`
 }
 
 func NewIndex(name string) (*Index, error) {
@@ -55,7 +59,11 @@ func (i *Index) PutScene(scene models.Scene) error {
 	}
 
 	si := SceneIndexed{
-		Fulltext: fmt.Sprintf("%v %v %v %v %v %v", scene.SceneID, scene.Title, scene.Site, scene.Synopsis, cast, castConcat),
+		Title:    fmt.Sprintf("%v", scene.Title),
+		Description: fmt.Sprintf("%v", scene.Synopsis),
+		Cast:     fmt.Sprintf("%v %v", cast, castConcat),
+		Site:     fmt.Sprintf("%v", scene.Site),
+		Id:       fmt.Sprintf("%v", scene.SceneID),
 	}
 	if err := i.Bleve.Index(scene.SceneID, si); err != nil {
 		return err

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -18,10 +18,10 @@ type Index struct {
 
 type SceneIndexed struct {
 	Description string `json:"description"`
-	Title    string `json:"title"`
-	Cast     string `json:"cast"`
-	Site     string `json:"site"`
-	Id       string `json:"id"`
+	Title       string `json:"title"`
+	Cast        string `json:"cast"`
+	Site        string `json:"site"`
+	Id          string `json:"id"`
 }
 
 func NewIndex(name string) (*Index, error) {
@@ -59,11 +59,11 @@ func (i *Index) PutScene(scene models.Scene) error {
 	}
 
 	si := SceneIndexed{
-		Title:    fmt.Sprintf("%v", scene.Title),
+		Title:       fmt.Sprintf("%v", scene.Title),
 		Description: fmt.Sprintf("%v", scene.Synopsis),
-		Cast:     fmt.Sprintf("%v %v", cast, castConcat),
-		Site:     fmt.Sprintf("%v", scene.Site),
-		Id:       fmt.Sprintf("%v", scene.SceneID),
+		Cast:        fmt.Sprintf("%v %v", cast, castConcat),
+		Site:        fmt.Sprintf("%v", scene.Site),
+		Id:          fmt.Sprintf("%v", scene.SceneID),
 	}
 	if err := i.Bleve.Index(scene.SceneID, si); err != nil {
 		return err

--- a/ui/src/components/WatchedButton.vue
+++ b/ui/src/components/WatchedButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <a :class="buttonClass"
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
+     :title="item.is_watched ? 'Mark as unwatched' : 'Mark as watched'">
+    <b-icon pack="mdi" :icon="item.is_watched ? 'eye-check' : 'eye'" size="is-small"/>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'WatchedButton',
+  props: { item: Object },
+  computed: {
+    buttonClass () {
+      if (this.item.is_watched) {
+        return 'button is-dark is-info is-small'
+      }
+      return 'button is-dark is-info is-outlined is-small'
+    }
+  }
+}
+</script>

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -13,6 +13,7 @@ import optionsDeoVR from './optionsDeoVR'
 import optionsSites from './optionsSites'
 import optionsPreviews from './optionsPreviews'
 import optionsFunscripts from './optionsFunscripts'
+import optionsVendor from './optionsVendor'
 
 Vue.use(Vuex)
 
@@ -29,6 +30,7 @@ export default new Vuex.Store({
     optionsWeb,
     optionsSites,
     optionsPreviews,
-    optionsFunscripts
+    optionsFunscripts,
+    optionsVendor
   }
 })

--- a/ui/src/store/optionsVendor.js
+++ b/ui/src/store/optionsVendor.js
@@ -1,0 +1,26 @@
+import ky from 'ky'
+
+const state = {
+  tpdb: {
+    apiToken: ''
+  }
+}
+
+const mutations = {}
+
+const actions = {
+  async load({ state }, params) {
+    ky.get('/api/options/state')
+      .json()
+      .then(data => {
+        state.tpdb.apiToken = data.config.vendor.tpdb.apiToken
+      })
+  },
+}
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions
+}

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -89,6 +89,9 @@ const mutations = {
         if (payload.list === 'favourite') {
           obj.favourite = !obj.favourite
         }
+        if (payload.list == 'watched') {
+          obj.is_watched = !obj.is_watched
+        }
         if (payload.list === 'needs_update') {
           obj.needs_update = !obj.needs_update
         }

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -52,6 +52,7 @@
         </div>
       </div>
     </div>
+
     <div class="columns is-multiline">
       <div class="column is-multiline is-one-third">
         <h3 class="title">{{$t('JAVR scraper')}}</h3>
@@ -65,6 +66,23 @@
           </div>
         </div>
       </div>
+
+      <div class="column is-multiline is-one-third">
+        <h3 class="title">{{$t('TPDB scraper')}}</h3>
+        <div class="card">
+          <div class="card-content content">
+            <h5 class="title">API Token</h5>
+            <b-input v-model="tpdbApiToken" placeholder="TPDB API Token" type="search"></b-input>
+            <br>
+            <h5 class="title">TPDB Scene URL</h5>
+            <b-field grouped>
+              <b-input v-model="tpdbSceneUrl" placeholder="TPDB URL" type="search"></b-input>
+              <b-button class="button is-primary" v-on:click="scrapeTPDB()">{{$t('Go')}}</b-button>
+            </b-field>
+          </div>
+        </div>
+      </div>
+
       <div class="column is-multiline is-one-third">
         <h3 class="title">{{$t('Custom scene')}}</h3>
         <div class="card">
@@ -95,11 +113,13 @@ export default {
   components: { VueLoadImage },
   data () {
     return {
-      javrQuery: ''
+      javrQuery: '',
+      tpdbSceneUrl: ''
     }
   },
   mounted () {
     this.$store.dispatch('optionsSites/load')
+    this.$store.dispatch('optionsVendor/load')
   },
   methods: {
     getImageURL (u) {
@@ -144,6 +164,11 @@ export default {
     scrapeJAVR () {
       ky.post('/api/task/scrape-javr', { json: { q: this.javrQuery } })
     },
+    scrapeTPDB () {
+      ky.post('/api/task/scrape-tpdb', {
+        json: { apiToken: this.tpdbApiToken, sceneUrl: this.tpdbSceneUrl }
+      })
+    },
     parseISO,
     formatDistanceToNow
   },
@@ -154,6 +179,14 @@ export default {
     runningScrapers () {
       this.$store.dispatch('optionsSites/load')
       return this.$store.state.messages.runningScrapers
+    },
+    tpdbApiToken: {
+      get () {
+        return this.$store.state.optionsVendor.tpdb.apiToken
+      },
+      set (value) {
+        this.$store.state.optionsVendor.tpdb.apiToken = value
+      }
     }
   }
 }

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -9,6 +9,7 @@
       @keydown.p="nextScene"
       @keydown.f="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
       @keydown.w="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
+      @keydown.W="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
       @keydown.e="$store.commit('overlay/editDetails', {scene: item.scene})"
       @keydown.g="toggleGallery"
     />
@@ -69,6 +70,7 @@
                     <div class="is-pulled-right">
                       <watchlist-button :item="item"/>&nbsp;
                       <favourite-button :item="item"/>&nbsp;
+                      <watched-button :item="item"/>&nbsp;
                       <edit-button :item="item"/>&nbsp;
                       <refresh-button :item="item"/>
                     </div>
@@ -211,12 +213,13 @@ import GlobalEvents from 'vue-global-events'
 import StarRating from 'vue-star-rating'
 import FavouriteButton from '../../components/FavouriteButton'
 import WatchlistButton from '../../components/WatchlistButton'
+import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import RefreshButton from '../../components/RefreshButton'
 
 export default {
   name: 'Details',
-  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, EditButton, RefreshButton },
+  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton },
   data () {
     return {
       index: 1,

--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -95,6 +95,7 @@
       <footer class="modal-card-foot">
         <b-field>
           <b-button type="is-primary" @click="save">{{ $t('Save Scene Details') }}</b-button>
+          <b-button type="is-danger" outlined @click="deletescene">{{ $t('Delete Scene') }}</b-button>
         </b-field>
       </footer>
     </div>
@@ -213,6 +214,22 @@ export default {
       this.changesMade = false
 
       this.close()
+    },
+    deletescene () {
+      this.$buefy.dialog.confirm({
+        title: 'Delete scene',
+        message: `Do you really want to delete the scene <strong>${this.scene.title}</strong> from <strong>${this.scene.studio}</strong>? If this is an existing scene, it will be re-added during the next scrape.`,
+        type: 'is-info is-wide',
+        hasIcon: true,
+        id: 'heh',
+        onConfirm: () => {
+          ky.post(`/api/scene/delete`, {json:{scene_id: this.scene.id}}).json().then(data => {
+            this.$store.dispatch('sceneList/load', { offset: 0 })
+            this.$store.commit('overlay/hideEditDetails')
+            this.$store.commit('overlay/hideDetails')
+          })
+        }
+      })
     },
     blur (field) {
       if (this.changesMade) return // Changes have already been made. No point to check any further

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -9,9 +9,6 @@
         <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}`" autoplay loop></video>
         <div class="overlay align-bottom-left">
           <div style="padding: 5px">
-            <b-tag v-if="item.is_watched">
-              <b-icon pack="mdi" icon="eye" size="is-small"/>
-            </b-tag>
             <b-tag type="is-info" v-if="videoFilesCount > 1 && !item.is_multipart">
               <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
               {{videoFilesCount}}
@@ -34,6 +31,7 @@
 
       <watchlist-button :item="item"/>
       <favourite-button :item="item"/>
+      <watched-button :item="item"/>
       <edit-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneEdit" />
 
       <span class="is-pulled-right" style="font-size:11px;text-align:right;">
@@ -50,12 +48,13 @@
 import { format, parseISO } from 'date-fns'
 import WatchlistButton from '../../components/WatchlistButton'
 import FavouriteButton from '../../components/FavouriteButton'
+import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 
 export default {
   name: 'SceneCard',
   props: { item: Object },
-  components: { WatchlistButton, FavouriteButton, EditButton },
+  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton },
   data () {
     return {
       preview: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,10 +976,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@mdi/font@5.8.55":
-  version "5.8.55"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.8.55.tgz#1464155bcbc8a6e4af6dffd611fe8e38e09af285"
-  integrity sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA==
+"@mdi/font@5.9.55":
+  version "5.9.55"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
+  integrity sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,22 +918,22 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.35":
-  version "0.2.35"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
-  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
 
-"@fortawesome/fontawesome-free@5.15.3":
-  version "5.15.3"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz#c36ffa64a2a239bf948541a97b6ae8d729e09a9a"
-  integrity sha512-rFnSUN/QOtnOAgqFRooTA3H57JLDm0QEG/jPdk+tLQNL/eWd+Aok8g3qCI+Q1xuDPWpGW/i9JySpJVsq8Q0s9w==
+"@fortawesome/fontawesome-free@5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
+  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
 
-"@fortawesome/fontawesome-svg-core@1.2.35":
-  version "1.2.35"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz#85aea8c25645fcec88d35f2eb1045c38d3e65cff"
-  integrity sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==
+"@fortawesome/fontawesome-svg-core@1.2.36":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.35"
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
 
 "@hapi/address@2.x.x":
   version "2.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5679,7 +5679,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-klona@^1.1.1:
+klona@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/klona/-/klona-1.1.2.tgz#a79e292518a5a5412ec8d097964bff1571a64db0"
   integrity sha512-xf88rTeHiXk+XE2Vhi6yj8Wm3gMZrygGdKjJqN8HkV+PwF/t50/LdAKHoHpPcxFAlmQszTZ1CugrK25S7qDRLA==
@@ -6338,7 +6338,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -7933,14 +7933,14 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-9.0.2.tgz#847c9b4c95328ddc8c7d35cf28c9d6e54e59a90b"
-  integrity sha512-nphcum3jNI442njnrZ5wJgSNX5lfEOHOKHCLf+PrTIaleploKqAMUuT9CVKjf+lyi6c2MCGPHh1vb9nGsjnZJA==
+sass-loader@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-9.0.3.tgz#086adcf0bfdcc9d920413e2cdc3ba3321373d547"
+  integrity sha512-fOwsP98ac1VMme+V3+o0HaaMHp8Q/C9P+MUazLFVi3Jl7ORGHQXL1XeRZt3zLSGZQQPC8xE42Y2WptItvGjDQg==
   dependencies:
-    klona "^1.1.1"
+    klona "^1.1.2"
     loader-utils "^2.0.0"
-    neo-async "^2.6.1"
+    neo-async "^2.6.2"
     schema-utils "^2.7.0"
     semver "^7.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,9 +1948,9 @@ async-limiter@~1.0.0:
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9029,9 +9029,9 @@ url-loader@^2.2.0:
     schema-utils "^2.5.0"
 
 url-parse@^1.4.3, url-parse@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
-  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,6 +6931,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
+  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
@@ -7344,13 +7349,12 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
-  version "7.0.35"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
-  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+  version "7.0.39"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
+  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
   dependencies:
-    chalk "^2.4.2"
+    picocolors "^0.2.1"
     source-map "^0.6.1"
-    supports-color "^6.1.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6152,9 +6152,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2282,12 +2282,12 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
-buefy@0.9.4:
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.4.tgz#01e2e2cf1e61b914239a5f2570e5ea8ed6786927"
-  integrity sha512-LRSIYVNrKTPQhmNRegASkntX+ObtZ7aSSA/3cybDKXzGtPNy8g8cl2tp79Rl8/LBVH/KkRT5rmmzJ21nxz9IcQ==
+buefy@0.9.20:
+  version "0.9.20"
+  resolved "https://registry.yarnpkg.com/buefy/-/buefy-0.9.20.tgz#db3fb39aee09adc61e4ee7035e3f49be852ef09e"
+  integrity sha512-lEJTLZEuN7dI6XUGq6N5oL691ncHV8Zu9WtyBsQTOlcBjCJkSUXKicorPukS0wQi0z3w+pOl/e/FTCVswJj3Ng==
   dependencies:
-    bulma "0.9.1"
+    bulma "0.9.3"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -2343,10 +2343,10 @@ bulma-extensions@6.2.7:
   resolved "https://registry.yarnpkg.com/bulma-extensions/-/bulma-extensions-6.2.7.tgz#f9f4d1478a7ac1606ae8db1e765aa45e3f12bb31"
   integrity sha512-y3dHsxlCYkuxUg87KKN9H4InM8NCk8tdnrlxLkYak8sd2WQdllg3wP2Nv41lj8X46uPXX2ADP0MO65LlXPHt/Q==
 
-bulma@0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.1.tgz#2bf0e25062a22166db5c92e8c3dcb4605ab040d8"
-  integrity sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA==
+bulma@0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.3.tgz#ddccb7436ebe3e21bf47afe01d3c43a296b70243"
+  integrity sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The current search process concatenates the scene-id, title, synopsis, cast and site into one field that is indexed so any of that information can be used for the basis of searches.
The change creates separate index fields for id, title, cast, site & description for indexing rather than a single one.  All separate fields are still searched by default, so you still get the same search results if you search for the same string as  you do now.
However, by splitting the fields into separate indexable fields, allows the opportunity specify which field you expect the search in in your query string and it will boost the score value for scenes where it matches that field. 
eg, with my data, searching for “Mommy Time”, it comes in at the 12th entry way down the quick find list and on page 3 when using the file match search.  Using the search in file matching, I can see the score for the scene is 66.91 both before and after my change.  However, by changing my search to “Title: Mommy Time” the scene I wanted jumps to the top with a score 591.33.  Note: it does not appear to stop searching of other fields, it just boasts the score if it matches the score if the field specified matches.
I still usually just search like now without specifying specific fields to boost, as the current search usually gets me what I want in the first couple of result over 90% of the time.  However, if I don’t get want I want, it has proved very valuable.
You can also specify multiple fields, eg “Title: Mommy Time Site:virtualtaboo Cast: Vittoria Dolce”
Impact on index space is fairly small, for 27k scenes I went from 89mb to 92mb
