### PR TITLE
title_size_change

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -916,7 +916,7 @@ func Migrate() {
 				if models.GetDBConn().Driver == "mysql" {
 					return tx.Model(&models.Scene{}).ModifyColumn("title", "varchar(1024)").Error
 				}
-				return tx.AutoMigrate(&models.Scene{}).Error
+				return nil
 			},
 		},
 	})

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -910,6 +910,15 @@ func Migrate() {
 				return tx.AutoMigrate(Scene{}).Error
 			},
 		},
+		{
+			ID: "0039-title-size-change",
+			Migrate: func(tx *gorm.DB) error {
+				if models.GetDBConn().Driver == "mysql" {
+					return tx.Model(&models.Scene{}).ModifyColumn("title", "varchar(1024)").Error
+				}
+				return tx.AutoMigrate(&models.Scene{}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -57,7 +57,7 @@ type Scene struct {
 	DeletedAt *time.Time `sql:"index" json:"-"`
 
 	SceneID         string    `json:"scene_id"`
-	Title           string    `json:"title"`
+	Title           string    `json:"title" sql:"type:varchar(1024);"`
 	SceneType       string    `json:"scene_type"`
 	Studio          string    `json:"studio"`
 	Site            string    `json:"site"`


### PR DESCRIPTION
Changes size of the title column for mysql. sqlite3 is not modified (only new installs reflect change). sqlte3 does not obey size restrictions by default unless table was created as "STRICT".