### PR TITLE
Add ability to schedule Preview Generation

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -98,6 +98,12 @@ type RequestSaveOptionsTaskSchedule struct {
 	RescanMinuteStart    int  `json:"rescanMinuteStart"`
 	RescanHourStart      int  `json:"rescanHourStart"`
 	RescanHourEnd        int  `json:"rescanHourEnd"`
+	PreviewEnabled       bool `json:"previewEnabled"`
+	PreviewHourInterval  int  `json:"previewHourInterval"`
+	PreviewUseRange      bool `json:"previewUseRange"`
+	PreviewMinuteStart   int  `json:"previewMinuteStart"`
+	PreviewHourStart     int  `json:"previewHourStart"`
+	PreviewHourEnd       int  `json:"previewHourEnd"`
 }
 
 type RequestCuepointsResponse struct {
@@ -624,6 +630,9 @@ func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *rest
 	if r.RescanHourEnd > 23 {
 		r.RescanHourEnd -= 24
 	}
+	if r.PreviewHourEnd > 23 {
+		r.PreviewHourEnd -= 24
+	}
 
 	config.Config.Cron.RescrapeSchedule.Enabled = r.RescrapeEnabled
 	config.Config.Cron.RescrapeSchedule.HourInterval = r.RescrapeHourInterval
@@ -638,6 +647,13 @@ func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *rest
 	config.Config.Cron.RescanSchedule.MinuteStart = r.RescanMinuteStart
 	config.Config.Cron.RescanSchedule.HourStart = r.RescanHourStart
 	config.Config.Cron.RescanSchedule.HourEnd = r.RescanHourEnd
+
+	config.Config.Cron.PreviewSchedule.Enabled = r.PreviewEnabled
+	config.Config.Cron.PreviewSchedule.HourInterval = r.PreviewHourInterval
+	config.Config.Cron.PreviewSchedule.UseRange = r.PreviewUseRange
+	config.Config.Cron.PreviewSchedule.MinuteStart = r.PreviewMinuteStart
+	config.Config.Cron.PreviewSchedule.HourStart = r.PreviewHourStart
+	config.Config.Cron.PreviewSchedule.HourEnd = r.PreviewHourEnd
 
 	config.SaveConfig()
 

--- a/pkg/api/tasks.go
+++ b/pkg/api/tasks.go
@@ -152,7 +152,7 @@ func (i TaskResource) restoreBundle(req *restful.Request, resp *restful.Response
 }
 
 func (i TaskResource) previewGenerate(req *restful.Request, resp *restful.Response) {
-	go tasks.GeneratePreviews()
+	go tasks.GeneratePreviews(nil)
 }
 
 func (i TaskResource) scrapeJAVR(req *restful.Request, resp *restful.Response) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -84,6 +84,14 @@ type ObjectConfig struct {
 			HourStart    int  `default:"0" json:"hourStart"`
 			HourEnd      int  `default:"23" json:"hourEnd"`
 		} `json:"rescanSchedule"`
+		PreviewSchedule struct {
+			Enabled      bool `default:"false" json:"enabled"`
+			HourInterval int  `default:"2" json:"hourInterval"`
+			UseRange     bool `default:"false" json:"useRange"`
+			MinuteStart  int  `default:"0" json:"minuteStart"`
+			HourStart    int  `default:"0" json:"hourStart"`
+			HourEnd      int  `default:"23" json:"hourEnd"`
+		} `json:"previewSchedule"`
 	} `json:"cron"`
 }
 

--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -67,7 +67,7 @@ func generatePreviewCron() {
 		if !config.Config.Cron.PreviewSchedule.UseRange {
 			tasks.GeneratePreviews(nil)
 		} else {
-			endTime := calcEndTime(config.Config.Cron.PreviewSchedule.HourStart, config.Config.Cron.PreviewSchedule.HourEnd)
+			endTime := calcEndTime(config.Config.Cron.PreviewSchedule.HourStart, config.Config.Cron.PreviewSchedule.HourEnd, config.Config.Cron.PreviewSchedule.MinuteStart)
 			log.Infof("Preview Generation will stop at %v", endTime)
 			tasks.GeneratePreviews(&endTime)
 		}
@@ -103,16 +103,16 @@ func formatCronSchedule(schedule config.CronSchedule) string {
 	}
 	return fmt.Sprintf("%v %v * * *", schedule.MinuteStart, formattedHourSchedule)
 }
-func calcEndTime(startHour int, endHour int) time.Time {
+func calcEndTime(startHour int, endHour int, minuteStart int) time.Time {
 
 	dt := time.Now()
 	if startHour > endHour {
-		if dt.Hour() > startHour {
+		if dt.Hour() > endHour {
 			return time.Date(dt.Year(), dt.Month(), dt.Day(), 23, 59, 0, 0, dt.Location())
 		} else {
-			return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, 59, 0, 0, dt.Location()).Add(time.Minute * -1)
+			return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, minuteStart, 0, 0, dt.Location())
 		}
 	} else {
-		return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, 0, 0, 0, dt.Location()).Add(time.Minute * -1)
+		return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, minuteStart, 0, 0, dt.Location())
 	}
 }

--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/xbapps/xbvr/pkg/config"
@@ -12,6 +13,7 @@ import (
 var cronInstance *cron.Cron
 var rescrapTask cron.EntryID
 var rescanTask cron.EntryID
+var previewTask cron.EntryID
 
 func SetupCron() {
 	cronInstance = cron.New()
@@ -25,12 +27,18 @@ func SetupCron() {
 		log.Println(fmt.Sprintf("Setup Rescan Task %v", formatCronSchedule(config.CronSchedule(config.Config.Cron.RescanSchedule))))
 		rescanTask, _ = cronInstance.AddFunc(formatCronSchedule(config.CronSchedule(config.Config.Cron.RescanSchedule)), rescanCron)
 	}
+	if config.Config.Cron.PreviewSchedule.Enabled {
+		log.Println(fmt.Sprintf("Setup Preview Generation Task %v", formatCronSchedule(config.CronSchedule(config.Config.Cron.PreviewSchedule))))
+		ps := formatCronSchedule(config.CronSchedule(config.Config.Cron.PreviewSchedule))
+		previewTask, _ = cronInstance.AddFunc(ps, generatePreviewCron)
+	}
 	cronInstance.Start()
 
 	go tasks.CalculateCacheSizes()
 
 	log.Println(fmt.Sprintf("Next Rescrape Task at %v", cronInstance.Entry(rescrapTask).Next))
 	log.Println(fmt.Sprintf("Next Rescan Task at %v", cronInstance.Entry(rescanTask).Next))
+	log.Println(fmt.Sprintf("Next Preview Generation Task at %v", cronInstance.Entry(previewTask).Next))
 }
 
 func scrapeCron() {
@@ -45,6 +53,26 @@ func rescanCron() {
 		tasks.RescanVolumes(-1)
 	}
 	log.Println(fmt.Sprintf("Next Rescan Task at %v", cronInstance.Entry(rescanTask).Next))
+}
+
+var previewGenerateInProgress = false
+
+func generatePreviewCron() {
+	if !session.HasActiveSession() || !previewGenerateInProgress {
+		previewGenerateInProgress = true
+		defer func() {
+			previewGenerateInProgress = false
+		}()
+
+		if !config.Config.Cron.PreviewSchedule.UseRange {
+			tasks.GeneratePreviews(nil)
+		} else {
+			endTime := calcEndTime(config.Config.Cron.PreviewSchedule.HourStart, config.Config.Cron.PreviewSchedule.HourEnd)
+			log.Infof("Preview Generation will stop at %v", endTime)
+			tasks.GeneratePreviews(&endTime)
+		}
+	}
+	log.Println(fmt.Sprintf("Next Preview Generation Task at %v", cronInstance.Entry(previewTask).Next))
 }
 func formatCronSchedule(schedule config.CronSchedule) string {
 	// 	this routine will format a crontab range description, https://crontab.guru is a good tool to decode the range description generated
@@ -74,4 +102,17 @@ func formatCronSchedule(schedule config.CronSchedule) string {
 		formattedHourSchedule = fmt.Sprintf("%v-%v%v", schedule.HourStart, schedule.HourEnd, hourInterval)
 	}
 	return fmt.Sprintf("%v %v * * *", schedule.MinuteStart, formattedHourSchedule)
+}
+func calcEndTime(startHour int, endHour int) time.Time {
+
+	dt := time.Now()
+	if startHour > endHour {
+		if dt.Hour() > startHour {
+			return time.Date(dt.Year(), dt.Month(), dt.Day(), 23, 59, 0, 0, dt.Location())
+		} else {
+			return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, 59, 0, 0, dt.Location()).Add(time.Minute * -1)
+		}
+	} else {
+		return time.Date(dt.Year(), dt.Month(), dt.Day(), endHour, 0, 0, 0, dt.Location()).Add(time.Minute * -1)
+	}
 }

--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func GeneratePreviews() {
+func GeneratePreviews(endTime *time.Time) {
 	if !models.CheckLock("previews") {
 		models.CreateLock("previews")
 		log.Infof("Generating previews")
@@ -28,6 +28,9 @@ func GeneratePreviews() {
 		for _, scene := range scenes {
 			files, _ := scene.GetFiles()
 			if len(files) > 0 {
+				if endTime != nil && time.Now().After(*endTime) {
+					return
+				}
 				i := 0
 				for i < len(files) && files[i].Exists() {
 					if files[i].Type == "video" {

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -107,5 +107,6 @@
   "Run this scraper": "Run this scraper",
   "Force update scenes": "Force update scenes",
   "JAVR scraper": "JAVR scraper",
+  "Preview Generation": "Preview Generation",
   "Go": "Go"
 }

--- a/ui/src/views/options/sections/Schedules.vue
+++ b/ui/src/views/options/sections/Schedules.vue
@@ -4,77 +4,122 @@
     <div class="content">
       <h3>{{$t("Task Schedules")}}</h3>
       <hr/>
+      <b-tabs v-model="activeTab" size="medium" type="is-boxed" style="margin-left: 0px" id="importexporttab">
+            <b-tab-item label="Rescrape"/>
+            <b-tab-item label="Rescan"/>
+            <b-tab-item label="Preview Generation"/>
+      </b-tabs>
       <div class="columns">
         <div class="column">
           <section>
-            <h4>{{$t("Scrape Sites")}}</h4>
-            <b-field>
-              <b-switch v-model="rescrapeEnabled">Enable schedule</b-switch>
-            </b-field>
-            <b-field v-if="rescrapeEnabled">
-              <b-slider v-model="rescrapeHourInterval" :min="1" :max="23" :step="1" ></b-slider>
-              <div class="column is-one-third" style="margin-left:.75em">{{`Run every ${this.rescrapeHourInterval} hour${this.rescrapeHourInterval > 1 ? 's': ''}`}}</div>
-            </b-field>
-            <b-field>
-              <b-switch v-if="rescrapeEnabled" v-model="useRescrapeTimeRange">Limit time of day</b-switch>
-            </b-field>
-            <div v-if="useRescrapeTimeRange && rescrapeEnabled">
+            <div v-if="activeTab == 0">
+              <h4>{{$t("Scrape Sites")}}</h4>
               <b-field>
-                <b-slider v-model="rescrapeTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescrapTo24Hours">
-                  <b-slider-tick :value="0">00:00</b-slider-tick>
-                  <b-slider-tick :value="6">06:00</b-slider-tick>
-                  <b-slider-tick :value="12">12:00</b-slider-tick>
-                  <b-slider-tick :value="18">18:00</b-slider-tick>
-                  <b-slider-tick :value="24">Midnight</b-slider-tick>
-                  <b-slider-tick :value="30">06:00</b-slider-tick>
-                  <b-slider-tick :value="36">12:00</b-slider-tick>
-                  <b-slider-tick :value="42">18:00</b-slider-tick>
-                  <b-slider-tick :value="48">00:00</b-slider-tick>
-                </b-slider>
-                <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescrapeTimeRange[0]]} - ${this.timeRange[this.rescrapeTimeRange[1]]}`}}</div>
+                <b-switch v-model="rescrapeEnabled">Enable schedule</b-switch>
+              </b-field>
+              <b-field v-if="rescrapeEnabled">
+                <b-slider v-model="rescrapeHourInterval" :min="1" :max="23" :step="1" ></b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{`Run every ${this.rescrapeHourInterval} hour${this.rescrapeHourInterval > 1 ? 's': ''}`}}</div>
               </b-field>
               <b-field>
-                <b-slider v-model="rescrapeMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
-                <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescrapeMinuteStart) }}</div>
+                <b-switch v-if="rescrapeEnabled" v-model="useRescrapeTimeRange">Limit time of day</b-switch>
               </b-field>
+              <div v-if="useRescrapeTimeRange && rescrapeEnabled">
+                <b-field>
+                  <b-slider v-model="rescrapeTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescrapTo24Hours">
+                    <b-slider-tick :value="0">00:00</b-slider-tick>
+                    <b-slider-tick :value="6">06:00</b-slider-tick>
+                    <b-slider-tick :value="12">12:00</b-slider-tick>
+                    <b-slider-tick :value="18">18:00</b-slider-tick>
+                    <b-slider-tick :value="24">Midnight</b-slider-tick>
+                    <b-slider-tick :value="30">06:00</b-slider-tick>
+                    <b-slider-tick :value="36">12:00</b-slider-tick>
+                    <b-slider-tick :value="42">18:00</b-slider-tick>
+                    <b-slider-tick :value="48">00:00</b-slider-tick>
+                  </b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescrapeTimeRange[0]]} - ${this.timeRange[this.rescrapeTimeRange[1]]}`}}</div>
+                </b-field>
+                <b-field>
+                  <b-slider v-model="rescrapeMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescrapeMinuteStart) }}</div>
+                </b-field>
+              </div>
+            </div>
+            <div v-if="activeTab == 1">            
+              <h4>{{$t("Rescan Folders")}}</h4>
+              <b-field>
+                <b-switch v-model="rescanEnabled">Enable schedule</b-switch>
+              </b-field>
+              <b-field v-if="rescanEnabled">
+                <b-slider v-model="rescanHourInterval" :min="1" :max="23" :step="1" ></b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{`Run every ${this.rescanHourInterval} hour${this.rescanHourInterval > 1 ? 's': ''}`}}</div>
+              </b-field>
+              <b-field>
+                <b-switch v-if="rescanEnabled" v-model="useRescanTimeRange">Limit time of day</b-switch>
+              </b-field>
+              <div v-if="useRescanTimeRange && rescanEnabled">
+                <b-field>
+                  <b-slider v-model="rescanTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescanTo24Hours">
+                    <b-slider-tick :value="0">00:00</b-slider-tick>
+                    <b-slider-tick :value="6">06:00</b-slider-tick>
+                    <b-slider-tick :value="12">12:00</b-slider-tick>
+                    <b-slider-tick :value="18">18:00</b-slider-tick>
+                    <b-slider-tick :value="24">Midnight</b-slider-tick>
+                    <b-slider-tick :value="30">06:00</b-slider-tick>
+                    <b-slider-tick :value="36">12:00</b-slider-tick>
+                    <b-slider-tick :value="42">18:00</b-slider-tick>
+                    <b-slider-tick :value="48">00:00</b-slider-tick>
+                  </b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescanTimeRange[0]]} - ${this.timeRange[this.rescanTimeRange[1]]}`}}</div>
+                </b-field>
+                <b-field>
+                  <b-slider v-model="rescanMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescanMinuteStart) }}</div>
+                </b-field>
+              </div>
+            </div>
+           <div v-if="activeTab == 2">            
+              <b-field>
+                <b-switch v-model="previewEnabled">Enable schedule</b-switch>
+              </b-field>
+              <b-field v-if="previewEnabled">
+                <b-slider v-model="previewHourInterval" :min="1" :max="23" :step="1" ></b-slider>
+                <div class="column is-one-third" style="margin-left:.75em">{{`Run every ${this.previewHourInterval} hour${this.previewHourInterval > 1 ? 's': ''}`}}</div>
+              </b-field>
+              <b-field>
+                <b-switch v-if="previewEnabled" v-model="usePreviewTimeRange">Limit time of day</b-switch>
+              </b-field>
+              <div v-if="usePreviewTimeRange && previewEnabled">
+                <b-field>
+                  <b-slider v-model="previewTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictPreviewTo24Hours">
+                    <b-slider-tick :value="0">00:00</b-slider-tick>
+                    <b-slider-tick :value="6">06:00</b-slider-tick>
+                    <b-slider-tick :value="12">12:00</b-slider-tick>
+                    <b-slider-tick :value="18">18:00</b-slider-tick>
+                    <b-slider-tick :value="24">Midnight</b-slider-tick>
+                    <b-slider-tick :value="30">06:00</b-slider-tick>
+                    <b-slider-tick :value="36">12:00</b-slider-tick>
+                    <b-slider-tick :value="42">18:00</b-slider-tick>
+                    <b-slider-tick :value="48">00:00</b-slider-tick>
+                  </b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.previewTimeRange[0]]} - ${this.timeRange[this.previewTimeRange[1]]}`}}</div>
+                </b-field>
+                <b-field>
+                  <b-slider v-model="previewMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(previewMinuteStart) }}</div>
+                </b-field>
+                <p>
+                  Preview Generation of a scene will not start after the Time Window Ends
+                </p>
+              </div>
+                <p>
+                  BETA NOTE: Please note this is CPU-heavy process, if approriate limit the Time of Day the task runs                  
+                </p>                  
             </div>
             <hr/>
-          
-            <h4>{{$t("Rescan Folders")}}</h4>
-            <b-field>
-              <b-switch v-model="rescanEnabled">Enable schedule</b-switch>
-            </b-field>
-            <b-field v-if="rescanEnabled">
-               <b-slider v-model="rescanHourInterval" :min="1" :max="23" :step="1" ></b-slider>
-               <div class="column is-one-third" style="margin-left:.75em">{{`Run every ${this.rescanHourInterval} hour${this.rescanHourInterval > 1 ? 's': ''}`}}</div>
-            </b-field>
-            <b-field>
-              <b-switch v-if="rescrapeEnabled" v-model="useRescanTimeRange">Limit time of day</b-switch>
-            </b-field>
-            <div v-if="useRescanTimeRange && rescanEnabled">
-              <b-field>
-                <b-slider v-model="rescanTimeRange" :min="0" :max="48" :step="1" :custom-formatter="val => timeRange[val]" @input="restrictRescanTo24Hours">
-                  <b-slider-tick :value="0">00:00</b-slider-tick>
-                  <b-slider-tick :value="6">06:00</b-slider-tick>
-                  <b-slider-tick :value="12">12:00</b-slider-tick>
-                  <b-slider-tick :value="18">18:00</b-slider-tick>
-                  <b-slider-tick :value="24">Midnight</b-slider-tick>
-                  <b-slider-tick :value="30">06:00</b-slider-tick>
-                  <b-slider-tick :value="36">12:00</b-slider-tick>
-                  <b-slider-tick :value="42">18:00</b-slider-tick>
-                  <b-slider-tick :value="48">00:00</b-slider-tick>
-                </b-slider>
-                <div class="column is-one-third" style="margin-left:.75em">{{`${this.timeRange[this.rescanTimeRange[0]]} - ${this.timeRange[this.rescanTimeRange[1]]}`}}</div>
+              <b-field grouped>
+                <b-button type="is-primary" @click="saveSettings" style="margin-right:1em">Save settings</b-button>
               </b-field>
-              <b-field>
-                <b-slider v-model="rescanMinuteStart" :min="0" :max="60" :step="1" ></b-slider>
-                <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescanMinuteStart) }}</div>
-              </b-field>
-            </div>
-            <hr/>
-            <b-field grouped>
-              <b-button type="is-primary" @click="saveSettings" style="margin-right:1em">Save settings</b-button>
-            </b-field>
           </section>
           <hr/>
           <section>
@@ -97,6 +142,7 @@ export default {
   data () {
     return {
       isLoading: true,
+      activeTab: 0,
       rescrapeEnabled: true,
       rescanEnabled: true,
       rescrapeTimeRange: [0, 23],
@@ -109,6 +155,12 @@ export default {
       rescrapeMinuteStart: 0,
       rescanMinuteStart: 0,
       rescanHourInterval: 0,
+      previewEnabled: false,
+      previewTimeRange:[0,23],
+      previewHourInterval: 0,
+      previewMinuteStart: 0,
+      lastPreviewTimeRange: [0,23],
+      usePreviewTimeRange: false,      
       timeRange: ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
         '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00',
         '00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
@@ -129,21 +181,25 @@ export default {
       this.rescanTimeRange = this.restrictTo24Hours(this.rescanTimeRange, this.lastrescanTimeRange)
       this.lastrescanTimeRange = this.rescanTimeRange
     },
-    restrictTo24Hours (rescrapeTimeRange, lastTimeRange) {
+    restrictPreviewTo24Hours () {
+      this.previewTimeRange = this.restrictTo24Hours(this.previewTimeRange, this.lastPreviewTimeRange)
+      this.lastPreviewTimeRange = this.previewTimeRange
+    },
+    restrictTo24Hours (timeRange, lastTimeRange) {
       // check the first time is not in the second 24 hours, no need, should be in the first 24 hours
-      if (rescrapeTimeRange[0] > 23) {
-        rescrapeTimeRange[0] = 23
-        rescrapeTimeRange = [rescrapeTimeRange[0], rescrapeTimeRange[1]]
+      if (timeRange[0] > 23) {
+        timeRange[0] = 23
+        timeRange = [timeRange[0], timeRange[1]]
       }
       // check they are not trying to select more than a 24 hour range
-      if ((rescrapeTimeRange[1] - rescrapeTimeRange[0]) > 23 ) {
-        if (rescrapeTimeRange[0] === lastTimeRange[0] || rescrapeTimeRange[0] === lastTimeRange[1]) {
-          rescrapeTimeRange = [rescrapeTimeRange[1] - 23, rescrapeTimeRange[1]]
+      if ((timeRange[1] - timeRange[0]) > 23 ) {
+        if (timeRange[0] === lastTimeRange[0] || timeRange[0] === lastTimeRange[1]) {
+          timeRange = [timeRange[1] - 23, timeRange[1]]
         } else {
-          rescrapeTimeRange = [rescrapeTimeRange[0], rescrapeTimeRange[0] + 23]
+          timeRange = [timeRange[0], timeRange[0] + 23]
         }
       }
-      return rescrapeTimeRange
+      return timeRange
     },
     async loadState () {
       this.isLoading = true
@@ -158,6 +214,10 @@ export default {
           this.rescanHourInterval = data.config.cron.rescanSchedule.hourInterval
           this.useRescanTimeRange = data.config.cron.rescanSchedule.useRange
           this.rescanMinuteStart = data.config.cron.rescanSchedule.minuteStart
+          this.previewEnabled = data.config.cron.previewSchedule.enabled
+          this.previewHourInterval = data.config.cron.previewSchedule.hourInterval
+          this.usePreviewTimeRange = data.config.cron.previewSchedule.useRange
+          this.previewMinuteStart = data.config.cron.previewSchedule.minuteStart
           if (data.config.cron.rescrapeSchedule.hourStart > data.config.cron.rescrapeSchedule.hourEnd) {
             this.rescrapeTimeRange = [data.config.cron.rescrapeSchedule.hourStart, data.config.cron.rescrapeSchedule.hourEnd + 24]
           } else {
@@ -167,6 +227,11 @@ export default {
             this.rescanTimeRange = [data.config.cron.rescanSchedule.hourStart, data.config.cron.rescanSchedule.hourEnd + 24]
           } else {
             this.rescanTimeRange = [data.config.cron.rescanSchedule.hourStart, data.config.cron.rescanSchedule.hourEnd]
+          }
+          if (data.config.cron.previewSchedule.hourStart > data.config.cron.previewSchedule.hourEnd) {
+            this.previewTimeRange = [data.config.cron.previewSchedule.hourStart, data.config.cron.previewSchedule.hourEnd + 24]
+          } else {
+            this.previewTimeRange = [data.config.cron.previewSchedule.hourStart, data.config.cron.previewSchedule.hourEnd]            
           }
           this.isLoading = false
         })
@@ -193,9 +258,15 @@ export default {
           rescanEnabled: this.rescanEnabled,
           rescanHourInterval: this.rescanHourInterval,
           rescanUseRange: this.useRescanTimeRange,
-          RescanMinuteStart: this.rescanMinuteStart,
+          rescanMinuteStart: this.rescanMinuteStart,
           rescanHourStart: this.rescanTimeRange[0],
-          rescanHourEnd: this.rescanTimeRange[1]
+          rescanHourEnd: this.rescanTimeRange[1],
+          previewEnabled: this.previewEnabled,
+          previewHourInterval: this.previewHourInterval,
+          previewUseRange: this.usePreviewTimeRange,
+          previewMinuteStart: this.previewMinuteStart,
+          previewHourStart: this.previewTimeRange[0],
+          previewHourEnd: this.previewTimeRange[1]
         }
       })
         .json()


### PR DESCRIPTION
Added the ability to schedule the running of Preview Generation.

Now that schedule tasks can have a start windows, users with XBVR running in low powered environments, can use the "Limit time of day" option to specify a period of low use to generate the Previews, so the resource intensive process is not running when they would normally use the system.  The schedule task "limit time" option usually just controls the time a job can start.  GeneratePreviews has been modified to stop generating Previews when the end of the time range for the schedule task is reached.