### PR TITLE
Fix VRBangers Image URLs

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -784,6 +784,38 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// some site, vrbangers & vrconk have blank covers, & vrbangers gallery images will not render due to double slashes ie .com//
+			ID: "0034-fix-vrbangers-images",
+			Migrate: func(tx *gorm.DB) error {
+				var scenes []models.Scene
+				err := tx.Where("studio  LIKE ?", "VRBangers").Or("images LIKE ?", "%{\"url\":\"\",\"type\":\"gallery\",\"orientation\":\"\"}%").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+
+				for _, scene := range scenes {
+					changed := false
+					// check for a blank cover image and remove them
+					if strings.Contains(scene.Images, ",{\"url\":\"\",\"type\":\"cover\",\"orientation\":\"\"}") {
+						scene.Images = strings.ReplaceAll(scene.Images, ",{\"url\":\"\",\"type\":\"cover\",\"orientation\":\"\"}", "")
+						changed = true
+					}
+					// remove double slashes from image url for VRBangers
+					if scene.Studio == "VRBangers" && strings.Contains(scene.Images, ".com//") {
+						scene.Images = strings.ReplaceAll(scene.Images, ".com//", ".com/")
+						changed = true
+					}
+					if changed {
+						err = tx.Save(&scene).Error
+						if err != nil {
+							return err
+						}
+					}
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -396,17 +396,21 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	var images []Image
 
 	for i := range ext.Covers {
-		images = append(images, Image{
-			URL:  ext.Covers[i],
-			Type: "cover",
-		})
+		if ext.Covers[i] != "" {
+			images = append(images, Image{
+				URL:  ext.Covers[i],
+				Type: "cover",
+			})
+		}
 	}
 
 	for i := range ext.Gallery {
-		images = append(images, Image{
-			URL:  ext.Gallery[i],
-			Type: "gallery",
-		})
+		if ext.Gallery[i] != "" {
+			images = append(images, Image{
+				URL:  ext.Gallery[i],
+				Type: "gallery",
+			})
+		}
 	}
 
 	imgTxt, err := json.Marshal(images)

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -98,7 +98,7 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		// Gallery - https://content.vrbangers.com/uploads/2021/08/611b4e0ca5c54351494706_XL.jpg
 		gallerytmp := gjson.Get(JsonMetadata, "data.item.galleryImages.#.previews.#(sizeAlias==XL).permalink")
 		for _, v := range gallerytmp.Array() {
-			sc.Gallery = append(sc.Gallery, contentURL+v.Str)
+			sc.Gallery = append(sc.Gallery, strings.Replace(contentURL+v.Str, ".com//", ".com/", 1))
 		}
 
 		// Synopsis


### PR DESCRIPTION
There are 2 separate issues with VRBangers Cover and Gallery Images resulting in blank images.

The main cover image is fine, but it is followed by 2 blank Urls entries.  I also found a few other sites where this has occurred, so I have fixed this in model_scene, rather than the vrbangers scrapper, so it is fixed regardless of the site.

The second issue effects the Gallery images which have a double slash // after the domain name in the Url.  eg https://content.vrbangers.com//uploads/2022/06/62a8fa846f6d4248833272_XL.jpg Changing this to a single / fixes the images not displaying.  I did find this on other sites as well, but they appear to display fine, so the fix was made just in the vrbangers scrapper.

A migration has been provided to fix existing scenes