### PR TITLE
Cuepoint Button & Default changes

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -926,6 +926,21 @@ func Migrate() {
 				return db.Model(&models.Scene{}).Where("site = ?", "perVRt/Terrible").Update("site", "perVRt").Error
 			},
 		},
+		{
+			// populate default cuepoint actions and positions
+			ID: "0041-default-cuepoints",
+			Migrate: func(tx *gorm.DB) error {
+				var kv models.KV
+				kv.Key = "cuepoints"
+				db.Find(&kv)
+
+				if kv.Value == "" {
+					kv.Value = "{\"positions\":[\"standing\", \"sitting\", \"laying\", \"kneeling\"],\"actions\":[\"handjob\", \"blowjob\", \"doggy\", \"cowgirl\", \"revcowgirl\", \"missionary\", \"titfuck\", \"anal\", \"cumshot\", \"69\", \"facesit\"]}"
+					kv.Save()
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
This change replaces the Cast and Tag links on the Scene Details/Cuepoint tab with buttons to to populate the Cuepoint entry details.  Making it a lot faster to enter cuepoints manually, rather than the auto complete dropdowns controls (which still exist as well).

Cuepoint buttons are provided for the standard Cuepoint Positions and Actions as well as the scenes tags.  

The default Cuepoint Positions and Actions have been shifted to the database, so they are no longer hard coded and can be changed to the user personal preferences.  

Cuepoint defaults are saved to the KV table in a new record with a key 'cuepoints'.  No UI to change them is provided at this stage, should come in a future PR, but if a user is comfortable with SQL & JSON they can change the defaults.  A migration is provided to setup the new record with the existing defaults.