### PR TITLE
Change Scene UpdateStatus to set has_video_preview flag when previews exist

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -336,6 +336,11 @@ func (o *Scene) UpdateStatus() {
 		changed = true
 	}
 
+	if !o.HasVideoPreview && o.PreviewExists() {
+		o.HasVideoPreview = true
+		changed = true
+	}
+
 	totalWatchTime := o.GetTotalWatchTime()
 	if o.TotalWatchTime != totalWatchTime {
 		o.TotalWatchTime = totalWatchTime


### PR DESCRIPTION
Currently the scene UpdateStatus function will clear the has_video_preview flag when preview files do not exists.
This change will also set the flag when it is unset, but video previews do exist.  This would not normally happen, but might if the user restored files outside of xbvr.