### PR TITLE
Add multiple video skip buttons

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -42,8 +42,24 @@
               </b-tab-item>
 
               <b-tab-item label="Player">
-                <video ref="player" class="video-js vjs-default-skin" controls playsinline preload="none"/>
-              </b-tab-item>
+                <video ref="player" class="video-js vjs-default-skin" controls playsinline preload="none"/>                
+                <b-field position="is-centered">
+                  <b-field>
+                    <b-tooltip v-for="(skipBack, i) in skipBackIntervals" class="is-size-7" :key="i" :active="skipBack == lastSkipBackInterval ? true : false" :label="$t('Keyboard shortcut: Left Arrow')" 
+                        position="is-top" type="is-primary is-light" >
+                    <b-button class="tag is-small is-outlined is-info is-light"  @click="playerStepBack(skipBack)">                      
+                      <b-icon v-if="skipBack == lastSkipBackInterval" pack="mdi" icon="arrow-left-thin" size="is-small"></b-icon> {{ skipBack }}</b-button>
+                    </b-tooltip>
+                  </b-field>
+                  <b-field style="margin-left:1em">
+                    <b-tooltip v-for="(skipForward, i) in skipForwardIntervals" :key="i" :active="skipForward == lastSkipFowardInterval ? true : false" :label="$t('Keyboard shortcut: Right Arrow')" 
+                        position="is-top" type="is-primary is-light" >                    
+                    <b-button class="tag is-small is-outlined is-info is-light" @click="playerStepForward(skipForward)">
+                      <b-icon v-if="skipForward == lastSkipFowardInterval" pack="mdi" icon="arrow-right-thin" size="is-small"></b-icon> +{{ skipForward }}</b-button>
+                    </b-tooltip>
+                  </b-field>
+                </b-field>
+             </b-tab-item>
 
             </b-tabs>
 
@@ -235,6 +251,10 @@ export default {
       cuepointActTags: ['', 'handjob', 'blowjob', 'doggy', 'cowgirl', 'revcowgirl', 'missionary', 'titfuck', 'anal', 'cumshot', '69', 'facesit'],
       carouselSlide: 0,
       vidPosition: null,
+      skipForwardIntervals: [5, 10, 30, 60, 120, 300],
+      skipBackIntervals: [-300, -120, -60, -30, -10, -5],
+      lastSkipFowardInterval: 5,
+      lastSkipBackInterval: -5,
       currentCuepointId: 0,
       maxTime: new Date(0, 0, 0, 5, 0, 0)
     }
@@ -526,27 +546,28 @@ export default {
         this.updatePlayer(undefined, '180')
       }
     },
-    playerStepBack () {
+    playerStepBack (interval) {
       const wasPlaying = !this.player.paused()
       if (wasPlaying) {
         this.player.pause()
       }
-      let seekTime = this.player.currentTime() - 5
+      let seekTime = this.player.currentTime() + interval
       if (seekTime <= 0) {
         seekTime = 0
       }
       this.player.currentTime(seekTime)
       if (wasPlaying) {
         this.player.play()
-      }
+      }      
+      this.lastSkipBackInterval = interval
     },
-    playerStepForward () {
+    playerStepForward (interval) {
       const duration = this.player.duration()
       const wasPlaying = !this.player.paused()
       if (wasPlaying) {
         this.player.pause()
       }
-      let seekTime = this.player.currentTime() + 5
+      let seekTime = this.player.currentTime() + interval
       if (seekTime >= duration) {
         seekTime = wasPlaying ? duration - 0.001 : duration
       }
@@ -554,6 +575,7 @@ export default {
       if (wasPlaying) {
         this.player.play()
       }
+      this.lastSkipFowardInterval = interval
     },
     toggleGallery () {
       if (this.activeMedia == 0) {
@@ -562,20 +584,20 @@ export default {
         this.activeMedia = 0
         }
     },
-    handleLeftArrow () {
+    handleLeftArrow () {      
       if (this.activeMedia === 0)
       {
         this.carouselSlide = this.carouselSlide - 1
-      } else {
-        this.playerStepBack()
+      } else {        
+        this.playerStepBack(this.lastSkipBackInterval)
       }
     },
     handleRightArrow () {
       if (this.activeMedia === 0)
       {
         this.carouselSlide = this.carouselSlide + 1
-      } else {
-        this.playerStepForward()
+      } else {        
+        this.playerStepForward(this.lastSkipFowardInterval)
       }
     },
     scrollToActiveIndicator (value) {


### PR DESCRIPTION
This change adds buttons in the Scene Edit Player tab to provide the ability to skip different intervals while playing back a video, i.e. -300, -120, -60, -30, -10, -5,  5, 10, 30, 60, 120, 300 seconds

Given jumping to another time code in the video player usually involves a second or two of buffering, so the existing skip of 5 seconds wasn't very useful.  Creating cue points usually involves a lot of jumping around., I found with a custom mod 30 seconds forward and 10 back work quite.  But found the options above gave even better flexibility

The Left and Right arrows key shortcuts will now skip by the last forward or back interval of the last buttons click.  The last button click will have a left/right arrow icon, to help the user know what value the left/right arrow shortcut are set to.