### PR TITLE
Fix Index Error Panic in GeneratePreview

### DIFF
--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -29,7 +29,7 @@ func GeneratePreviews() {
 			files, _ := scene.GetFiles()
 			if len(files) > 0 {
 				i := 0
-				for files[i].Exists() {
+				for i < len(files) && files[i].Exists() {
 					if files[i].Type == "video" {
 						log.Infof("Rendering %v", scene.SceneID)
 						destFile := filepath.Join(common.VideoPreviewDir, scene.SceneID+".mp4")


### PR DESCRIPTION
The GeneratePreviews function now loops through files for a scene to handle (ignore) funscripts (PR 716 merged but not yet released). When ffmpeg successfully generates a preview it breaks out of the for loop and everything is fine, which is almost always. However, if ffmpeg fails, GeneratePreviews loops around to try another file, if there are no more files, the "index out of range" panic is thrown and XBVR crashes.  The for loop needed a index size check added.