### PR TITLE
Add ability to run tasks at startup

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -101,18 +101,21 @@ type RequestSaveOptionsTaskSchedule struct {
 	RescrapeMinuteStart  int  `json:"rescrapeMinuteStart"`
 	RescrapeHourStart    int  `json:"rescrapeHourStart"`
 	RescrapeHourEnd      int  `json:"rescrapeHourEnd"`
+	RescrapeStartDelay   int  `json:"rescrapeStartDelay"`
 	RescanEnabled        bool `json:"rescanEnabled"`
 	RescanHourInterval   int  `json:"rescanHourInterval"`
 	RescanUseRange       bool `json:"rescanUseRange"`
 	RescanMinuteStart    int  `json:"rescanMinuteStart"`
 	RescanHourStart      int  `json:"rescanHourStart"`
 	RescanHourEnd        int  `json:"rescanHourEnd"`
+	RescanStartDelay     int  `json:"rescanStartDelay"`
 	PreviewEnabled       bool `json:"previewEnabled"`
 	PreviewHourInterval  int  `json:"previewHourInterval"`
 	PreviewUseRange      bool `json:"previewUseRange"`
 	PreviewMinuteStart   int  `json:"previewMinuteStart"`
 	PreviewHourStart     int  `json:"previewHourStart"`
 	PreviewHourEnd       int  `json:"previewHourEnd"`
+	PreviewStartDelay    int  `json:"previewStartDelay"`
 }
 
 type RequestCuepointsResponse struct {
@@ -658,6 +661,7 @@ func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *rest
 	config.Config.Cron.RescrapeSchedule.MinuteStart = r.RescrapeMinuteStart
 	config.Config.Cron.RescrapeSchedule.HourStart = r.RescrapeHourStart
 	config.Config.Cron.RescrapeSchedule.HourEnd = r.RescrapeHourEnd
+	config.Config.Cron.RescrapeSchedule.RunAtStartDelay = r.RescrapeStartDelay
 
 	config.Config.Cron.RescanSchedule.Enabled = r.RescanEnabled
 	config.Config.Cron.RescanSchedule.HourInterval = r.RescanHourInterval
@@ -665,6 +669,7 @@ func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *rest
 	config.Config.Cron.RescanSchedule.MinuteStart = r.RescanMinuteStart
 	config.Config.Cron.RescanSchedule.HourStart = r.RescanHourStart
 	config.Config.Cron.RescanSchedule.HourEnd = r.RescanHourEnd
+	config.Config.Cron.RescanSchedule.RunAtStartDelay = r.RescanStartDelay
 
 	config.Config.Cron.PreviewSchedule.Enabled = r.PreviewEnabled
 	config.Config.Cron.PreviewSchedule.HourInterval = r.PreviewHourInterval
@@ -672,6 +677,7 @@ func (i ConfigResource) saveOptionsTaskSchedule(req *restful.Request, resp *rest
 	config.Config.Cron.PreviewSchedule.MinuteStart = r.PreviewMinuteStart
 	config.Config.Cron.PreviewSchedule.HourStart = r.PreviewHourStart
 	config.Config.Cron.PreviewSchedule.HourEnd = r.PreviewHourEnd
+	config.Config.Cron.PreviewSchedule.RunAtStartDelay = r.PreviewStartDelay
 
 	config.SaveConfig()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,12 +9,13 @@ import (
 )
 
 type CronSchedule struct {
-	Enabled      bool `default:"true" json:"enabled"`
-	HourInterval int  `json:"hourInterval"`
-	UseRange     bool `default:"false" json:"useRange"`
-	MinuteStart  int  `default:"0" json:"minuteStart"`
-	HourStart    int  `default:"0" json:"hourStart"`
-	HourEnd      int  `default:"23" json:"hourEnd"`
+	Enabled         bool `default:"true" json:"enabled"`
+	HourInterval    int  `json:"hourInterval"`
+	UseRange        bool `default:"false" json:"useRange"`
+	MinuteStart     int  `default:"0" json:"minuteStart"`
+	HourStart       int  `default:"0" json:"hourStart"`
+	HourEnd         int  `default:"23" json:"hourEnd"`
+	RunAtStartDelay int  `default:"0" json:"runAtStartDelay"`
 }
 
 type ObjectConfig struct {
@@ -80,28 +81,31 @@ type ObjectConfig struct {
 	} `json:"library"`
 	Cron struct {
 		RescrapeSchedule struct {
-			Enabled      bool `default:"true" json:"enabled"`
-			HourInterval int  `default:"12" json:"hourInterval"`
-			UseRange     bool `default:"false" json:"useRange"`
-			MinuteStart  int  `default:"0" json:"minuteStart"`
-			HourStart    int  `default:"0" json:"hourStart"`
-			HourEnd      int  `default:"23" json:"hourEnd"`
+			Enabled         bool `default:"true" json:"enabled"`
+			HourInterval    int  `default:"12" json:"hourInterval"`
+			UseRange        bool `default:"false" json:"useRange"`
+			MinuteStart     int  `default:"0" json:"minuteStart"`
+			HourStart       int  `default:"0" json:"hourStart"`
+			HourEnd         int  `default:"23" json:"hourEnd"`
+			RunAtStartDelay int  `default:"0" json:"runAtStartDelay"`
 		} `json:"rescrapeSchedule"`
 		RescanSchedule struct {
-			Enabled      bool `default:"true" json:"enabled"`
-			HourInterval int  `default:"2" json:"hourInterval"`
-			UseRange     bool `default:"false" json:"useRange"`
-			MinuteStart  int  `default:"0" json:"minuteStart"`
-			HourStart    int  `default:"0" json:"hourStart"`
-			HourEnd      int  `default:"23" json:"hourEnd"`
+			Enabled         bool `default:"true" json:"enabled"`
+			HourInterval    int  `default:"2" json:"hourInterval"`
+			UseRange        bool `default:"false" json:"useRange"`
+			MinuteStart     int  `default:"0" json:"minuteStart"`
+			HourStart       int  `default:"0" json:"hourStart"`
+			HourEnd         int  `default:"23" json:"hourEnd"`
+			RunAtStartDelay int  `default:"0" json:"runAtStartDelay"`
 		} `json:"rescanSchedule"`
 		PreviewSchedule struct {
-			Enabled      bool `default:"false" json:"enabled"`
-			HourInterval int  `default:"2" json:"hourInterval"`
-			UseRange     bool `default:"false" json:"useRange"`
-			MinuteStart  int  `default:"0" json:"minuteStart"`
-			HourStart    int  `default:"0" json:"hourStart"`
-			HourEnd      int  `default:"23" json:"hourEnd"`
+			Enabled         bool `default:"false" json:"enabled"`
+			HourInterval    int  `default:"2" json:"hourInterval"`
+			UseRange        bool `default:"false" json:"useRange"`
+			MinuteStart     int  `default:"0" json:"minuteStart"`
+			HourStart       int  `default:"0" json:"hourStart"`
+			HourEnd         int  `default:"23" json:"hourEnd"`
+			RunAtStartDelay int  `default:"0" json:"runAtStartDelay"`
 		} `json:"previewSchedule"`
 	} `json:"cron"`
 }

--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -36,6 +36,16 @@ func SetupCron() {
 
 	go tasks.CalculateCacheSizes()
 
+	if config.Config.Cron.RescrapeSchedule.RunAtStartDelay > 0 {
+		time.AfterFunc(time.Duration(config.Config.Cron.RescrapeSchedule.RunAtStartDelay*int(time.Minute)), scrapeCron)
+	}
+	if config.Config.Cron.RescanSchedule.RunAtStartDelay > 0 {
+		time.AfterFunc(time.Duration(config.Config.Cron.RescanSchedule.RunAtStartDelay*int(time.Minute)), rescanCron)
+	}
+	if config.Config.Cron.PreviewSchedule.RunAtStartDelay > 0 {
+		time.AfterFunc(time.Duration(config.Config.Cron.PreviewSchedule.RunAtStartDelay*int(time.Minute)), generatePreviewCron)
+	}
+
 	log.Println(fmt.Sprintf("Next Rescrape Task at %v", cronInstance.Entry(rescrapTask).Next))
 	log.Println(fmt.Sprintf("Next Rescan Task at %v", cronInstance.Entry(rescanTask).Next))
 	log.Println(fmt.Sprintf("Next Preview Generation Task at %v", cronInstance.Entry(previewTask).Next))

--- a/ui/src/views/options/sections/Schedules.vue
+++ b/ui/src/views/options/sections/Schedules.vue
@@ -44,6 +44,11 @@
                   <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescrapeMinuteStart) }}</div>
                 </b-field>
               </div>
+              <br/>
+              <b-field label="Startup">
+                  <b-slider v-model="rescrapeStartDelay" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ delayStartMsg(rescrapeStartDelay) }}</div>
+              </b-field>
             </div>
             <div v-if="activeTab == 1">            
               <h4>{{$t("Rescan Folders")}}</h4>
@@ -77,6 +82,11 @@
                   <div class="column is-one-third" style="margin-left:.75em">{{ minutesStartMsg(rescanMinuteStart) }}</div>
                 </b-field>
               </div>
+              <br/>
+              <b-field label="Startup">
+                  <b-slider v-model="rescanStartDelay" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ delayStartMsg(rescanStartDelay) }}</div>
+              </b-field>
             </div>
            <div v-if="activeTab == 2">            
               <b-field>
@@ -112,9 +122,14 @@
                   Preview Generation of a scene will not start after the Time Window Ends
                 </p>
               </div>
-                <p>
-                  BETA NOTE: Please note this is CPU-heavy process, if approriate limit the Time of Day the task runs                  
-                </p>                  
+              <br/>
+              <b-field label="Startup">
+                  <b-slider v-model="previewStartDelay" :min="0" :max="60" :step="1" ></b-slider>
+                  <div class="column is-one-third" style="margin-left:.75em">{{ delayStartMsg(previewStartDelay) }}</div>
+              </b-field>
+              <p>
+                BETA NOTE: Please note this is CPU-heavy process, if approriate limit the Time of Day the task runs                  
+              </p>                  
             </div>
             <hr/>
               <b-field grouped>
@@ -161,6 +176,9 @@ export default {
       previewMinuteStart: 0,
       lastPreviewTimeRange: [0,23],
       usePreviewTimeRange: false,      
+      rescrapeStartDelay: 0,
+      rescanStartDelay: 0,
+      previewStartDelay: 0,
       timeRange: ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
         '12:00', '13:00', '14:00', '15:00', '16:00', '17:00', '18:00', '19:00', '20:00', '21:00', '22:00', '23:00',
         '00:00', '01:00', '02:00', '03:00', '04:00', '05:00', '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',
@@ -233,6 +251,9 @@ export default {
           } else {
             this.previewTimeRange = [data.config.cron.previewSchedule.hourStart, data.config.cron.previewSchedule.hourEnd]            
           }
+          this.rescrapeStartDelay = data.config.cron.rescrapeSchedule.runAtStartDelay
+          this.rescanStartDelay = data.config.cron.rescanSchedule.runAtStartDelay          
+          this.previewStartDelay = data.config.cron.previewSchedule.runAtStartDelay
           this.isLoading = false
         })
     },
@@ -245,6 +266,17 @@ export default {
       }
       return `Start at ${start} minutes past the hour`
     },
+    delayStartMsg (start) {
+      if (start === 0) {
+        return 'Do not run at statup'
+      }else{
+        if (start === 1) {
+          return `Run at 1 minute after startup`
+        }else{
+          return `Run at ${start} minutes after startup`
+        }
+      }
+    },
     async saveSettings () {
       this.isLoading = true
       await ky.post('/api/options/task-schedule', {
@@ -255,18 +287,21 @@ export default {
           rescrapeMinuteStart: this.rescrapeMinuteStart,
           rescrapeHourStart: this.rescrapeTimeRange[0],
           rescrapeHourEnd: this.rescrapeTimeRange[1],
+          rescrapeStartDelay: this.rescrapeStartDelay,
           rescanEnabled: this.rescanEnabled,
           rescanHourInterval: this.rescanHourInterval,
           rescanUseRange: this.useRescanTimeRange,
           rescanMinuteStart: this.rescanMinuteStart,
           rescanHourStart: this.rescanTimeRange[0],
           rescanHourEnd: this.rescanTimeRange[1],
+          rescanStartDelay: this.rescanStartDelay,
           previewEnabled: this.previewEnabled,
           previewHourInterval: this.previewHourInterval,
           previewUseRange: this.usePreviewTimeRange,
           previewMinuteStart: this.previewMinuteStart,
           previewHourStart: this.previewTimeRange[0],
-          previewHourEnd: this.previewTimeRange[1]
+          previewHourEnd: this.previewTimeRange[1],
+          previewStartDelay:this.previewStartDelay
         }
       })
         .json()


### PR DESCRIPTION
Adds the ability to run a Task after Startup. 

User specifies how many minutes after startup to run the job. This allows for some basic sequencing, e.g., run a File Rescan 1 minute after starting and Preview Generations 3 minutes after starting, which would allow time for the rescan and then generate previews for any new files.

Running at startup is independent from the Task Schedule, i.e., you can disable the Schedule for a Task and still run it at startup, but only at startup in that case