### PR TITLE
Create separate searchable fields for id, title, cast, site & description

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -376,7 +376,7 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 	query := bleve.NewQueryStringQuery(q)
 
 	searchRequest := bleve.NewSearchRequest(query)
-	searchRequest.Fields = []string{"fulltext"}
+	searchRequest.Fields = []string{"Id", "title", "cast", "site", "description"}
 	searchRequest.IncludeLocations = true
 	searchRequest.From = 0
 	searchRequest.Size = 25

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -784,6 +784,20 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// rebuild search indexes with new fields
+			ID: "034-rebuild-new-indexes",
+			Migrate: func(d *gorm.DB) error {
+				os.RemoveAll(common.IndexDirV2)
+				os.MkdirAll(common.IndexDirV2, os.ModePerm)
+				// rebuild asynchronously, no need to hold up startup, blocking the UI
+				go func() {
+					tasks.SearchIndex()
+					tasks.CalculateCacheSizes()
+				}()
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -93,7 +93,7 @@ type Scene struct {
 
 	NeedsUpdate bool `json:"needs_update"`
 
-	Fulltext string  `gorm:"-" json:"fulltext"`
+	Description string  `gorm:"-" json:"description"`
 	Score    float64 `gorm:"-" json:"_score"`
 }
 

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -94,7 +94,7 @@ type Scene struct {
 	NeedsUpdate bool `json:"needs_update"`
 
 	Description string  `gorm:"-" json:"description"`
-	Score    float64 `gorm:"-" json:"_score"`
+	Score       float64 `gorm:"-" json:"_score"`
 }
 
 type Image struct {

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -17,7 +17,11 @@ type Index struct {
 }
 
 type SceneIndexed struct {
-	Fulltext string `json:"fulltext"`
+	Description string `json:"description"`
+	Title    string `json:"title"`
+	Cast     string `json:"cast"`
+	Site     string `json:"site"`
+	Id       string `json:"id"`
 }
 
 func NewIndex(name string) (*Index, error) {
@@ -55,7 +59,11 @@ func (i *Index) PutScene(scene models.Scene) error {
 	}
 
 	si := SceneIndexed{
-		Fulltext: fmt.Sprintf("%v %v %v %v %v %v", scene.SceneID, scene.Title, scene.Site, scene.Synopsis, cast, castConcat),
+		Title:    fmt.Sprintf("%v", scene.Title),
+		Description: fmt.Sprintf("%v", scene.Synopsis),
+		Cast:     fmt.Sprintf("%v %v", cast, castConcat),
+		Site:     fmt.Sprintf("%v", scene.Site),
+		Id:       fmt.Sprintf("%v", scene.SceneID),
 	}
 	if err := i.Bleve.Index(scene.SceneID, si); err != nil {
 		return err

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -19,10 +19,10 @@ type Index struct {
 
 type SceneIndexed struct {
 	Description string `json:"description"`
-	Title    string `json:"title"`
-	Cast     string `json:"cast"`
-	Site     string `json:"site"`
-	Id       string `json:"id"`
+	Title       string `json:"title"`
+	Cast        string `json:"cast"`
+	Site        string `json:"site"`
+	Id          string `json:"id"`
 }
 
 func NewIndex(name string) (*Index, error) {
@@ -72,11 +72,11 @@ func (i *Index) PutScene(scene models.Scene) error {
 	}
 
 	si := SceneIndexed{
-		Title:    fmt.Sprintf("%v", scene.Title),
+		Title:       fmt.Sprintf("%v", scene.Title),
 		Description: fmt.Sprintf("%v", scene.Synopsis),
-		Cast:     fmt.Sprintf("%v %v", cast, castConcat),
-		Site:     fmt.Sprintf("%v", scene.Site),
-		Id:       fmt.Sprintf("%v", scene.SceneID),
+		Cast:        fmt.Sprintf("%v %v", cast, castConcat),
+		Site:        fmt.Sprintf("%v", scene.Site),
+		Id:          fmt.Sprintf("%v", scene.SceneID),
 	}
 	if err := i.Bleve.Index(scene.SceneID, si); err != nil {
 		return err


### PR DESCRIPTION
The current search process concatenates the scene-id, title, synopsis, cast and site into one field that is indexed so all of that information can be used for the basis of searches.

This change creates separate index fields for id, title, cast, site & description for indexing rather than a single one. By default, Bleve still builds an internal field _all, which contains all the separate fields concatenated and this is the default search, so effectively the default search returns the same results as previously. 
However, by indexing the fields separately as well, this allows the option to specify which specific field you wish to search for the word in by using the field prefix eg **title:** or **cast:**
eg, with my data, searching for “Mommy Time”, it comes in at the 12th entry way down the quick find list and on page 3 when using the file match search. Using the search in file matching, I can see the score for the scene is 66.91 both before and after my change. However, by changing my search to “title: Mommy Time” the scene I wanted jumps to the top with a score 591.33.
I still usually just search like now without specifying specific fields to boost, as the current search usually gets me what I want in the first couple of results over 90% of the time. However, if I don’t get want I want, it has proved very valuable to prefix words with the relevant field (typically title).
You can also specify multiple fields, eg “title:Mommy title:Time Site:virtualtaboo Cast:Vittoria Cast:Dolce”, any word not prefixed by the field name, will search all fields.
Impact on index space is fairly small.

Existing Indexes are rebuilt, using migrations.go
