### PR TITLE
Incorrect Cuepoints displayed after editing

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -441,12 +441,14 @@ export default {
           time_start: this.player.currentTime()
         }
       }).json().then(data => {
+        this.$store.commit('sceneList/updateScene', data)
         this.$store.commit('overlay/showDetails', { scene: data })
       })
     },
     deleteCuepoint (cuepoint) {
       ky.delete(`/api/scene/${this.item.id}/cuepoint/${cuepoint.id}`)
         .json().then(data => {
+          this.$store.commit('sceneList/updateScene', data)
           this.$store.commit('overlay/showDetails', { scene: data })
         })
     },


### PR DESCRIPTION
If you add or delete Cuepoints for a scene in Scene Details, return to the Scene List and then go back to the Scene Details to make more changes, the Cuepoints displayed reflect how they originally were and do not reflect the changes made.  You have to refresh the browser to reload the data.

On the add and delete Cuepoint functions I added a call to sceneList/updateScene so the scene details are updated and reflect the cuepoint change made