### PR TITLE
Updates via Heresphere API

### DIFF
--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -310,13 +310,17 @@ func (i FilesResource) removeFile(req *restful.Request, resp *restful.Response) 
 	if err != nil {
 		return
 	}
+	scene := removeFileByFileId(uint(fileId))
+	resp.WriteHeaderAndEntity(http.StatusOK, scene)
+}
+func removeFileByFileId(fileId uint) models.Scene {
 
 	var scene models.Scene
 	var file models.File
 	db, _ := models.GetDB()
 	defer db.Close()
 
-	err = db.Preload("Volume").Where(&models.File{ID: uint(fileId)}).First(&file).Error
+	err := db.Preload("Volume").Where(&models.File{ID: fileId}).First(&file).Error
 	if err == nil {
 
 		deleted := false
@@ -331,7 +335,7 @@ func (i FilesResource) removeFile(req *restful.Request, resp *restful.Response) 
 		case "putio":
 			id, err := strconv.ParseInt(file.Path, 10, 64)
 			if err != nil {
-				return
+				return scene
 			}
 			client := file.Volume.GetPutIOClient()
 			err = client.Files.Delete(context.Background(), id)
@@ -352,6 +356,5 @@ func (i FilesResource) removeFile(req *restful.Request, resp *restful.Response) 
 	} else {
 		log.Errorf("Error deleting file ", err)
 	}
-
-	resp.WriteHeaderAndEntity(http.StatusOK, scene)
+	return scene
 }

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -171,6 +171,12 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 		return
 	}
 
+	var requestData HereSphereAuthRequest
+	if err := json.NewDecoder(req.Request.Body).Decode(&requestData); err != nil {
+		log.Errorf("Error decoding heresphere api POST request: %v", err)
+		return
+	}
+
 	db, _ := models.GetDB()
 	defer db.Close()
 
@@ -212,6 +218,9 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 		DateAdded:            file.CreatedTime.Format("2006-01-02"),
 		DurationMilliseconds: uint(file.VideoDuration * 1000),
 		Media:                media,
+	}
+	if requestData.DeleteFiles != nil && config.Config.Interfaces.Heresphere.AllowFileDeletes {
+		removeFileByFileId(file.ID)
 	}
 
 	resp.WriteHeaderAndEntity(http.StatusOK, video)

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -57,13 +57,16 @@ type RequestSaveOptionsDLNA struct {
 }
 
 type RequestSaveOptionsDeoVR struct {
-	Enabled        bool   `json:"enabled"`
-	AuthEnabled    bool   `json:"auth_enabled"`
-	Username       string `json:"username"`
-	Password       string `json:"password"`
-	RemoteEnabled  bool   `json:"remote_enabled"`
-	TrackWatchTime bool   `json:"track_watch_time"`
-	RenderHeatmaps bool   `json:"render_heatmaps"`
+	Enabled              bool   `json:"enabled"`
+	AuthEnabled          bool   `json:"auth_enabled"`
+	Username             string `json:"username"`
+	Password             string `json:"password"`
+	RemoteEnabled        bool   `json:"remote_enabled"`
+	TrackWatchTime       bool   `json:"track_watch_time"`
+	RenderHeatmaps       bool   `json:"render_heatmaps"`
+	AllowFileDeletes     bool   `json:"allow_file_deletes"`
+	AllowRatingUpdates   bool   `json:"allow_rating_updates"`
+	AllowFavoriteUpdates bool   `json:"allow_favorite_updates"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -284,6 +287,9 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.DeoVR.RemoteEnabled = r.RemoteEnabled
 	config.Config.Interfaces.DeoVR.TrackWatchTime = r.TrackWatchTime
 	config.Config.Interfaces.DeoVR.Username = r.Username
+	config.Config.Interfaces.Heresphere.AllowFileDeletes = r.AllowFileDeletes
+	config.Config.Interfaces.Heresphere.AllowRatingUpdates = r.AllowRatingUpdates
+	config.Config.Interfaces.Heresphere.AllowFavoriteUpdates = r.AllowFavoriteUpdates
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -69,6 +69,8 @@ type RequestSaveOptionsDeoVR struct {
 	AllowRatingUpdates   bool   `json:"allow_rating_updates"`
 	AllowFavoriteUpdates bool   `json:"allow_favorite_updates"`
 	AllowHspData         bool   `json:"allow_hsp_data"`
+	AllowTagUpdates      bool   `json:"allow_tag_updates"`
+	AllowCuepointUpdates bool   `json:"allow_cuepoint_updates"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -294,6 +296,8 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.Heresphere.AllowRatingUpdates = r.AllowRatingUpdates
 	config.Config.Interfaces.Heresphere.AllowFavoriteUpdates = r.AllowFavoriteUpdates
 	config.Config.Interfaces.Heresphere.AllowHspData = r.AllowHspData
+	config.Config.Interfaces.Heresphere.AllowTagUpdates = r.AllowTagUpdates
+	config.Config.Interfaces.Heresphere.AllowCuepointUpdates = r.AllowCuepointUpdates
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -58,19 +58,20 @@ type RequestSaveOptionsDLNA struct {
 }
 
 type RequestSaveOptionsDeoVR struct {
-	Enabled              bool   `json:"enabled"`
-	AuthEnabled          bool   `json:"auth_enabled"`
-	Username             string `json:"username"`
-	Password             string `json:"password"`
-	RemoteEnabled        bool   `json:"remote_enabled"`
-	TrackWatchTime       bool   `json:"track_watch_time"`
-	RenderHeatmaps       bool   `json:"render_heatmaps"`
-	AllowFileDeletes     bool   `json:"allow_file_deletes"`
-	AllowRatingUpdates   bool   `json:"allow_rating_updates"`
-	AllowFavoriteUpdates bool   `json:"allow_favorite_updates"`
-	AllowHspData         bool   `json:"allow_hsp_data"`
-	AllowTagUpdates      bool   `json:"allow_tag_updates"`
-	AllowCuepointUpdates bool   `json:"allow_cuepoint_updates"`
+	Enabled               bool   `json:"enabled"`
+	AuthEnabled           bool   `json:"auth_enabled"`
+	Username              string `json:"username"`
+	Password              string `json:"password"`
+	RemoteEnabled         bool   `json:"remote_enabled"`
+	TrackWatchTime        bool   `json:"track_watch_time"`
+	RenderHeatmaps        bool   `json:"render_heatmaps"`
+	AllowFileDeletes      bool   `json:"allow_file_deletes"`
+	AllowRatingUpdates    bool   `json:"allow_rating_updates"`
+	AllowFavoriteUpdates  bool   `json:"allow_favorite_updates"`
+	AllowHspData          bool   `json:"allow_hsp_data"`
+	AllowTagUpdates       bool   `json:"allow_tag_updates"`
+	AllowCuepointUpdates  bool   `json:"allow_cuepoint_updates"`
+	AllowWatchlistUpdates bool   `json:"allow_watchlist_updates"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -298,6 +299,7 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.Heresphere.AllowHspData = r.AllowHspData
 	config.Config.Interfaces.Heresphere.AllowTagUpdates = r.AllowTagUpdates
 	config.Config.Interfaces.Heresphere.AllowCuepointUpdates = r.AllowCuepointUpdates
+	config.Config.Interfaces.Heresphere.AllowWatchlistUpdates = r.AllowWatchlistUpdates
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -46,6 +46,7 @@ type RequestSaveOptionsWeb struct {
 	SceneWatched   bool   `json:"sceneWatched"`
 	SceneEdit      bool   `json:"sceneEdit"`
 	SceneCuepoint  bool   `json:"sceneCuepoint"`
+	ShowHspFile    bool   `json:"showHspFile"`
 	UpdateCheck    bool   `json:"updateCheck"`
 }
 
@@ -67,6 +68,7 @@ type RequestSaveOptionsDeoVR struct {
 	AllowFileDeletes     bool   `json:"allow_file_deletes"`
 	AllowRatingUpdates   bool   `json:"allow_rating_updates"`
 	AllowFavoriteUpdates bool   `json:"allow_favorite_updates"`
+	AllowHspData         bool   `json:"allow_hsp_data"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -267,6 +269,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.SceneWatched = r.SceneWatched
 	config.Config.Web.SceneEdit = r.SceneEdit
 	config.Config.Web.SceneCuepoint = r.SceneCuepoint
+	config.Config.Web.ShowHspFile = r.ShowHspFile
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.SaveConfig()
 
@@ -290,6 +293,7 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.Heresphere.AllowFileDeletes = r.AllowFileDeletes
 	config.Config.Interfaces.Heresphere.AllowRatingUpdates = r.AllowRatingUpdates
 	config.Config.Interfaces.Heresphere.AllowFavoriteUpdates = r.AllowFavoriteUpdates
+	config.Config.Interfaces.Heresphere.AllowHspData = r.AllowHspData
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,11 @@ type ObjectConfig struct {
 			Username       string `default:"" json:"username"`
 			Password       string `default:"" json:"password"`
 		} `json:"deovr"`
+		Heresphere struct {
+			AllowFileDeletes     bool `default:"false" json:"allow_file_deletes"`
+			AllowRatingUpdates   bool `default:"false" json:"allow_rating_updates"`
+			AllowFavoriteUpdates bool `default:"false" json:"allow_favorite_updates"`
+		} `json:"heresphere"`
 	} `json:"interfaces"`
 	Library struct {
 		Preview struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type ObjectConfig struct {
 		SceneWatched   bool   `default:"false" json:"sceneWatched"`
 		SceneEdit      bool   `default:"false" json:"sceneEdit"`
 		SceneCuepoint  bool   `default:"true" json:"sceneCuepoint"`
+		ShowHspFile    bool   `default:"true" json:"showHspFile"`
 		UpdateCheck    bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Vendor struct {
@@ -60,6 +61,7 @@ type ObjectConfig struct {
 			AllowFileDeletes     bool `default:"false" json:"allow_file_deletes"`
 			AllowRatingUpdates   bool `default:"false" json:"allow_rating_updates"`
 			AllowFavoriteUpdates bool `default:"false" json:"allow_favorite_updates"`
+			AllowHspData         bool `default:"false" json:"allow_hsp_data"`
 		} `json:"heresphere"`
 	} `json:"interfaces"`
 	Library struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,8 @@ type ObjectConfig struct {
 			AllowRatingUpdates   bool `default:"false" json:"allow_rating_updates"`
 			AllowFavoriteUpdates bool `default:"false" json:"allow_favorite_updates"`
 			AllowHspData         bool `default:"false" json:"allow_hsp_data"`
+			AllowTagUpdates      bool `default:"false" json:"allow_tag_updates"`
+			AllowCuepointUpdates bool `default:"false" json:"allow_cuepoint_updates"`
 		} `json:"heresphere"`
 	} `json:"interfaces"`
 	Library struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,12 +58,13 @@ type ObjectConfig struct {
 			Password       string `default:"" json:"password"`
 		} `json:"deovr"`
 		Heresphere struct {
-			AllowFileDeletes     bool `default:"false" json:"allow_file_deletes"`
-			AllowRatingUpdates   bool `default:"false" json:"allow_rating_updates"`
-			AllowFavoriteUpdates bool `default:"false" json:"allow_favorite_updates"`
-			AllowHspData         bool `default:"false" json:"allow_hsp_data"`
-			AllowTagUpdates      bool `default:"false" json:"allow_tag_updates"`
-			AllowCuepointUpdates bool `default:"false" json:"allow_cuepoint_updates"`
+			AllowFileDeletes      bool `default:"false" json:"allow_file_deletes"`
+			AllowRatingUpdates    bool `default:"false" json:"allow_rating_updates"`
+			AllowFavoriteUpdates  bool `default:"false" json:"allow_favorite_updates"`
+			AllowHspData          bool `default:"false" json:"allow_hsp_data"`
+			AllowTagUpdates       bool `default:"false" json:"allow_tag_updates"`
+			AllowCuepointUpdates  bool `default:"false" json:"allow_cuepoint_updates"`
+			AllowWatchlistUpdates bool `default:"false" json:"allow_watchlist_updates"`
 		} `json:"heresphere"`
 	} `json:"interfaces"`
 	Library struct {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -18,6 +18,7 @@ type ObjectState struct {
 		SceneWatched   bool   `json:"sceneWatched"`
 		SceneEdit      bool   `json:"sceneEdit"`
 		SceneCuepoint  bool   `json:"sceneCuepoint"`
+		ShowHspFile    bool   `json:"showHspFile"`
 		UpdateCheck    bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -280,21 +280,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 		}
 
 		for _, path := range hspProcList {
-			var fl models.File
-			db.Where(&models.File{
-				Path:     filepath.Dir(path),
-				Filename: filepath.Base(path),
-				Type:     "hsp",
-			}).FirstOrCreate(&fl)
-
-			fStat, _ := os.Stat(path)
-			fTimes, _ := times.Stat(path)
-
-			fl.Size = fStat.Size()
-			fl.CreatedTime = fTimes.ModTime()
-			fl.UpdatedTime = fTimes.ModTime()
-			fl.VolumeID = vol.ID
-			fl.Save()
+			ScanLocalHspFile(path, vol.ID, 0)
 		}
 
 		vol.LastScan = time.Now()
@@ -395,4 +381,28 @@ func RefreshSceneStatuses() {
 	}
 
 	tlog.Infof("Scene status refresh complete")
+}
+func ScanLocalHspFile(path string, volID uint, sceneId uint) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var fl models.File
+	db.Where(&models.File{
+		Path:     filepath.Dir(path),
+		Filename: filepath.Base(path),
+		Type:     "hsp",
+	}).FirstOrCreate(&fl)
+
+	fStat, _ := os.Stat(path)
+	fTimes, _ := times.Stat(path)
+
+	fl.Size = fStat.Size()
+	fl.CreatedTime = fTimes.ModTime()
+	fl.UpdatedTime = fTimes.ModTime()
+	fl.VolumeID = volID
+	if sceneId > 0 {
+		fl.SceneID = sceneId
+	}
+	fl.Save()
+
 }

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -11,6 +11,11 @@ const state = {
     username: '',
     password: '',
     boundIp: []
+  },
+  heresphere: {
+    allow_file_deletes: false,
+    allow_rating_updates: false,
+    allow_favorite_updates: false
   }
 }
 
@@ -30,12 +35,15 @@ const actions = {
         state.deovr.username = data.config.interfaces.deovr.username
         state.deovr.password = data.config.interfaces.deovr.password
         state.deovr.boundIp = data.currentState.server.bound_ip
-        state.loading = false
+        state.heresphere.allow_file_deletes = data.config.interfaces.heresphere.allow_file_deletes
+        state.heresphere.allow_rating_updates = data.config.interfaces.heresphere.allow_rating_updates
+        state.heresphere.allow_favorite_updates = data.config.interfaces.heresphere.allow_favorite_updates
+        state.loading = false        
       })
   },
   async save ({ state }, enabled) {
     state.loading = true
-    ky.put('/api/options/interface/deovr', { json: { ...state.deovr } })
+    ky.put('/api/options/interface/deovr', { json: { ...state.deovr, ...state.heresphere } })
       .json()
       .then(data => {
         state.loading = false

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -16,6 +16,8 @@ const state = {
     allow_file_deletes: false,
     allow_rating_updates: false,
     allow_favorite_updates: false,
+    allow_tag_updates: false,
+    allow_cuepoint_updates: false,
     allow_hsp_data: false
   }
 }
@@ -39,6 +41,8 @@ const actions = {
         state.heresphere.allow_file_deletes = data.config.interfaces.heresphere.allow_file_deletes
         state.heresphere.allow_rating_updates = data.config.interfaces.heresphere.allow_rating_updates
         state.heresphere.allow_favorite_updates = data.config.interfaces.heresphere.allow_favorite_updates
+        state.heresphere.allow_tag_updates = data.config.interfaces.heresphere.allow_tag_updates
+        state.heresphere.allow_cuepoint_updates = data.config.interfaces.heresphere.allow_cuepoint_updates
         state.heresphere.allow_hsp_data = data.config.interfaces.heresphere.allow_hsp_data
         state.loading = false        
       })

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -18,6 +18,7 @@ const state = {
     allow_favorite_updates: false,
     allow_tag_updates: false,
     allow_cuepoint_updates: false,
+    allow_watchlist_updates: false,
     allow_hsp_data: false
   }
 }
@@ -43,6 +44,7 @@ const actions = {
         state.heresphere.allow_favorite_updates = data.config.interfaces.heresphere.allow_favorite_updates
         state.heresphere.allow_tag_updates = data.config.interfaces.heresphere.allow_tag_updates
         state.heresphere.allow_cuepoint_updates = data.config.interfaces.heresphere.allow_cuepoint_updates
+        state.heresphere.allow_watchlist_updates = data.config.interfaces.heresphere.allow_watchlist_updates
         state.heresphere.allow_hsp_data = data.config.interfaces.heresphere.allow_hsp_data
         state.loading = false        
       })

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -15,7 +15,8 @@ const state = {
   heresphere: {
     allow_file_deletes: false,
     allow_rating_updates: false,
-    allow_favorite_updates: false
+    allow_favorite_updates: false,
+    allow_hsp_data: false
   }
 }
 
@@ -38,6 +39,7 @@ const actions = {
         state.heresphere.allow_file_deletes = data.config.interfaces.heresphere.allow_file_deletes
         state.heresphere.allow_rating_updates = data.config.interfaces.heresphere.allow_rating_updates
         state.heresphere.allow_favorite_updates = data.config.interfaces.heresphere.allow_favorite_updates
+        state.heresphere.allow_hsp_data = data.config.interfaces.heresphere.allow_hsp_data
         state.loading = false        
       })
   },

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -9,6 +9,7 @@ const state = {
     sceneWatched: false,
     sceneEdit: false,
     sceneCuepoint: true,
+    showHspFile: true,
     updateCheck: true
   }
 }
@@ -27,6 +28,7 @@ const actions = {
         state.web.sceneWatched = data.config.web.sceneWatched
         state.web.sceneEdit = data.config.web.sceneEdit
         state.web.sceneCuepoint = data.config.web.sceneCuepoint
+        state.web.showHspFile = data.config.web.showHspFile
         state.web.updateCheck = data.config.web.updateCheck
         state.loading = false
       })
@@ -42,6 +44,7 @@ const actions = {
         state.web.sceneWatched = data.sceneWatched
         state.web.sceneEdit = data.sceneEdit
         state.web.sceneCuepoint = data.sceneCuepoint
+        state.web.showHspFile = data.showHspFile
         state.web.updateCheck = data.updateCheck
         state.loading = false
       })

--- a/ui/src/views/options/Options.vue
+++ b/ui/src/views/options/Options.vue
@@ -22,7 +22,7 @@
                          @click="setActive('data-import-export')"/>
           </b-menu-list>
           <b-menu-list :label="$t('Interfaces')">
-            <b-menu-item :label="$t('DeoVR')" :active="active==='interface_deovr'" @click="setActive('interface_deovr')"/>
+            <b-menu-item :label="$t('Players')" :active="active==='interface_deovr'" @click="setActive('interface_deovr')"/>
             <b-menu-item :label="$t('DLNA')" :active="active==='interface_dlna'" @click="setActive('interface_dlna')"/>
             <b-menu-item :label="$t('Web UI')" :active="active==='interface_web'" @click="setActive('interface_web')"/>
           </b-menu-list>

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="container">
     <b-loading :is-full-page="false" :active.sync="isLoading"></b-loading>
-    <div class="content">
-      <h3>{{ $t("DeoVR interface") }}</h3>
+    <b-tabs v-model="activeTab" size="medium" type="is-boxed" style="margin-left: 0px" id="playertab">
+      <b-tab-item label="Shared Settings"/>
+      <b-tab-item label="DeoVR"/>
+      <b-tab-item label="Heresphere"/>
+    </b-tabs>
+    <div class="content" v-if="activeTab == 0">
+      <h3>Shared Player Options</h3>
       <hr/>
       <div class="columns">
         <div class="column">
           <section>
-            <b-field label="DeoVR integration">
+            <b-field label="Player integration">
               <b-switch v-model="enabled">
                 Enabled
               </b-switch>
@@ -37,25 +42,7 @@
                   </b-switch>
                 </b-field>
                 <p>
-                  If you are using funscripts, you can add a heatmap to the thumbnails of scripted scenes in the DeoVR interface.
-                </p>
-              </div>
-              <hr/>
-              <div class="block">
-                <b-field label="Watch time tracking">
-                  <b-switch v-model="watchTimeTrackingEnabled">
-                    Enabled
-                  </b-switch>
-                </b-field>
-                <b-field label="Remote mode">
-                  <b-switch v-model="remoteEnabled" :disabled="watchTimeTrackingEnabled === false">
-                    Enabled
-                  </b-switch>
-                </b-field>
-                <p>
-                  To use remote mode, which enables more precise watch time tracking, you need to turn it on in DeoVR
-                  settings too - see <a href="https://deovr.com/doc#remote-control" target="_blank" rel="noreferrer">
-                  instructions in DeoVR documentation</a>.
+                  If you are using funscripts, you can add a heatmap to the thumbnails of scripted scenes in the Player interface.
                 </p>
               </div>
             </div>
@@ -63,7 +50,7 @@
         </div>
         <div class="column content">
           <p>
-            {{ $t("DeoVR interface is available at following URLs:") }}
+            {{ $t("Player interface is available at following URLs:") }}
           </p>
           <div>
             <h4 v-for="(addr, idx) in boundIp" :key="'ip' + idx">{{ addr }}</h4>
@@ -75,7 +62,51 @@
           </p>
         </div>
       </div>
-
+    </div>
+    <div class="content" v-if="activeTab == 1">
+      <h3>DeoVR interface</h3>
+      <hr/>
+      <div class="block">
+          <b-field label="Watch time tracking">
+            <b-switch v-model="watchTimeTrackingEnabled">
+              Enabled
+            </b-switch>
+          </b-field>
+          <b-field label="Remote mode">
+            <b-switch v-model="remoteEnabled" :disabled="watchTimeTrackingEnabled === false">
+              Enabled
+            </b-switch>
+          </b-field>
+          <p>
+            To use remote mode, which enables more precise watch time tracking, you need to turn it on in DeoVR
+            settings too - see <a href="https://deovr.com/doc#remote-control" target="_blank" rel="noreferrer">
+            instructions in DeoVR documentation</a>.
+          </p>
+        </div>
+    </div>
+    <div class="content" v-if="activeTab == 2">
+      <h3>Heresphere interface</h3>
+      <hr/>
+          <b-tooltip
+            label="WANRING: file deletes from Heresphere are permanent. ALL files associated with a scene will be deleted"
+            size="is-large" type="is-danger" multilined :delay="250" >
+            <b-field label="Allow File Deletion">
+              <b-switch v-model="allowFileDeletions">
+                Enabled
+              </b-switch>
+            </b-field>
+          </b-tooltip>
+          <b-field label="Allow Ratings Updates">
+            <b-switch v-model="allowRatingUpdates">
+              Enabled
+            </b-switch>
+          </b-field>
+          <b-field label="Allow Favorite Updates">
+            <b-switch v-model="allowFavouriteUpdates">
+              Enabled
+            </b-switch>
+          </b-field>
+      </div>
       <b-field>
         <b-button type="is-primary" @click="save">Save and apply changes</b-button>
       </b-field>
@@ -88,6 +119,11 @@ export default {
   name: 'InterfaceDeoVR',
   mounted () {
     this.$store.dispatch('optionsDeoVR/load')
+  },
+  data () {
+    return {
+      activeTab: 0
+    }
   },
   methods: {
     save () {
@@ -165,6 +201,30 @@ export default {
     boundIp: {
       get () {
         return this.$store.state.optionsDeoVR.deovr.boundIp
+      }
+    },        
+    allowFileDeletions: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_file_deletes
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_file_deletes= value
+      }
+    },
+    allowRatingUpdates: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_rating_updates
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_rating_updates = value
+      }
+    },
+    allowFavouriteUpdates: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_favorite_updates
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_favorite_updates = value
       }
     },
     isLoading: function () {

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -116,6 +116,15 @@
               Enabled
             </b-switch>
           </b-field>
+          <b-tooltip
+            label="Add or delete the Feature:watchlist tag to toggle the Watchlist flag in XBVR"
+            size="is-large" type="is-primary" multilined :delay="250" >
+            <b-field label="Allow Watchlist Updates">
+              <b-switch v-model="allowWatchlistUpdates">
+                Enabled
+              </b-switch>
+            </b-field>
+          </b-tooltip>
           <b-field label="Allow Saving Hsp Files">
             <b-switch v-model="allowHspData">
               Enabled
@@ -256,6 +265,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.heresphere.allow_cuepoint_updates = value
+      }
+    },
+    allowWatchlistUpdates: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_watchlist_updates
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_watchlist_updates = value
       }
     },
     allowHspData: {

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -106,6 +106,16 @@
               Enabled
             </b-switch>
           </b-field>
+          <b-field label="Allow Tag Updates">
+            <b-switch v-model="allowTagUpdates">
+              Enabled
+            </b-switch>
+          </b-field>
+          <b-field label="Allow Cuepoint Updates">
+            <b-switch v-model="allowCuepointUpdates">
+              Enabled
+            </b-switch>
+          </b-field>
           <b-field label="Allow Saving Hsp Files">
             <b-switch v-model="allowHspData">
               Enabled
@@ -230,6 +240,22 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.heresphere.allow_favorite_updates = value
+      }
+    },
+    allowTagUpdates: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_tag_updates
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_tag_updates = value
+      }
+    },
+    allowCuepointUpdates: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_cuepoint_updates
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_cuepoint_updates = value
       }
     },
     allowHspData: {

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -106,6 +106,11 @@
               Enabled
             </b-switch>
           </b-field>
+          <b-field label="Allow Saving Hsp Files">
+            <b-switch v-model="allowHspData">
+              Enabled
+            </b-switch>
+          </b-field>
       </div>
       <b-field>
         <b-button type="is-primary" @click="save">Save and apply changes</b-button>
@@ -225,6 +230,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.heresphere.allow_favorite_updates = value
+      }
+    },
+    allowHspData: {
+      get () {
+        return this.$store.state.optionsDeoVR.heresphere.allow_hsp_data
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.allow_hsp_data= value
       }
     },
     isLoading: function () {

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -45,6 +45,11 @@
                 show Cuepoints  button
               </b-switch>
             </b-field>
+            <b-field>
+              <b-switch v-model="hspFile" type="is-dark">
+                show Hsp File button
+              </b-switch>
+            </b-field>
 
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
@@ -128,6 +133,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.sceneCuepoint = value
+      }
+    },
+    hspFile: {
+      get () {
+        return this.$store.state.optionsWeb.web.showHspFile
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showHspFile = value
       }
     },
     isLoading: function () {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -20,6 +20,10 @@
               <b-icon pack="mdi" icon="pulse" size="is-small"/>
               <span v-if="scriptFilesCount > 1">{{scriptFilesCount}}</span>
             </b-tag>
+            <b-tag type="is-info" v-if="hspFilesCount > 0 && this.$store.state.optionsWeb.web.showHspFile">
+              <b-icon pack="mdi" icon="safety-goggles" size="is-small"/>
+              <span v-if="hspFilesCount > 1">{{hspFilesCount}}</span>
+            </b-tag>
             <b-tag type="is-info" v-if="item.cuepoints.length>0 && this.$store.state.optionsWeb.web.sceneCuepoint">
               <b-icon pack="mdi" icon="skip-next-outline" size="is-small"/>
               <span v-if="item.cuepoints.length > 1">{{item.cuepoints.length}}</span>
@@ -83,6 +87,15 @@ export default {
       let count = 0
       this.item.file.forEach(obj => {
         if (obj.type === 'script') {
+          count = count + 1
+        }
+      })
+      return count
+    },
+    hspFilesCount () {
+      let count = 0
+      this.item.file.forEach(obj => {
+        if (obj.type === 'hsp') {
           count = count + 1
         }
       })


### PR DESCRIPTION
This change enables updates to Ratings, Favorites, Tags and Cuepoints via the  Heresphere Api.  Uses can also save HSP files which will automatically be associated with the scene.  Users can also delete all files associated to a scene, i.e., video, scripts & HSP files.

The HSP file will be saved in the same location as the first video file with the same base filename and a .hsp extension.

After upgrading XBVR, by default, no updates from Heresphere are accepted, so the Heresphere API won't just start updating XBVR data.  The user must go into Options/Player (use to be Deovr)/Heresphere and enable what updates they wish to allow.

Tags and Cuepoints are different between XBVR & Heresphere.  
- Tags stored in XBVR are mapped to Heresphere as "Category:..."in Heresphere.  Only Category prefixed tags in Heresphere will be synced back to XBVR.  

- Cuepoints are timestamped Tags in Heresphere, i.e., they have a start and end time not covering the whole scene.  Differences with syncing back cuepoints to XBVR are 

  - XBVR Cuepoints do not have an end time, their End Time is the start of the next tag.  Therefore, if a user creates a gap and syncs back to XBVR, that gap will disappear.  
  - Heresphere allows for multiple tracks of timestamped tags.  XBVR does not.  The first track with Timestamped tags (cuepoints) will be synced back to XBVR as cuepoints. If timestamped tags on subsequent tracks have the same start time as a tag on the first track (within 5 seconds), then the descriptions will be combined in the XBVR Tag.  Note:  PR #938 will split the XBVR cuepoint descriptions back into multiple tracks when the scene details are requested by Heresphere. If it is not implemented, they will appear as a single track.

Assuming #938 is accepted as well, there will be a merge conflict.  If one is updated to the main branch I can resolve the conflict and update the other PR.