### PR TITLE
patch-fisheye180

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -404,6 +404,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 			videoFiles[0].VideoProjection == "mkx220" ||
 			videoFiles[0].VideoProjection == "rf52" ||
 			videoFiles[0].VideoProjection == "fisheye190" ||
+			videoFiles[0].VideoProjection == "fisheye" ||
 			videoFiles[0].VideoProjection == "vrca220" {
 			stereoMode = "sbs"
 			screenType = videoFiles[0].VideoProjection

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -217,7 +217,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 							if part == "mkx200" || part == "mkx220" || part == "rf52" || part == "fisheye190" || part == "vrca220" || part == "flat" {
 								fl.VideoProjection = part
 								break
-							} else if part == "fisheye" || part == "F180" || part == "180F" {
+							} else if part == "fisheye" || part == "f180" || part == "180f" {
 								fl.VideoProjection = "fisheye"
 								break
 							} else if i < len(nameparts)-1 && (part+"_"+nameparts[i+1] == "mono_360" || part+"_"+nameparts[i+1] == "mono_180") {

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -214,8 +214,11 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 						fl.VideoProjection = "180_sbs"
 						nameparts := filenameSeparator.Split(strings.ToLower(filepath.Base(path)), -1)
 						for i, part := range nameparts {
-							if part == "mkx200" || part == "mkx220" || part == "rf52" || part == "fisheye190" || part == "vrca220" || part == "flat" || part == "fisheye" {
+							if part == "mkx200" || part == "mkx220" || part == "rf52" || part == "fisheye190" || part == "vrca220" || part == "flat" {
 								fl.VideoProjection = part
+								break
+							} else if part == "fisheye" || part == "F180" || part == "180F" {
+								fl.VideoProjection = "fisheye"
 								break
 							} else if i < len(nameparts)-1 && (part+"_"+nameparts[i+1] == "mono_360" || part+"_"+nameparts[i+1] == "mono_180") {
 								fl.VideoProjection = nameparts[i+1] + "_mono"

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -214,7 +214,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 						fl.VideoProjection = "180_sbs"
 						nameparts := filenameSeparator.Split(strings.ToLower(filepath.Base(path)), -1)
 						for i, part := range nameparts {
-							if part == "mkx200" || part == "mkx220" || part == "rf52" || part == "fisheye190" || part == "vrca220" || part == "flat" {
+							if part == "mkx200" || part == "mkx220" || part == "rf52" || part == "fisheye190" || part == "vrca220" || part == "flat" || part == "fisheye" {
 								fl.VideoProjection = part
 								break
 							} else if i < len(nameparts)-1 && (part+"_"+nameparts[i+1] == "mono_360" || part+"_"+nameparts[i+1] == "mono_180") {


### PR DESCRIPTION
* fisheye_projection_type

Added 180 degree fisheye lens type (detected by filename _fisheye)

I looked at #807 and tried to imitate it. DeoVR API does claim to separately support 180 degree fisheye projection, [9. Naming convention](https://deovr.com/app/doc#naming) & [11. Supported type of meshes](https://deovr.com/app/doc#Supportedmeshes)

I am not sure if this will break parsing for fisheye vs. fisheye190. A considerable chunk of older JAV uses linear 180 degree fisheye and not mkx200.