### PR TITLE
Aka Search in Heresphere

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -359,16 +359,17 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		Name: "Studio:" + scene.Site,
 	})
 
-	for i := range scene.Cast {
-		tags = append(tags, HeresphereTag{
-			Name: "Talent:" + scene.Cast[i].Name,
-		})
-	}
-
 	akaCnt := 0
-	for _, c := range scene.Cast {
-		if strings.HasPrefix(c.Name, "aka:") {
+	for i := range scene.Cast {
+		if strings.HasPrefix(scene.Cast[i].Name, "aka:") {
 			akaCnt++
+			tags = append(tags, HeresphereTag{
+				Name: strings.Replace(scene.Cast[i].Name, ",", "/", -1),
+			})
+		} else {
+			tags = append(tags, HeresphereTag{
+				Name: "Talent:" + scene.Cast[i].Name,
+			})
 		}
 	}
 	if (len(scene.Cast) - akaCnt) > 5 {

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -131,22 +131,22 @@
     </div>
     <div class="is-divider" data-content="Actor Also Known As groups"></div>
     <b-field>
-      <b-tooltip position="is-bottom" label="New Aka Group" :delay="200">
+      <b-tooltip position="is-right" label="New Aka Group. Select 2 or more actors in the Cast filter" multilined :delay="200">
         <button class="button is-small is-outlined" @click="createAkaGroup" :disabled="disableNewAkaGroup">
           <b-icon pack="mdi" icon="account-multiple-plus-outline"></b-icon>
         </button>
       </b-tooltip>
-      <b-tooltip position="is-bottom" label="Delete Aka Group" :delay="200">
+      <b-tooltip position="is-right" label="Select the Aka Group to delete in the Cast Filter" multilined :delay="200">
         <button class="button is-small is-outlined" @click="deleteAkaGroup" :disabled="disableDeleteAkaGroup">
           <b-icon pack="mdi" icon="delete-outline"></b-icon>
         </button>
       </b-tooltip>
-      <b-tooltip position="is-bottom" label="Add Cast to Aka Group" :delay="200">
+      <b-tooltip position="is-bottom" label="Add Cast to Aka Group. Select the Aka group and Actors to add in the Cast Filter" multilined :delay="200">
         <button class="button is-small is-outlined" @click="addToAkaGroup" :disabled="disableAddToAkaGroup">
           <b-icon pack="mdi" icon="account-plus-outline"></b-icon>
         </button>
       </b-tooltip>
-      <b-tooltip position="is-bottom" label="Remove Cast from Aka Group" :delay="200">
+      <b-tooltip position="is-bottom" label="Remove Cast from Aka Group. Select the Aka group and Actors to remove in the Cast Filter" multilined :delay="200">
         <button class="button is-small is-outlined" @click="removeFromAkaGroup" :disabled="disableRemoveFromAkaGroup">
           <b-icon pack="mdi" icon="account-minus-outline"></b-icon>
         </button>


### PR DESCRIPTION
Aka groups are currently treated like other normal actors and sent to Heresphere in the "Talent" group.  However, the colon and commas in the aka groups name, causes problems with Heresphere where these characters have special meaning in the search. functions

This change creates a separate Tag Category in Herepshere for Aka Groups and replaces the comma with a /.

Users should click Rescan Library (under Settings button on the bottom right of the scene list), once all files have been scanned, then select Generate Categorized Tags to load the new Category for existing scenes.

Tooltips also added to the button to give users more direction for setting up groups