### PR TITLE
Enable Left/Right Arrows to Scroll Gallery Images

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -5,6 +5,8 @@
       @keyup.esc="close"
       @keydown.arrowLeft="handleLeftArrow"
       @keydown.arrowRight="handleRightArrow"
+      @keydown.left="handleLeftArrow"
+      @keydown.right="handleRightArrow"
       @keydown.o="prevScene"
       @keydown.p="nextScene"
       @keydown.f="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -3,15 +3,13 @@
     <GlobalEvents
       :filter="e => !['INPUT', 'TEXTAREA'].includes(e.target.tagName)"
       @keyup.esc="close"
-      @keydown.arrowLeft="handleLeftArrow"
-      @keydown.arrowRight="handleRightArrow"
       @keydown.left="handleLeftArrow"
       @keydown.right="handleRightArrow"
       @keydown.o="prevScene"
       @keydown.p="nextScene"
       @keydown.f="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
-      @keydown.w="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
-      @keydown.W="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
+      @keydown.exact.w="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
+      @keydown.shift.w="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
       @keydown.e="$store.commit('overlay/editDetails', {scene: item.scene})"
       @keydown.g="toggleGallery"
     />
@@ -517,7 +515,7 @@ export default {
       this.activeMedia = 0
     },
     handleLeftArrow () {
-      if (this.activeMedia == 0)
+      if (this.activeMedia === 0)
       {
         this.carouselSlide = this.carouselSlide - 1
       } else {
@@ -525,7 +523,7 @@ export default {
       }
     },
     handleRightArrow () {
-      if (this.activeMedia == 0)
+      if (this.activeMedia === 0)
       {
         this.carouselSlide = this.carouselSlide + 1
       } else {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -3,8 +3,8 @@
     <GlobalEvents
       :filter="e => !['INPUT', 'TEXTAREA'].includes(e.target.tagName)"
       @keyup.esc="close"
-      @keydown.arrowLeft="playerStepBack"
-      @keydown.arrowRight="playerStepForward"
+      @keydown.arrowLeft="handleLeftArrow"
+      @keydown.arrowRight="handleRightArrow"
       @keydown.o="prevScene"
       @keydown.p="nextScene"
       @keydown.f="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
@@ -513,6 +513,22 @@ export default {
     },
     toggleGallery () {
       this.activeMedia = 0
+    },
+    handleLeftArrow () {
+      if (this.activeMedia == 0)
+      {
+        this.carouselSlide = this.carouselSlide - 1
+      } else {
+        this.playerStepBack()
+      }
+    },
+    handleRightArrow () {
+      if (this.activeMedia == 0)
+      {
+        this.carouselSlide = this.carouselSlide + 1
+      } else {
+        this.playerStepForward()
+      }
     },
     scrollToActiveIndicator (value) {
       const indicators = document.querySelector('.carousel-indicator')


### PR DESCRIPTION
When in the Scene Details, the left and right arrow keys are coded to skip the media player position forward and back.
This change will check if the user is on the Gallery tab and if so the pressing the left or right arrow keys will scroll forward or back through the Gallery Images.  If they are on the Player tab then the media position will continue to skip forward or backwards as it does now.