### PR TITLE
Actor Aka Groups

### DIFF
--- a/pkg/api/akas.go
+++ b/pkg/api/akas.go
@@ -1,0 +1,385 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful"
+	restfulspec "github.com/emicklei/go-restful-openapi"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+type RequestDeleteAka struct {
+	AkaID uint   `json:"aka_id"`
+	Name  string `json:"name"`
+}
+
+type RequestEditAkaMembers struct {
+	Actors []string `json:"actorList"`
+}
+
+type ResponseGetAkas struct {
+	Results int          `json:"results"`
+	Scenes  []models.Aka `json:"akas"`
+}
+
+type ResponseAka struct {
+	Status string     `json:"status"`
+	Aka    models.Aka `json:"akas"`
+}
+type ResponseAkas struct {
+	Error error        `json:"error"`
+	Akas  []models.Aka `json:"akas"`
+}
+
+type AkaResource struct{}
+
+func (i AkaResource) WebService() *restful.WebService {
+	tags := []string{"Aka"}
+
+	ws := new(restful.WebService)
+
+	ws.Path("/api/aka").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	ws.Route(ws.GET("/list").To(i.getAkas).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(ResponseGetScenes{}))
+
+	ws.Route(ws.POST("/create").To(i.createAkaGroup).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+
+	ws.Route(ws.POST("/delete").To(i.deleteAka).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
+	ws.Route(ws.GET("/{aka-id}").To(i.getAka).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+
+	ws.Route(ws.POST("/add").To(i.addToAkaGroup).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+
+	ws.Route(ws.POST("/remove").To(i.removeFromAkaGroup).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+	return ws
+}
+
+func (i AkaResource) createAkaGroup(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	//Get request data
+	var r RequestEditAkaMembers
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	//Construct aka record
+	var aka models.Aka
+	var akaActorList []models.Actor
+	var tmpActor models.Actor
+	var akaActor models.Actor
+	var names []string
+	var errors []string
+	ret := http.StatusOK
+
+	actorCnt := 0
+	for _, a := range r.Actors {
+		tmpActor.ID = 0
+		db.Where("name = ?", a).First(&tmpActor)
+		if tmpActor.ID != 0 {
+			// check if the actor is already in a group
+			cnt := 0
+			db.Model(&aka).
+				Joins("join actor_akas on actor_akas.aka_id =akas.id").
+				Where("actor_akas.actor_id  = ?", tmpActor.ID).Count(&cnt)
+			if cnt > 0 {
+				errors = append(errors, a+" already in aka group")
+			}
+			akaActorList = append(akaActorList, tmpActor)
+			names = append(names, a)
+			actorCnt++
+		} else {
+			errors = append(errors, a+" not found")
+			ret = http.StatusNotFound
+		}
+	}
+
+	if ret != http.StatusNotFound {
+		if actorCnt > 0 {
+			// create an actor to represent the aka group
+			akaActor.ID = 0
+			akaActor.Name = "aka:" + strings.Join(names, ",")
+			akaActor.Save()
+
+			aka.ID = 0
+			aka.AkaActor = akaActor
+			aka.Akas = akaActorList
+			aka.Name = aka.AkaNameSortedAlphabetcally()
+			aka.Save()
+		}
+	} else {
+		createResp := &ResponseAka{
+			Status: strings.Join(errors, ","),
+			Aka:    aka,
+		}
+		RefreshAka(&aka)
+		resp.WriteHeaderAndEntity(ret, createResp)
+		return
+	}
+
+	RefreshAka(&aka)
+	createResp := &ResponseAka{
+		Status: strings.Join(errors, ","),
+		Aka:    aka,
+	}
+
+	resp.WriteHeaderAndEntity(http.StatusOK, createResp)
+}
+
+func (i AkaResource) deleteAka(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var r RequestDeleteAka
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	var aka models.Aka
+	if r.AkaID != 0 {
+		err = db.First(&aka, r.AkaID).Error
+	} else {
+		// find on the aka name
+		err = db.Where(&models.Aka{Name: r.Name}).First(&aka).Error
+		if err != nil {
+			// find on the aka actor name
+			var actor models.Actor
+			db.Where("name = ?", r.Name).First(&actor)
+			err = db.Where("aka_actor_id = ?", actor.ID).First(&aka).Error
+		}
+	}
+
+	if err != nil {
+		log.Error(err)
+		resp.WriteHeaderAndEntity(http.StatusNotFound, nil)
+		return
+	}
+
+	db.Delete(&aka)
+	defer resp.WriteHeaderAndEntity(http.StatusOK, aka)
+
+	var akaActor models.Actor
+	akaActor.ID = aka.AkaActorId
+	db.Model(&akaActor).Association("Scenes").Clear() // delete scene links with aka
+	db.Delete(&akaActor)                              // delete aka actor
+	aka.UpdateAkaSceneCastRecords()
+}
+
+func (i AkaResource) getAkas(req *restful.Request, resp *restful.Response) {
+
+	var akas []models.Aka
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	db.Preload("Actors").Find(&akas)
+	resp.WriteHeaderAndEntity(http.StatusOK, akas)
+}
+
+func (i AkaResource) getAka(req *restful.Request, resp *restful.Response) {
+	sceneId, err := strconv.Atoi(req.PathParameter("aka-id"))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	var aka models.Aka
+	db, _ := models.GetDB()
+	err = aka.GetIfExistByPK(uint(sceneId))
+	db.Close()
+
+	resp.WriteHeaderAndEntity(http.StatusOK, aka)
+}
+
+func (i AkaResource) removeFromAkaGroup(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	//Get request data
+	var r RequestEditAkaMembers
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	var aka models.Aka
+	var errors []string
+	ret := http.StatusOK
+
+	akaActorName := ""
+	for _, a := range r.Actors {
+		if strings.HasPrefix(a, "aka:") {
+			akaActorName = a
+		}
+	}
+	var actor models.Actor
+	db.Where("name = ?", akaActorName).First(&actor)
+	db.Where("aka_actor_id = ?", actor.ID).Preload("AkaActor").Preload("Akas").First(&aka)
+
+	// check we aren't going to remove everyone
+	remainActorCount := len(aka.Akas)
+	for _, actor := range r.Actors {
+		if !strings.HasPrefix(actor, "aka:") {
+			for _, rec := range aka.Akas {
+				if rec.Name == actor {
+					remainActorCount--
+				}
+			}
+		}
+	}
+	if remainActorCount < 2 {
+		RefreshAka(&aka)
+		createResp := &ResponseAka{
+			Status: "A Group needs at least 2 actors. Delete the group instead",
+			Aka:    aka,
+		}
+		resp.WriteHeaderAndEntity(ret, createResp)
+		return
+	}
+
+	for _, actor := range r.Actors {
+		if !strings.HasPrefix(actor, "aka:") {
+			found := false
+			for idx, rec := range aka.Akas {
+				if rec.Name == actor {
+					db.Model(&aka).Association("Akas").Delete(&aka.Akas[idx])
+					found = true
+				}
+			}
+			if !found {
+				errors = append(errors, actor+" not found in group")
+			}
+		}
+	}
+
+	aka.Name = aka.AkaNameSortedAlphabetcally()
+	aka.Save()
+
+	RefreshAka(&aka)
+	if len(errors) > 0 {
+		createResp := &ResponseAka{
+			Status: strings.Join(errors, ","),
+			Aka:    aka,
+		}
+		resp.WriteHeaderAndEntity(ret, createResp)
+		return
+	}
+
+	createResp := &ResponseAka{
+		Aka: aka,
+	}
+
+	resp.WriteHeaderAndEntity(http.StatusOK, createResp)
+
+}
+
+func (i AkaResource) addToAkaGroup(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	//Get request data
+	var r RequestEditAkaMembers
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	//Construct aka record
+	var aka models.Aka
+	var tmpActor models.Actor
+	var errors []string
+	ret := http.StatusOK
+
+	akaActorName := ""
+	actorCnt := 0
+	for _, a := range r.Actors {
+		if strings.HasPrefix(a, "aka:") {
+			akaActorName = a
+		}
+	}
+	var actor models.Actor
+	db.Where("name = ?", akaActorName).First(&actor)
+	db.Where("aka_actor_id = ?", actor.ID).Preload("AkaActor").Preload("Akas").First(&aka)
+
+	for _, a := range r.Actors {
+		if !strings.HasPrefix(a, "aka:") {
+
+			tmpActor.ID = 0
+			db.Where("name = ?", a).First(&tmpActor)
+			if tmpActor.ID != 0 {
+				// check if the actor is already this group
+				cnt := 0
+				db.Model(&aka).
+					Joins("join actor_akas on actor_akas.aka_id = akas.id").
+					Where("actor_akas.actor_id  = ?", tmpActor.ID).Count(&cnt)
+				if cnt > 0 {
+					errors = append(errors, a+" already in this group")
+				} else {
+					// check if the actor is already in another group
+					cnt = 0
+					db.Model(models.Aka{}).
+						Joins("join actor_akas on akas.id=actor_akas.aka_id").
+						Where("actor_akas.actor_id  = ?", tmpActor.ID).Count(&cnt)
+					if cnt > 0 {
+						errors = append(errors, a+" already in another group")
+					}
+					aka.Akas = append(aka.Akas, tmpActor)
+					actorCnt++
+
+				}
+			} else {
+				errors = append(errors, a+" not found")
+			}
+		}
+	}
+
+	if actorCnt > 0 {
+		aka.Name = aka.AkaNameSortedAlphabetcally()
+		aka.Save()
+	}
+
+	RefreshAka(&aka)
+	if len(errors) > 0 {
+		createResp := &ResponseAka{
+			Status: strings.Join(errors, ","),
+			Aka:    aka,
+		}
+		resp.WriteHeaderAndEntity(ret, createResp)
+		return
+	}
+
+	createResp := &ResponseAka{
+		Aka: aka,
+	}
+
+	resp.WriteHeaderAndEntity(http.StatusOK, createResp)
+
+}
+func RefreshAka(aka *models.Aka) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	aka.UpdateAkaSceneCastRecords()
+	db.Preload("AkaActor").Preload("Akas").Find(&aka)
+}

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -322,10 +322,16 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		})
 	}
 
-	if len(scene.Cast) > 5 {
+	akaCnt := 0
+	for _, c := range scene.Cast {
+		if strings.HasPrefix(c.Name, "aka:") {
+			akaCnt++
+		}
+	}
+	if (len(scene.Cast) - akaCnt) > 5 {
 		addFeatureTag("Cast: 6+")
-	} else if len(scene.Cast) > 0 {
-		addFeatureTag(fmt.Sprintf("Cast: %d", len(scene.Cast)))
+	} else if (len(scene.Cast) - akaCnt) > 0 {
+		addFeatureTag(fmt.Sprintf("Cast: %d", (len(scene.Cast) - akaCnt)))
 	}
 
 	for i := range scene.Tags {

--- a/pkg/api/tasks.go
+++ b/pkg/api/tasks.go
@@ -124,13 +124,14 @@ func (i TaskResource) backupBundle(req *restful.Request, resp *restful.Response)
 	inclCuepoints, _ := strconv.ParseBool(req.QueryParameter("inclCuepoints"))
 	inclHistory, _ := strconv.ParseBool(req.QueryParameter("inclHistory"))
 	inclPlaylists, _ := strconv.ParseBool(req.QueryParameter("inclPlaylists"))
+	inclActorAkas, _ := strconv.ParseBool(req.QueryParameter("inclActorAkas"))
 	inclVolumes, _ := strconv.ParseBool(req.QueryParameter("inclVolumes"))
 	inclSites, _ := strconv.ParseBool(req.QueryParameter("inclSites"))
 	inclActions, _ := strconv.ParseBool(req.QueryParameter("inclActions"))
 	playlistId := req.QueryParameter("playlistId")
 	download := req.QueryParameter("download")
 
-	bundle := tasks.BackupBundle(inclAllSites, inclScenes, inclFileLinks, inclCuepoints, inclHistory, inclPlaylists, inclVolumes, inclSites, inclActions, playlistId)
+	bundle := tasks.BackupBundle(inclAllSites, inclScenes, inclFileLinks, inclCuepoints, inclHistory, inclPlaylists, inclActorAkas, inclVolumes, inclSites, inclActions, playlistId)
 	if download == "true" {
 		resp.WriteHeaderAndEntity(http.StatusOK, ResponseBackupBundle{Response: "Ready to Download from http://xxx.xxx.xxx.xxx:9999/download/xbvr-content-bundle.json"})
 	} else {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -946,6 +946,13 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0042-actor-akas",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.
+					AutoMigrate(&models.Aka{}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_aka.go
+++ b/pkg/models/model_aka.go
@@ -1,0 +1,135 @@
+package models
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/avast/retry-go/v3"
+)
+
+type Aka struct {
+	ID         uint      `gorm:"primary_key" json:"id" xbvrbackup:"-"`
+	CreatedAt  time.Time `json:"-" xbvrbackup:"-"`
+	UpdatedAt  time.Time `json:"-" xbvrbackup:"-"`
+	Name       string    `json:"name" xbvrbackup:"name"`
+	AkaActorId uint      `json:"aka_actor_id" xbvrbackup:"-"`
+
+	AkaActor Actor   `gorm:"foreignKey:AkaActorId; references:ID" json:"aka_actor"  xbvrbackup:"aka_actor"`
+	Akas     []Actor `gorm:"many2many:actor_akas;" json:"actors"  xbvrbackup:"actors"`
+}
+
+func (i *Aka) Save() error {
+	db, _ := GetDB()
+	defer db.Close()
+
+	err := retry.Do(
+		func() error {
+			err := db.Save(&i).Error
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		log.Fatal("Failed to save ", err)
+	}
+
+	return nil
+}
+
+func (o *Aka) GetIfExistByPK(id uint) error {
+	db, _ := GetDB()
+	defer db.Close()
+
+	return db.
+		Preload("Actors").
+		Where(&Aka{ID: id}).First(o).Error
+}
+
+func (o *Aka) UpdateAkaSceneCastRecords() {
+	db, _ := GetDB()
+	defer db.Close()
+
+	// Queries to update the scene_cast table for the aka actor are comlex but fast.
+	//  Significating faster than iterating through the results of multiple simpler queries.
+	// 	The Raw Sql used is compatible between mysql & sqlite
+
+	// add missing scene_cast records for aka actors
+	db.Exec(`
+	insert into scene_cast 
+	select distinct sc.scene_id, a.aka_actor_id 
+	from akas a 
+	join actor_akas aa on aa.aka_id =a.id 
+	join scene_cast sc on sc.actor_id = aa.actor_id
+	left join scene_cast sc2 on sc2.scene_id = sc.scene_id  and sc2.actor_id = a.aka_actor_id 
+	where sc2.actor_id is NULL 
+	`)
+
+	// make a list of scene_cast records for aka actors that have been removed
+	type DeleteList struct {
+		AkaActorId uint
+		SceneId    uint
+	}
+	var deleteList []DeleteList
+
+	db.Raw(`
+		with SceneIds as (
+			select distinct a.id, sc.scene_id
+			from akas a 
+			join actor_akas aa on aa.aka_id =a.id 
+			join scene_cast sc on sc.actor_id=aa.actor_id
+			)
+			select distinct a.aka_actor_id, sc.scene_id  from akas a
+			join scene_cast sc on sc.actor_id=a.aka_actor_id 
+			left join SceneIds si on si.id=a.id and sc.scene_id= si.scene_id
+			where si.scene_id is null	
+			`).Scan(&deleteList)
+
+	for _, scenecast := range deleteList {
+		db.Exec(` delete from scene_cast where scene_id = ? and actor_id = ?`, scenecast.SceneId, scenecast.AkaActorId)
+	}
+
+	var actor Actor
+	actor.CountActorTags()
+	o.RefreshAkaActorNames()
+}
+
+func (o *Aka) RefreshAkaActorNames() {
+	db, _ := GetDB()
+	defer db.Close()
+
+	type SortedList struct {
+		AkaActorId uint
+		SortedName string
+	}
+	var sortedList []SortedList
+
+	// this update the aka names by reordering the actor names based on descending count
+	db.Raw(`
+	with sorted as (
+		select a.aka_actor_id, a2.name, a2.count  from akas a 
+		join actor_akas aa on a.id =aa.aka_id 
+		join actors a2 on a2.id =aa.actor_id		
+		ORDER BY a.id, a2.count DESC
+		)
+		select aka_actor_id, GROUP_CONCAT(name) as sorted_name from sorted group by aka_actor_id
+		`).Scan(&sortedList)
+
+	for _, listItem := range sortedList {
+		var actor Actor
+		actor.ID = listItem.AkaActorId
+		db.Model(&actor).Where("name != ?", "aka:"+listItem.SortedName).Update("name", "aka:"+listItem.SortedName)
+	}
+}
+
+func (o *Aka) AkaNameSortedAlphabetcally() string {
+	var names []string
+	for _, a := range o.Akas {
+		names = append(names, a.Name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ",")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -85,6 +85,7 @@ func StartServer(version, commit, branch, date string) {
 	restful.Add(api.DeoVRResource{}.WebService())
 	restful.Add(api.HeresphereResource{}.WebService())
 	restful.Add(api.PlaylistResource{}.WebService())
+	restful.Add(api.AkaResource{}.WebService())
 
 	restConfig := restfulspec.Config{
 		WebServices: restful.RegisteredWebServices(),

--- a/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataImportExport.vue
@@ -79,6 +79,13 @@
       <div class="block">
         <b-field>
           <b-tooltip
+            label="Includes your Actor Aka Groups"
+            size="is-large" type="is-primary is-light" multilined :delay="1000" >
+            <b-switch v-model="includeActorAkas">Include Actor Aka Groups</b-switch>
+          </b-tooltip>
+        </b-field>
+        <b-field>
+          <b-tooltip
             label="Includes your Saved Search definitions"
             size="is-large" type="is-primary is-light" multilined :delay="1000" >
             <b-switch v-model="includePlaylists">Include Saved Searches</b-switch>
@@ -153,6 +160,7 @@ export default {
       includePlaylists: true,
       includeVolumes: true,
       includeSites: true,
+      includeActorAkas: true,
       overwrite: true,
       allSites: "true",
       currentPlaylist: '0',
@@ -192,13 +200,13 @@ export default {
         // put up a starting msg, as large files can cause it to appear to hang
         this.$store.state.messages.lastScrapeMessage = 'Starting restore'
         ky.post('/api/task/bundle/restore', {
-          json: { allSites: this.allSites == "true", inclScenes: this.includeScenes, inclHistory: this.includeHistory, inclLinks: this.includeFileLinks, inclCuepoints: this.includeCuepoints, inclActions: this.includeActions, inclPlaylists: this.includePlaylists, inclVolumes: this.includeVolumes, inclSites: this.includeSites, overwrite: this.overwrite, uploadData: this.uploadData }
+          json: { allSites: this.allSites == "true", inclScenes: this.includeScenes, inclHistory: this.includeHistory, inclLinks: this.includeFileLinks, inclCuepoints: this.includeCuepoints, inclActions: this.includeActions, inclPlaylists: this.includePlaylists, inclActorAkas: this.includeActorAkas,inclVolumes: this.includeVolumes, inclSites: this.includeSites, overwrite: this.overwrite, uploadData: this.uploadData }
         })
         this.file = null
       }
     },
     backupContent () {
-      ky.get('/api/task/bundle/backup', { timeout: false, searchParams: { allSites: this.allSites == "true", inclScenes: this.includeScenes, inclHistory: this.includeHistory, inclLinks: this.includeFileLinks, inclCuepoints: this.includeCuepoints, inclActions: this.includeActions, inclPlaylists: this.includePlaylists, inclVolumes: this.includeVolumes, inclSites: this.includeSites, playlistId: this.currentPlaylist, download: true } }).json().then(data => {
+      ky.get('/api/task/bundle/backup', { timeout: false, searchParams: { allSites: this.allSites == "true", inclScenes: this.includeScenes, inclHistory: this.includeHistory, inclLinks: this.includeFileLinks, inclCuepoints: this.includeCuepoints, inclActions: this.includeActions, inclPlaylists: this.includePlaylists, inclActorAkas: this.includeActorAkas, inclVolumes: this.includeVolumes, inclSites: this.includeSites, playlistId: this.currentPlaylist, download: true } }).json().then(data => {
         const link = document.createElement('a')
         link.href = this.myUrl
         link.click()


### PR DESCRIPTION
This modification allows users to group different Actors together who are actually the same person.  This is to handle where an Actor is known by another name or in the case of Sqlite, case sensitivity of the name means an extra actor is created

It works by creating a new actor to represent the combined group, the original actor record remains untouched.  This actor record is then added to all the scenes that the original actors are in.  This gives the ability to look up all the scenes for an actor (with the new actor) or the scenes under the individual actors as the currently do.

To maintain the groups, there is 4 new buttons to create a group, delete a group, add to a existing group and remove from a group
Select Actors in the Cast Filter to maintain groups.  

- To Create a group select 2 or more actors
- To Delete a group select to the actors AKA actor record
- To Add cast members to a group, select the AKA actor record and actors you wish to add
- To Remove cast members from a group, select the AKA actor record and actors you wish to remove
You cannot maintain or delete more than 1 AKA Actor group at a time

The Actor groups can be imported and exported. 