### PR TITLE
Fix cover breaking when editing scene

### DIFF
--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -184,10 +184,7 @@ export default {
         })
       })
       this.scene.images = JSON.stringify(images)
-      this.scene.cover_url = ""
-      if (this.scene.length > 0) {
-          this.scene.cover_url = this.scene.covers[0]
-      }
+      this.scene.cover_url = this.scene.covers[0]
       this.scene.filenames_arr = JSON.stringify(this.scene.files)
 
       ky.post(`/api/scene/edit/${this.scene.id}`, { json: { ...this.scene } })


### PR DESCRIPTION
Just reverting a small change introduced in the last release that causes the cover to be removed from the scene card whenever a scene is edited.