### PR TITLE
Shortcuts for file match overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Ready to get started?
 * On the XBVR scenes page, create a filter (cast, site, tags, etc.) and sort order, then create a "saved search" (see top left) and check "use as DeoVR list". 
 * Inside DeoVR you will now see your saved search listed
 #### Keyboard Shortcuts
+* Global
+? - Quick Find  
 * Details Pane  
 o - previous scene  
 p - next scene  
@@ -118,3 +120,9 @@ g - toggles gallery / video window
 esc - closes details pane  
 left arrow - cycles backwards in gallery / skips backwards in video  
 right arrow - cycles forward in gallery / skips forward in video
+* File Match Pane  
+o - previous file  
+p - next file  
+left arrow - next page of search results  
+right arrow - previous  page of search results  
+esc - closes matching pane  

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="modal is-active">
+    <GlobalEvents
+      :filter="e => !['INPUT', 'TEXTAREA'].includes(e.target.tagName)"
+      @keyup.esc="close"
+      @keydown.left="handleLeftArrow"
+      @keydown.right="handleRightArrow"
+      @keydown.o="prevFile"
+      @keydown.p="nextFile"
+    />
     <div class="modal-background"></div>
     <div class="modal-card">
       <header class="modal-card-head">
@@ -61,8 +69,8 @@
         </div>
       </section>
     </div>
-    <a class="prev" @click="prevFile">&#10094;</a>
-    <a class="next" @click="nextFile">&#10095;</a>
+    <a class="prev" @click="prevFile" title="Keyboard shortcut: O">&#10094;</a>
+    <a class="next" @click="nextFile" title="Keyboard shortcut: P">&#10095;</a>
   </div>
 </template>
 
@@ -71,10 +79,11 @@ import ky from 'ky'
 import { format, parseISO } from 'date-fns'
 import prettyBytes from 'pretty-bytes'
 import VueLoadImage from 'vue-load-image'
+import GlobalEvents from 'vue-global-events'
 
 export default {
   name: 'SceneMatch',
-  components: { VueLoadImage },
+  components: { VueLoadImage, GlobalEvents },
   data () {
     return {
       data: [],
@@ -197,6 +206,21 @@ export default {
         }
       })
       return count
+    },
+    handleRightArrow () {
+      if ((this.currentPage) * 5 < this.data.length) {
+        this.currentPage = this.currentPage + 1
+      } else {
+        this.currentPage = 1
+      }
+    },
+    handleLeftArrow () {
+      if (this.currentPage === 1) {
+        // dont assume last page is 5
+        this.currentPage = ~~((this.data.length + 4) / 5)
+      } else {
+        this.currentPage = this.currentPage - 1
+      }
     },
     prettyBytes
   }


### PR DESCRIPTION
Adds shortcut keys to the File Matching overlay, consistent with the Scene Edit overlay.
o/p - previous/next file
left/right arrow - scrolls the the search results pages
esc - close