### PR TITLE
Fixed Scenes view out of bounds

### DIFF
--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column">
+  <div>
     <b-loading :is-full-page="true" :active.sync="isLoading"></b-loading>
 
     <div class="columns is-multiline is-full">

--- a/ui/src/views/scenes/Scenes.vue
+++ b/ui/src/views/scenes/Scenes.vue
@@ -10,7 +10,9 @@
         </a>
       </div>
 
-      <List/>
+      <div class="column is-four-fifths">
+        <List/>
+      </div>
 
     </div>
   </div>


### PR DESCRIPTION
Last time i tried this, i wrote that "is-four-fifths" is missing from the List in the Scenes view.
I fixed it by adding "is-four-fifths" to the list itself.
But that fix is wrong, a list shouldn't dictate its own size, it should accomodate its parent (as to make it more portable).
So now Scenes.vue dictates the size of the list, and not the other way around.
