### PR TITLE
Fixed List.vue out of bounds

### DIFF
--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column">
+  <div class="column is-four-fifths">
     <b-loading :is-full-page="true" :active.sync="isLoading"></b-loading>
 
     <div class="columns is-multiline is-full">


### PR DESCRIPTION
Somehow, the list implicitly knew the size before bulma.css updated, but doesn't anymore.
This patch simply adds is-four-fifths to the list.