### PR TITLE
Schedule tasks

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -83,6 +83,21 @@ type GetFunscriptCountResponse struct {
 	Updated int64 `json:"updated"`
 }
 
+type RequestSaveOptionsTaskSchedule struct {
+	RescrapeEnabled      bool `json:"rescrapeEnabled"`
+	RescrapeHourInterval int  `json:"rescrapeHourInterval"`
+	RescrapeUseRange     bool `json:"rescrapeUseRange"`
+	RescrapeMinuteStart  int  `json:"rescrapeMinuteStart"`
+	RescrapeHourStart    int  `json:"rescrapeHourStart"`
+	RescrapeHourEnd      int  `json:"rescrapeHourEnd"`
+	RescanEnabled        bool `json:"rescanEnabled"`
+	RescanHourInterval   int  `json:"rescanHourInterval"`
+	RescanUseRange       bool `json:"rescanUseRange"`
+	RescanMinuteStart    int  `json:"rescanMinuteStart"`
+	RescanHourStart      int  `json:"rescanHourStart"`
+	RescanHourEnd        int  `json:"rescanHourEnd"`
+}
+
 type ConfigResource struct{}
 
 func (i ConfigResource) WebService() *restful.WebService {
@@ -150,6 +165,9 @@ func (i ConfigResource) WebService() *restful.WebService {
 
 	// "Funscripts" section endpoints
 	ws.Route(ws.GET("/funscripts/count").To(i.getFunscriptsCount).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
+	ws.Route(ws.POST("/task-schedule").To(i.saveOptionsTaskSchedule).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	return ws
@@ -579,4 +597,39 @@ func (i ConfigResource) getFunscriptsCount(req *restful.Request, resp *restful.R
 	}
 
 	resp.WriteHeaderAndEntity(http.StatusOK, r)
+}
+
+func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *restful.Response) {
+	var r RequestSaveOptionsTaskSchedule
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if r.RescrapeHourEnd > 23 {
+		r.RescrapeHourEnd -= 24
+	}
+	if r.RescanHourEnd > 23 {
+		r.RescanHourEnd -= 24
+	}
+
+	config.Config.Cron.RescrapeSchedule.Enabled = r.RescrapeEnabled
+	config.Config.Cron.RescrapeSchedule.HourInterval = r.RescrapeHourInterval
+	config.Config.Cron.RescrapeSchedule.UseRange = r.RescrapeUseRange
+	config.Config.Cron.RescrapeSchedule.MinuteStart = r.RescrapeMinuteStart
+	config.Config.Cron.RescrapeSchedule.HourStart = r.RescrapeHourStart
+	config.Config.Cron.RescrapeSchedule.HourEnd = r.RescrapeHourEnd
+
+	config.Config.Cron.RescanSchedule.Enabled = r.RescanEnabled
+	config.Config.Cron.RescanSchedule.HourInterval = r.RescanHourInterval
+	config.Config.Cron.RescanSchedule.UseRange = r.RescanUseRange
+	config.Config.Cron.RescanSchedule.MinuteStart = r.RescanMinuteStart
+	config.Config.Cron.RescanSchedule.HourStart = r.RescanHourStart
+	config.Config.Cron.RescanSchedule.HourEnd = r.RescanHourEnd
+
+	config.SaveConfig()
+
+	resp.WriteHeaderAndEntity(http.StatusOK, r)
+
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,15 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
+type CronSchedule struct {
+	Enabled      bool `default:"true" json:"enabled"`
+	HourInterval int  `json:"hourInterval"`
+	UseRange     bool `default:"false" json:"useRange"`
+	MinuteStart  int  `default:"0" json:"minuteStart"`
+	HourStart    int  `default:"0" json:"hourStart"`
+	HourEnd      int  `default:"23" json:"hourEnd"`
+}
+
 type ObjectConfig struct {
 	Server struct {
 		BindAddress string `default:"0.0.0.0" json:"bindAddress"`
@@ -58,8 +67,22 @@ type ObjectConfig struct {
 		} `json:"preview"`
 	} `json:"library"`
 	Cron struct {
-		ScrapeContentInterval int `default:"12" json:"scrapeContentInt"`
-		RescanLibraryInterval int `default:"2" json:"rescanLibraryInt"`
+		RescrapeSchedule struct {
+			Enabled      bool `default:"true" json:"enabled"`
+			HourInterval int  `default:"12" json:"hourInterval"`
+			UseRange     bool `default:"false" json:"useRange"`
+			MinuteStart  int  `default:"0" json:"minuteStart"`
+			HourStart    int  `default:"0" json:"hourStart"`
+			HourEnd      int  `default:"23" json:"hourEnd"`
+		} `json:"rescrapeSchedule"`
+		RescanSchedule struct {
+			Enabled      bool `default:"true" json:"enabled"`
+			HourInterval int  `default:"2" json:"hourInterval"`
+			UseRange     bool `default:"false" json:"useRange"`
+			MinuteStart  int  `default:"0" json:"minuteStart"`
+			HourStart    int  `default:"0" json:"hourStart"`
+			HourEnd      int  `default:"23" json:"hourEnd"`
+		} `json:"rescanSchedule"`
 	} `json:"cron"`
 }
 

--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -10,26 +10,68 @@ import (
 )
 
 var cronInstance *cron.Cron
+var rescrapTask cron.EntryID
+var rescanTask cron.EntryID
 
 func SetupCron() {
-	cronInstance := cron.New()
+	cronInstance = cron.New()
 	cronInstance.AddFunc("@every 2s", session.CheckForDeadSession)
 	cronInstance.AddFunc("@every 6h", tasks.CalculateCacheSizes)
-	cronInstance.AddFunc(fmt.Sprintf("@every %vh", config.Config.Cron.ScrapeContentInterval), scrapeCron)
-	cronInstance.AddFunc(fmt.Sprintf("@every %vh", config.Config.Cron.RescanLibraryInterval), rescanCron)
+	if config.Config.Cron.RescrapeSchedule.Enabled {
+		log.Println(fmt.Sprintf("Setup Rescrape Task %v", formatCronSchedule(config.CronSchedule(config.Config.Cron.RescrapeSchedule))))
+		rescrapTask, _ = cronInstance.AddFunc(formatCronSchedule(config.CronSchedule(config.Config.Cron.RescrapeSchedule)), scrapeCron)
+	}
+	if config.Config.Cron.RescanSchedule.Enabled {
+		log.Println(fmt.Sprintf("Setup Rescan Task %v", formatCronSchedule(config.CronSchedule(config.Config.Cron.RescanSchedule))))
+		rescanTask, _ = cronInstance.AddFunc(formatCronSchedule(config.CronSchedule(config.Config.Cron.RescanSchedule)), rescanCron)
+	}
 	cronInstance.Start()
 
 	go tasks.CalculateCacheSizes()
+
+	log.Println(fmt.Sprintf("Next Rescrape Task at %v", cronInstance.Entry(rescrapTask).Next))
+	log.Println(fmt.Sprintf("Next Rescan Task at %v", cronInstance.Entry(rescanTask).Next))
 }
 
 func scrapeCron() {
 	if !session.HasActiveSession() {
 		tasks.Scrape("_enabled")
 	}
+	log.Println(fmt.Sprintf("Next Rescrape Task at %v", cronInstance.Entry(rescrapTask).Next))
 }
 
 func rescanCron() {
 	if !session.HasActiveSession() {
 		tasks.RescanVolumes()
 	}
+	log.Println(fmt.Sprintf("Next Rescan Task at %v", cronInstance.Entry(rescanTask).Next))
+}
+func formatCronSchedule(schedule config.CronSchedule) string {
+	// 	this routine will format a crontab range description, https://crontab.guru is a good tool to decode the range description generated
+	// 	if the start hour > end hour then the time range will extend across midnight into the next day
+	//		to achieve this with cron you create a range from the start until midnight and then a second from from midnight to the end time
+	//		we need to calculate the start time for the range after midnight to make sure we still get the right iterval
+	hourInterval := ""
+	formattedHourSchedule := ""
+
+	if !schedule.UseRange {
+		return fmt.Sprintf("@every %vh", schedule.HourInterval)
+	}
+
+	if schedule.HourInterval > 0 {
+		hourInterval = fmt.Sprintf("/%v", schedule.HourInterval)
+	}
+	if schedule.HourStart > schedule.HourEnd { // if the start > end, time range goes over midnight into the next day
+		afterMidnightStart := (schedule.HourInterval - ((24 - schedule.HourStart) % schedule.HourInterval)) % schedule.HourInterval // calculate what time after midnight to restart
+		if afterMidnightStart <= schedule.HourEnd {
+			// schedule the range needed to start after midnight
+			formattedHourSchedule = fmt.Sprintf("%v-%v%v,%v-23%v", afterMidnightStart, schedule.HourEnd, hourInterval, schedule.HourStart, hourInterval)
+		} else {
+			// the interval was too big to schedule after midnight before reaching the end time, so only create the pre midnight range
+			formattedHourSchedule = fmt.Sprintf("%v-23%v", schedule.HourStart, hourInterval)
+		}
+	} else {
+		formattedHourSchedule = fmt.Sprintf("%v-%v%v", schedule.HourStart, schedule.HourEnd, hourInterval)
+	}
+	return fmt.Sprintf("%v %v * * *", schedule.MinuteStart, formattedHourSchedule)
 }

--- a/ui/src/views/options/Options.vue
+++ b/ui/src/views/options/Options.vue
@@ -9,6 +9,7 @@
             <b-menu-item :label="$t('Previews')" :active="active==='previews'" @click="setActive('previews')"/>
             <!--            <b-menu-item :label="$t('Scheduled tasks')" :active="active==='tasks'" @click="setActive ('tasks')"/>-->
             <b-menu-item :label="$t('Cache')" :active="active==='cache'" @click="setActive('cache')"></b-menu-item>
+            <b-menu-item :label="$t('Task Schedules')" :active="active==='schedules'" @click="setActive('schedules')"></b-menu-item>
           </b-menu-list>
           <b-menu-list :label="$t('Scene data')">
             <b-menu-item :label="$t('Scrapers')" :active="active==='data-scrapers'"
@@ -33,6 +34,7 @@
           <Storage v-show="active==='storage'"/>
           <Cache v-show="active==='cache'"/>
           <Previews v-show="active==='previews'"/>
+          <Schedules v-show="active==='schedules'"/>
           <SceneDataScrapers v-show="active==='data-scrapers'"/>
           <SceneCreate v-show="active==='create-scene'"/>
           <Funscripts v-show="active==='funscripts'"/>
@@ -57,10 +59,11 @@ import SceneDataImportExport from './sections/OptionsSceneDataImportExport'
 import InterfaceDLNA from './sections/InterfaceDLNA.vue'
 import Cache from './sections/Cache.vue'
 import Previews from './sections/Previews.vue'
+import Schedules from './sections/Schedules.vue'
 import InterfaceDeoVR from './sections/InterfaceDeoVR.vue'
 
 export default {
-  components: { Storage, SceneDataScrapers, SceneCreate, Funscripts, SceneDataImportExport, InterfaceWeb, InterfaceDLNA, InterfaceDeoVR, Cache, Previews },
+  components: { Storage, SceneDataScrapers, SceneCreate, Funscripts, SceneDataImportExport, InterfaceWeb, InterfaceDLNA, InterfaceDeoVR, Cache, Previews, Schedules },
   data: function () {
     return {
       active: 'storage'

--- a/ui/src/views/options/sections/Schedules.vue
+++ b/ui/src/views/options/sections/Schedules.vue
@@ -1,0 +1,232 @@
+<template>
+  <div class="container">
+    <b-loading :is-full-page="false" :active.sync="isLoading"></b-loading>
+    <div class="content">
+      <h3>{{$t("Task Schedules")}}</h3>
+      <hr/>
+      <div class="columns">
+        <div class="column">
+          <section>
+            <b-field>
+              <h4>{{$t("Rescrape Schedule")}}</h4>
+              <b-switch style="margin-left:2em" v-model="useRescrapeTimeRange">
+                <p>{{ useRescrapeTimeRange ? 'Use Processing Window' : 'Process All Day' }}</p>
+              </b-switch>
+            </b-field>
+            <b-field label="Interval">
+              <b-slider v-model="rescrapeHourInterval" :min="1" :max="23" :step="1" ></b-slider>
+              <div class="column is-one-third" style="margin-left:.75em">{{`Repeat every ${this.rescrapeHourInterval} hour${this.rescrapeHourInterval > 1 ? 's': ''}`}}</div>
+            </b-field>
+            <div v-if="useRescrapeTimeRange">
+              <b-field label="Processing Window">
+                <b-slider v-model="rescrapeTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescrapTo24Hours">
+                  <b-slider-tick :value="0">00:00</b-slider-tick>
+                  <b-slider-tick :value="6">06:00</b-slider-tick>
+                  <b-slider-tick :value="12">12:00</b-slider-tick>
+                  <b-slider-tick :value="18">18:00</b-slider-tick>
+                  <b-slider-tick :value="24">Midnight</b-slider-tick>
+                  <b-slider-tick :value="30">06:00</b-slider-tick>
+                  <b-slider-tick :value="36">12:00</b-slider-tick>
+                  <b-slider-tick :value="42">18:00</b-slider-tick>
+                  <b-slider-tick :value="48">00:00</b-slider-tick>
+                </b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescrapeTimeRange[0]]} - ${this.timeRange[this.rescrapeTimeRange[1]]}`}}</div>
+              </b-field>
+              <b-field>
+                <b-slider v-model="rescrapeMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescrapeMinuteStart) }}</div>
+              </b-field>
+            </div>
+            <hr/>
+            <b-field>
+              <h4>{{$t("Rescan Schedule")}}</h4>
+              <b-switch style="margin-left:2em" v-model="useRescanTimeRange">
+                <p>{{ useRescanTimeRange ? 'Use Processing Window' : 'Process All Day' }}</p>
+              </b-switch>
+            </b-field>
+            <b-field label="Interval">
+               <b-slider v-model="rescanHourInterval" :min="1" :max="23" :step="1" ></b-slider>
+               <div class="column is-one-third" style="margin-left:.75em">{{`Repeat every ${this.rescanHourInterval} hour${this.rescanHourInterval > 1 ? 's': ''}`}}</div>
+            </b-field>
+            <div v-if="useRescanTimeRange">
+              <b-field label="Processing Window">
+                <b-slider v-model="rescanTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescanTo24Hours">
+                  <b-slider-tick :value="0">00:00</b-slider-tick>
+                  <b-slider-tick :value="6">06:00</b-slider-tick>
+                  <b-slider-tick :value="12">12:00</b-slider-tick>
+                  <b-slider-tick :value="18">18:00</b-slider-tick>
+                  <b-slider-tick :value="24">Midnight</b-slider-tick>
+                  <b-slider-tick :value="30">06:00</b-slider-tick>
+                  <b-slider-tick :value="36">12:00</b-slider-tick>
+                  <b-slider-tick :value="42">18:00</b-slider-tick>
+                  <b-slider-tick :value="48">00:00</b-slider-tick>
+                </b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescanTimeRange[0]]} - ${this.timeRange[this.rescanTimeRange[1]]}`}}</div>
+              </b-field>
+              <b-field>
+                <b-slider v-model="rescanMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescanMinuteStart) }}</div>
+              </b-field>
+            </div>
+            <hr/>
+            <b-field grouped>
+              <b-button type="is-primary" @click="saveSettings" style="margin-right:1em">Save settings</b-button>
+            </b-field>
+          </section>
+          <hr/>
+          <section>
+            <p>
+              NOTE: The processing window cannot be more than 24 hours.
+            </p>
+            <p>
+              Restart XBVR to use new schedule settings
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import ky from 'ky'
+import prettyBytes from 'pretty-bytes'
+
+export default {
+  name: 'Schedules',
+  data () {
+    return {
+      isLoading: true,
+      rescrapeEnabled: true,
+      rescanEnabled: true,
+      rescrapeTimeRange: [0, 23],
+      lastTimeRange: [0, 23],
+      rescanTimeRange: [0, 23],
+      lastrescanTimeRange: [0, 23],
+      useRescrapeTimeRange: false,
+      useRescanTimeRange: false,
+      rescrapeHourInterval: 0,
+      rescrapeMinuteStart: 0,
+      rescanMinuteStart: 0,
+      rescanHourInterval: 0,
+      timeRange: ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
+        '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00',
+        '00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
+        '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00', '00:00']
+    }
+  },
+  async mounted () {
+    await this.loadState()
+  },
+  computed: {
+  },
+  methods: {
+    restrictRescrapTo24Hours () {
+      this.rescrapeTimeRange = this.restrictTo24Hours(this.rescrapeTimeRange, this.lastTimeRange)
+      this.lastTimeRange = this.rescrapeTimeRange
+    },
+    restrictRescanTo24Hours () {
+      this.rescanTimeRange = this.restrictTo24Hours(this.rescanTimeRange, this.lastrescanTimeRange)
+      this.lastrescanTimeRange = this.rescanTimeRange
+    },
+    restrictTo24Hours (rescrapeTimeRange, lastTimeRange) {
+      // check the first time is not in the second 24 hours, no need, should be in the first 24 hours
+      if (rescrapeTimeRange[0] > 23) {
+        rescrapeTimeRange[0] = 23
+        rescrapeTimeRange = [rescrapeTimeRange[0], rescrapeTimeRange[1]]
+      }
+      // check they are not trying to select more than a 24 hour range
+      if ((rescrapeTimeRange[1] - rescrapeTimeRange[0]) > 23 ) {
+        if (rescrapeTimeRange[0] === lastTimeRange[0] || rescrapeTimeRange[0] === lastTimeRange[1]) {
+          rescrapeTimeRange = [rescrapeTimeRange[1] - 23, rescrapeTimeRange[1]]
+        } else {
+          rescrapeTimeRange = [rescrapeTimeRange[0], rescrapeTimeRange[0] + 23]
+        }
+      }
+      return rescrapeTimeRange
+    },
+    async loadState () {
+      this.isLoading = true
+      await ky.get('/api/options/state')
+        .json()
+        .then(data => {
+          this.rescrapeEnabled = data.config.cron.rescrapeSchedule.enabled
+          this.rescrapeHourInterval = data.config.cron.rescrapeSchedule.hourInterval
+          this.useRescrapeTimeRange = data.config.cron.rescrapeSchedule.useRange
+          this.rescrapeMinuteStart = data.config.cron.rescrapeSchedule.minuteStart
+          this.rescanEnabled = data.config.cron.rescanSchedule.enabled
+          this.rescanHourInterval = data.config.cron.rescanSchedule.hourInterval
+          this.useRescanTimeRange = data.config.cron.rescanSchedule.useRange
+          this.rescanMinuteStart = data.config.cron.rescanSchedule.minuteStart
+          if (data.config.cron.rescrapeSchedule.hourStart > data.config.cron.rescrapeSchedule.hourEnd) {
+            this.rescrapeTimeRange = [data.config.cron.rescrapeSchedule.hourStart, data.config.cron.rescrapeSchedule.hourEnd + 24]
+          } else {
+            this.rescrapeTimeRange = [data.config.cron.rescrapeSchedule.hourStart, data.config.cron.rescrapeSchedule.hourEnd]
+          }
+          if (data.config.cron.rescanSchedule.hourStart > data.config.cron.rescanSchedule.hourEnd) {
+            this.rescanTimeRange = [data.config.cron.rescanSchedule.hourStart, data.config.cron.rescanSchedule.hourEnd + 24]
+          } else {
+            this.rescanTimeRange = [data.config.cron.rescanSchedule.hourStart, data.config.cron.rescanSchedule.hourEnd]
+          }
+          this.isLoading = false
+        })
+    },
+    minutesStartMsg (start) {
+      if (start === 0) {
+        return 'Start on the hour'
+      }
+      if (start === 1) {
+        return 'Start at 1 minute past the hour'
+      }
+      return `Start at ${start} minutes past the hour`
+    },
+    async saveSettings () {
+      this.isLoading = true
+      this.rescrapeEnabled = true
+      this.rescanEnabled = true
+      await ky.post('/api/options/task-schedule', {
+        json: {
+          rescrapeEnabled: this.rescrapeEnabled,
+          rescrapeHourInterval: this.rescrapeHourInterval,
+          rescrapeUseRange: this.useRescrapeTimeRange,
+          rescrapeMinuteStart: this.rescrapeMinuteStart,
+          rescrapeHourStart: this.rescrapeTimeRange[0],
+          rescrapeHourEnd: this.rescrapeTimeRange[1],
+          rescanEnabled: this.rescanEnabled,
+          rescanHourInterval: this.rescanHourInterval,
+          rescanUseRange: this.useRescanTimeRange,
+          RescanMinuteStart: this.rescanMinuteStart,
+          rescanHourStart: this.rescanTimeRange[0],
+          rescanHourEnd: this.rescanTimeRange[1]
+        }
+      })
+        .json()
+        .then(data => {
+          this.isLoading = false
+        })
+    },
+    prettyBytes
+  }
+}
+</script>
+
+<style scoped>
+  video {
+    width: 100%;
+  }
+
+  .bbox {
+    flex: 1 0 calc(25% - 10px);
+    margin: 5px;
+    background: #f0f0f0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .bbox:after {
+    content: '';
+    display: block;
+    padding-bottom: 100%;
+  }
+</style>

--- a/ui/src/views/options/sections/Schedules.vue
+++ b/ui/src/views/options/sections/Schedules.vue
@@ -9,15 +9,18 @@
           <section>
             <b-field>
               <h4>{{$t("Rescrape Schedule")}}</h4>
-              <b-switch style="margin-left:2em" v-model="useRescrapeTimeRange">
+              <b-switch style="margin-left:2em" v-model="rescrapeEnabled">
+                <p>{{ rescrapeEnabled ? 'Enabled' : 'Disabled' }}</p>
+              </b-switch>
+              <b-switch v-if="rescrapeEnabled" style="margin-left:2em" v-model="useRescrapeTimeRange">
                 <p>{{ useRescrapeTimeRange ? 'Use Processing Window' : 'Process All Day' }}</p>
               </b-switch>
             </b-field>
-            <b-field label="Interval">
+            <b-field v-if="rescrapeEnabled" label="Interval">
               <b-slider v-model="rescrapeHourInterval" :min="1" :max="23" :step="1" ></b-slider>
               <div class="column is-one-third" style="margin-left:.75em">{{`Repeat every ${this.rescrapeHourInterval} hour${this.rescrapeHourInterval > 1 ? 's': ''}`}}</div>
             </b-field>
-            <div v-if="useRescrapeTimeRange">
+            <div v-if="useRescrapeTimeRange && rescrapeEnabled">
               <b-field label="Processing Window">
                 <b-slider v-model="rescrapeTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescrapTo24Hours">
                   <b-slider-tick :value="0">00:00</b-slider-tick>
@@ -40,15 +43,18 @@
             <hr/>
             <b-field>
               <h4>{{$t("Rescan Schedule")}}</h4>
-              <b-switch style="margin-left:2em" v-model="useRescanTimeRange">
+              <b-switch style="margin-left:2em" v-model="rescanEnabled">
+                <p>{{ rescanEnabled ? 'Enabled' : 'Disabled' }}</p>
+              </b-switch>
+              <b-switch v-if="rescanEnabled" style="margin-left:2em" v-model="useRescanTimeRange">
                 <p>{{ useRescanTimeRange ? 'Use Processing Window' : 'Process All Day' }}</p>
               </b-switch>
             </b-field>
-            <b-field label="Interval">
+            <b-field v-if="rescanEnabled" label="Interval">
                <b-slider v-model="rescanHourInterval" :min="1" :max="23" :step="1" ></b-slider>
                <div class="column is-one-third" style="margin-left:.75em">{{`Repeat every ${this.rescanHourInterval} hour${this.rescanHourInterval > 1 ? 's': ''}`}}</div>
             </b-field>
-            <div v-if="useRescanTimeRange">
+            <div v-if="useRescanTimeRange && rescanEnabled">
               <b-field label="Processing Window">
                 <b-slider v-model="rescanTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescanTo24Hours">
                   <b-slider-tick :value="0">00:00</b-slider-tick>
@@ -182,8 +188,6 @@ export default {
     },
     async saveSettings () {
       this.isLoading = true
-      this.rescrapeEnabled = true
-      this.rescanEnabled = true
       await ky.post('/api/options/task-schedule', {
         json: {
           rescrapeEnabled: this.rescrapeEnabled,


### PR DESCRIPTION
resolves #710 

Give users the ability to schedule when the rescan and re-scrape tasks run.

For the Re-scrape and Re-scan tasks you can
- Config the current setting, i.e. every 2 hours, etc., to your preferred frequency
- Optionally, you can also specify a processing window, e.g. 18:00-06:00 if you only want to run overnight or 09:00-17:00 for during the day, 0-23 for all day
- If you specify a process window, you can specify how many minutes after the hour to start the task
- Can disable the task, so you only run it manually

Migration will keep the existing settings (in case they were changed via sql) and will generate a random minutes start after hour value, so everyone doesn't scrape on the hour.