### PR TITLE
Heresphere post body errors

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -173,8 +173,7 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 
 	var requestData HereSphereAuthRequest
 	if err := json.NewDecoder(req.Request.Body).Decode(&requestData); err != nil {
-		log.Errorf("Error decoding heresphere api POST request: %v", err)
-		return
+		log.Warnf("Error decoding heresphere api POST request: %v", err)
 	}
 
 	db, _ := models.GetDB()
@@ -233,8 +232,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 
 	var requestData HereSphereAuthRequest
 	if err := json.NewDecoder(req.Request.Body).Decode(&requestData); err != nil {
-		log.Errorf("Error decoding heresphere api POST request: %v", err)
-		return
+		log.Warnf("Error decoding heresphere api POST request: %v", err)
 	}
 
 	sceneID := req.PathParameter("scene-id")
@@ -620,7 +618,7 @@ func ProcessHeresphereUpdates(scene *models.Scene, requestData HereSphereAuthReq
 	if requestData.Hsp != nil && config.Config.Interfaces.Heresphere.AllowHspData {
 		hspContent, err := base64.StdEncoding.DecodeString(*requestData.Hsp)
 		if err != nil {
-			log.Error("Error decoding heresphere hsp data %v", err)
+			log.Warnf("Error decoding heresphere hsp data %v", err)
 		}
 
 		fName := filepath.Join(scene.Files[0].Path, strings.TrimSuffix(scene.Files[0].Filename, filepath.Ext(videoFile.Filename))+".hsp")

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -173,7 +173,7 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 
 	var requestData HereSphereAuthRequest
 	if err := json.NewDecoder(req.Request.Body).Decode(&requestData); err != nil {
-		log.Warnf("Error decoding heresphere api POST request: %v", err)
+		log.Warnf("Error decoding heresphere api POST request: %v %s", err, req.Request.RequestURI)
 	}
 
 	db, _ := models.GetDB()
@@ -232,7 +232,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 
 	var requestData HereSphereAuthRequest
 	if err := json.NewDecoder(req.Request.Body).Decode(&requestData); err != nil {
-		log.Warnf("Error decoding heresphere api POST request: %v", err)
+		log.Warnf("Error decoding heresphere api POST request: %v %s", err, req.Request.RequestURI)
 	}
 
 	sceneID := req.PathParameter("scene-id")
@@ -261,6 +261,12 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		return
 	}
 
+	if len(videoFiles) == 0 {
+		// this may happen if the file is removed from the file system, noy via xbvr
+		// so no videos exist but the scene status is still available
+		log.Errorf("No videofiles for %s %s", scene.ID, scene.SceneID)
+		return
+	}
 	ProcessHeresphereUpdates(&scene, requestData, videoFiles[0])
 
 	features := make(map[string]bool, 30)


### PR DESCRIPTION
A Post request with an empty body or a Get to the Heresphere Api is treated as an error when the Json body cannot be decoded.  This should not occur, and I can't reproduce, but looks to have happened for 1 user.  Since this is treated as an error no scene details are returned to Heresphere.  This change will no longer treat this scenario as an error and will continue to return scene data.

A possible panic was also addressed that could occur in the Heresphere API if a scene had no video files but had an isAvailable status.  This could occur if video files were deleted from the filesystem