### PR TITLE
Fix Orphaned Cuepoint Associations

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1006,6 +1006,13 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// VRCONK has changed scene numbering schema, so it needs to be flushed
+			ID: "00046-fix-orphaned-cuepoints",
+			Migrate: func(tx *gorm.DB) error {
+				return db.Where("scene_id is null").Delete(&models.SceneCuepoint{}).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
Fixes an issue where _**extra**_ scene_cuepoint records exist with no scene_id (null).  There is no impact to the user, this fix tidies up what is happening in the database.

This issue happens when changes are made to Cuepoints in Heresphere and updated back to XBVR via the API.  The update routine uses gorms Assoications Replace function.  This is creating a complete brand-new set of scene_cuepoint records for the scene and rather than deleting the old ones, it sets the scene_id to null, I guess it removes the association not the record.

From a user perspective, the system is still working fine, they don't see the old records with the null scene_id and do still have a complete set of valid cuepoints.  Fix includes migration to remove the old records.
