### PR TITLE
Scripted Scene Title issue with Hereshpere Api And Scriptplayer

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -430,6 +430,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 	thumbnailURL := "http://" + req.Request.Host + "/img/700x/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 
 	if scene.IsScripted {
+		title = scene.GetFunscriptTitle()
 		if config.Config.Interfaces.DeoVR.RenderHeatmaps {
 			thumbnailURL = "http://" + req.Request.Host + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 		}


### PR DESCRIPTION
For Scripted Scenes, the Heresphere Title is just the scene title.  In the Deovr Api it is "Scene Id - Title". 
When using Heresphere with ScriptPlayer, it passes the scene title to ScriptPlayer as the name of the funscript file to open.  Therefore with the Heresphere Api  the script player does not look for the right file.  

This change uses the GetFunscriptTitle for the Title in the Hereshpere api, to align with the funscript files exported