### PR TITLE
only apply edits to scenes which where rescraped

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -901,6 +901,15 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0038-edits-applied",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					EditsApplied bool `json:"edits_applied" gorm:"default:false"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -91,7 +91,8 @@ type Scene struct {
 	HasVideoPreview bool `json:"has_preview" gorm:"default:false"`
 	// HasVideoThumbnail bool `json:"has_video_thumbnail" gorm:"default:false"`
 
-	NeedsUpdate bool `json:"needs_update"`
+	NeedsUpdate  bool `json:"needs_update"`
+	EditsApplied bool `json:"edits_applied" gorm:"default:false"`
 
 	Description string  `gorm:"-" json:"description"`
 	Score       float64 `gorm:"-" json:"_score"`
@@ -351,6 +352,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	db.Where(&Scene{SceneID: ext.SceneID}).FirstOrCreate(&o)
 
 	o.NeedsUpdate = false
+	o.EditsApplied = false
 	o.SceneID = ext.SceneID
 
 	if o.Title != ext.Title {

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -99,7 +99,12 @@ func ReapplyEdits() {
 	var actions []models.Action
 	db, _ := models.GetDB()
 	defer db.Close()
-	db.Find(&actions)
+	db.Model(&actions).
+		Joins("join scenes on actions.scene_id=scenes.scene_id").
+		Where("scenes.edits_applied = ?", false).
+		Where("scenes.deleted_at is null").
+		Debug().
+		Find(&actions)
 
 	for _, a := range actions {
 		var scene models.Scene
@@ -148,6 +153,7 @@ func ReapplyEdits() {
 			db.Model(&scene).Update("release_date", dt)
 		}
 	}
+	db.Model(&models.Scene{}).Update("edits_applied", true)
 }
 
 func Scrape(toScrape string) {


### PR DESCRIPTION
This PR adds an edits_applied flag to scenes, so only scenes which were rescraped are considered for the ReapplyEdits step after a scrape. This step could become quite lengthy if you got a lot of manually matched files.