### PR TITLE
Add option to display Scene Cuepoint button

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -44,6 +44,7 @@ type RequestSaveOptionsWeb struct {
 	SceneFavourite bool   `json:"sceneFavourite"`
 	SceneWatched   bool   `json:"sceneWatched"`
 	SceneEdit      bool   `json:"sceneEdit"`
+	SceneCuepoint  bool   `json:"sceneCuepoint"`
 	UpdateCheck    bool   `json:"updateCheck"`
 }
 
@@ -236,6 +237,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.SceneFavourite = r.SceneFavourite
 	config.Config.Web.SceneWatched = r.SceneWatched
 	config.Config.Web.SceneEdit = r.SceneEdit
+	config.Config.Web.SceneCuepoint = r.SceneCuepoint
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.SaveConfig()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ type ObjectConfig struct {
 		SceneFavourite bool   `default:"true" json:"sceneFavourite"`
 		SceneWatched   bool   `default:"false" json:"sceneWatched"`
 		SceneEdit      bool   `default:"false" json:"sceneEdit"`
+		SceneCuepoint  bool   `default:"true" json:"sceneCuepoint"`
 		UpdateCheck    bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Vendor struct {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -17,6 +17,7 @@ type ObjectState struct {
 		SceneFavourite bool   `json:"sceneFavourite"`
 		SceneWatched   bool   `json:"sceneWatched"`
 		SceneEdit      bool   `json:"sceneEdit"`
+		SceneCuepoint  bool   `json:"sceneCuepoint"`
 		UpdateCheck    bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -8,6 +8,7 @@ const state = {
     sceneFavourite: true,
     sceneWatched: false,
     sceneEdit: false,
+    sceneCuepoint: true,
     updateCheck: true
   }
 }
@@ -25,6 +26,7 @@ const actions = {
         state.web.sceneFavourite = data.config.web.sceneFavourite
         state.web.sceneWatched = data.config.web.sceneWatched
         state.web.sceneEdit = data.config.web.sceneEdit
+        state.web.sceneCuepoint = data.config.web.sceneCuepoint
         state.web.updateCheck = data.config.web.updateCheck
         state.loading = false
       })
@@ -39,6 +41,7 @@ const actions = {
         state.web.sceneFavourite = data.sceneFavourite
         state.web.sceneWatched = data.sceneWatched
         state.web.sceneEdit = data.sceneEdit
+        state.web.sceneCuepoint = data.sceneCuepoint
         state.web.updateCheck = data.updateCheck
         state.loading = false
       })

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -40,6 +40,11 @@
                 show Edit Scene button
               </b-switch>
             </b-field>
+            <b-field>
+              <b-switch v-model="sceneCuepoint" type="is-dark">
+                show Cuepoints  button
+              </b-switch>
+            </b-field>
 
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
@@ -100,7 +105,7 @@ export default {
       set (value) {
         this.$store.state.optionsWeb.web.sceneWatched = value
       }
-    },            
+    },
     sceneEdit: {
       get () {
         return this.$store.state.optionsWeb.web.sceneEdit
@@ -115,6 +120,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.updateCheck = value
+      }
+    },
+    sceneCuepoint: {
+      get () {
+        return this.$store.state.optionsWeb.web.sceneCuepoint
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.sceneCuepoint = value
       }
     },
     isLoading: function () {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -20,6 +20,10 @@
               <b-icon pack="mdi" icon="pulse" size="is-small"/>
               <span v-if="scriptFilesCount > 1">{{scriptFilesCount}}</span>
             </b-tag>
+            <b-tag type="is-info" v-if="item.cuepoints.length>0 && this.$store.state.optionsWeb.web.sceneCuepoint">
+              <b-icon pack="mdi" icon="skip-next-outline" size="is-small"/>
+              <span v-if="item.cuepoints.length > 1">{{item.cuepoints.length}}</span>
+            </b-tag>
             <b-tag type="is-warning" v-if="item.star_rating > 0">
               <b-icon pack="mdi" icon="star" size="is-small"/>
               {{item.star_rating}}


### PR DESCRIPTION
Adds an icon to the Scene Card to show how many Cue points a scene has.
With Custom Descriptions for Cue Points added to XBVR, I've started to create Cue Points for scenes, however, you quickly lose track of what ones have been done and which haven't, unless you go into the scene details.

This mod allows you to easily see which do and which don't.
The example below from the bottom of a scene card shows 2 files, is scripted, with 9 cue points.

The icon is optional in line with the change made in the last release

![image](https://user-images.githubusercontent.com/104477758/178100105-9b9030ec-bcbe-484e-ad41-ac330f7e3b47.png)
