### PR TITLE
Enhance VRPHub Scrapers (VRHush/StripzVR)

### DIFF
--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -157,10 +157,10 @@ func vrhushCallback(e *colly.HTMLElement, sc *models.ScrapedScene) {
 			break
 		}
 
-		tmp := strings.Split(tmpVideoUrls[i], "/")
-		tmp2 := strings.Split(tmp[len(tmp)-1], "_")[0]
-		if tmp2 != "VRHush" {
-			sc.SiteID = strings.Replace(tmp2, "vrh", "", -1)
+		vrhIdRegEx := regexp.MustCompile(`vrh(\d+)_`)
+		matches := vrhIdRegEx.FindStringSubmatch(tmpVideoUrls[i])
+		if len(matches) > 0 && len(matches[1]) > 0 {
+			sc.SiteID = matches[1]
 			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 			sceneIdFound = true
 		}

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -200,9 +200,6 @@ func vrhushCallback(e *colly.HTMLElement, sc *models.ScrapedScene) {
 }
 
 func stripzvrCallback(e *colly.HTMLElement, sc *models.ScrapedScene) {
-	// Make sure we don't collide with SLR StripzVR scraper
-	sc.SceneID = "vrphub-" + sc.SceneID
-
 	// Remove prefix for StripzVR trailers
 	for i := range sc.Filenames {
 		sc.Filenames[i] = strings.TrimPrefix(sc.Filenames[i], "StripzVR-SAMPLE-")
@@ -223,5 +220,5 @@ func addVRPHubScraper(id string, name string, company string, vrpCategory string
 
 func init() {
 	addVRPHubScraper("vrphub-vrhush", "VRHush", "VRHush", "vr-hush", "https://z5w6x5a4.ssl.hwcdn.net/sites/vrh/favicon/apple-touch-icon-180x180.png", vrhushCallback)
-	addVRPHubScraper("vrphub-stripzvr", "StripzVR", "StripzVR", "stripzvr", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", stripzvrCallback)
+	addVRPHubScraper("vrphub-stripzvr", "StripzVR - VRP Hub", "StripzVR", "stripzvr", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", stripzvrCallback)
 }

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -184,12 +184,12 @@ func vrhushCallback(e *colly.HTMLElement, sc *models.ScrapedScene) {
 	})
 
 	sceneIdFound := false
+	vrhIdRegEx := regexp.MustCompile(`vrh(\d+)_`)
 	for i := range tmpVideoUrls {
 		if sceneIdFound {
 			break
 		}
 
-		vrhIdRegEx := regexp.MustCompile(`vrh(\d+)_`)
 		matches := vrhIdRegEx.FindStringSubmatch(tmpVideoUrls[i])
 		if len(matches) > 0 && len(matches[1]) > 0 {
 			sc.SiteID = matches[1]

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -28,7 +28,7 @@ func getVideoName(fileUrl string) (string, error) {
 	return filename, nil
 }
 
-func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string, vrpCategory string,  callback func(e *colly.HTMLElement, sc *models.ScrapedScene)) error {
+func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string, vrpCategory string, callback func(e *colly.HTMLElement, sc *models.ScrapedScene)) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -56,7 +56,7 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 			sc.SiteID = u.Query()["p"][0]
 			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 		})
-		if (!isPost) {
+		if !isPost {
 			return
 		}
 
@@ -171,6 +171,7 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 	return nil
 }
 
+// We can pass this noop callback for studios that require no modifications
 func noop(e *colly.HTMLElement, sc *models.ScrapedScene) {}
 
 func vrhushCallback(e *colly.HTMLElement, sc *models.ScrapedScene) {


### PR DESCRIPTION
This is in many ways an extension to https://github.com/xbapps/xbvr/pull/701, fixing bugs from that PR and also adding more enhancements.

The biggest thing is does is allow reusing of the VRP Hub scraper for other studios. In this PR I added StripzVR scraper from VRPHub to complement the scraper from SLR (which hasn't been updated with new scenes for a couple of years).

Outside of that, it fixes a few issues from the original implementation of VRHush scraper:
- The original scraper tries to scrape list page (e.g. `/tags/remastered`) as scenes, as a result it creates empty scenes in the DB.
- The original scraper tries to get filenames based on common conventions from VRPHub, but that convention does not always work, creating wrong scene ids for VRHush. For example, one scene id that was created is `vrhush-10-741x486.jpg`.

The code is structured similar to SLR scraper, which allows easy addition of other studios to the scraper. One thing that is different is that I implemented a callback system so that we can customize each studio if needed. For example, in this PR I use this callback system to implement scene id parsing for VRHush, and correcting filenames from StripzVR.