### PR TITLE
Make watched toggle button black

### DIFF
--- a/ui/src/components/WatchedButton.vue
+++ b/ui/src/components/WatchedButton.vue
@@ -13,9 +13,9 @@ export default {
   computed: {
     buttonClass () {
       if (this.item.is_watched) {
-        return 'button is-dark is-info is-small'
+        return 'button is-dark is-small'
       }
-      return 'button is-dark is-info is-outlined is-small'
+      return 'button is-dark is-outlined is-small'
     }
   }
 }


### PR DESCRIPTION
In #721, my intent was to make that button black (as seen in the screenshots that I included), but somehow I made a mistake and an extra class made its way in there, making the button blue. I finally noticed today when I updated my fork. This is obviously very minor, but I figured I'd submit a PR anyway since there hasn't been a release since #721 was merged. (Also I use #539 and that button's blue as well and it's bugging me. :laughing:)