### PR TITLE
Scene Property Filtering Enhancements

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -538,14 +538,26 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 	}
 
 	for _, i := range r.Lists {
-		if i.OrElse("") == "watchlist" {
-			tx = tx.Where("watchlist = ?", true)
-		}
-		if i.OrElse("") == "favourite" {
-			tx = tx.Where("favourite = ?", true)
-		}
-		if i.OrElse("") == "scripted" {
-			tx = tx.Where("is_scripted = ?", true)
+		truefalse := true
+		fieldName := i.OrElse("")
+
+		if fieldName != "" {
+			if strings.HasPrefix(fieldName, "!") { // ! prefix indicate NOT filtering
+				truefalse = false
+				fieldName = fieldName[1:]
+			}
+			switch fieldName {
+			case "star_rating":
+				if truefalse {
+					tx = tx.Where("star_rating > ?", 0)
+				} else {
+					tx = tx.Where("star_rating = ?", 0)
+				}
+			case "scripted":
+				tx = tx.Where("is_scripted = ?", truefalse)
+			default:
+				tx = tx.Where(fieldName+" = ?", truefalse)
+			}
 		}
 	}
 

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -8,6 +8,7 @@
 
     <div class="columns is-multiline is-gapless">
       <div class="column is-half">
+        <b-field>
         <b-button expanded
           :type="watchlistState==false ? 'is-danger': (watchlistState ? 'is-success' : '')"
           @click.native.prevent="toggleProperty($event, 'watchlist', watchlistState)">
@@ -16,46 +17,70 @@
           <b-icon pack="mdi" icon="calendar-check"/>
           <span>{{ $t('Watchlist') }}</span>
         </b-button>
+        <button v-show="watchlistState!=undefined" type="submit" class="button is-light" @click="toggleProperty($event, 'watchlist', false)">
+          <b-icon pack="fas" icon="times" size="is-small"></b-icon>
+        </button>
+        </b-field>
       </div>
       <div class="column is-half">
-        <b-button expanded
-          :type="favouriteState==false ? 'is-danger': (favouriteState ? 'is-success' : '')"
-          @click.native.prevent="toggleProperty($event, 'favourite', favouriteState)">
-          <b-icon pack="mdi" v-if="favouriteState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" v-if="favouriteState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" icon="heart"/>
-          <span>{{ $t('Favourite') }}</span>
-        </b-button>
+        <b-field>
+          <b-button expanded
+            :type="favouriteState==false ? 'is-danger': (favouriteState ? 'is-success' : '')"
+            @click.native.prevent="toggleProperty($event, 'favourite', favouriteState)">
+            <b-icon pack="mdi" v-if="favouriteState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" v-if="favouriteState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" icon="heart"/>
+            <span>{{ $t('Favourite') }}</span>
+          </b-button>
+          <button v-show="favouriteState!=undefined" type="submit" class="button is-light" @click="toggleProperty($event, 'favourite', false)">
+            <b-icon pack="fas" icon="times" size="is-small"></b-icon>
+          </button>
+        </b-field>
       </div>
       <div class="column is-half">
-        <b-button expanded
-          :type="scriptedState==false ? 'is-danger': (scriptedState ? 'is-success' : '')"
-          @click.native.prevent="toggleProperty($event, 'scripted', scriptedState)">
-          <b-icon pack="mdi" v-if="scriptedState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" v-if="scriptedState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" icon="pulse"/>
-          <span>{{ $t('Scripted') }}</span>
-        </b-button>
+        <b-field>
+          <b-button expanded
+            :type="scriptedState==false ? 'is-danger': (scriptedState ? 'is-success' : '')"
+            @click.native.prevent="toggleProperty($event, 'scripted', scriptedState)">
+            <b-icon pack="mdi" v-if="scriptedState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" v-if="scriptedState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" icon="pulse"/>
+            <span>{{ $t('Scripted') }}</span>
+          </b-button>
+          <button v-show="scriptedState!=undefined" type="submit" class="button is-light" @click="toggleProperty($event, 'scripted', false)">
+            <b-icon pack="fas" icon="times" size="is-small"></b-icon>
+          </button>
+        </b-field>
       </div>
       <div class="column is-half" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist">
-        <b-button expanded
-          :type="trailerlistState==false ? 'is-danger': (trailerlistState ? 'is-success' : '')"
-          @click.native.prevent="toggleProperty($event, 'trailerlist', trailerlistState)">
-          <b-icon pack="mdi" v-if="trailerlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" v-if="trailerlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" icon="movie-search-outline"/>
-          <span>{{ $t('Trailer List') }}</span>
-        </b-button>
+        <b-field>
+          <b-button expanded
+            :type="trailerlistState==false ? 'is-danger': (trailerlistState ? 'is-success' : '')"
+            @click.native.prevent="toggleProperty($event, 'trailerlist', trailerlistState)">
+            <b-icon pack="mdi" v-if="trailerlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" v-if="trailerlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" icon="movie-search-outline"/>
+            <span>{{ $t('Trailer List') }}</span>
+          </b-button>
+          <button v-show="trailerlistState!=undefined" type="submit" class="button is-light" @click="toggleProperty($event, 'trailerlist', false)">
+            <b-icon pack="fas" icon="times" size="is-small"></b-icon>
+          </button>
+        </b-field>
       </div>
       <div class="column is-half">
-        <b-button expanded
-          :type="ratingState==false ? 'is-danger': (ratingState ? 'is-success' : '')"
-          @click.native.prevent="toggleProperty($event, 'star_rating', ratingState)">
-          <b-icon pack="mdi" v-if="ratingState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" v-if="ratingState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
-          <b-icon pack="mdi" icon="star"/>
-          <span>{{ $t('Rating') }}</span>
-        </b-button>
+        <b-field>
+          <b-button expanded
+            :type="ratingState==false ? 'is-danger': (ratingState ? 'is-success' : '')"
+            @click.native.prevent="toggleProperty($event, 'star_rating', ratingState)">
+            <b-icon pack="mdi" v-if="ratingState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" v-if="ratingState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+            <b-icon pack="mdi" icon="star"/>
+            <span>{{ $t('Rating') }}</span>
+          </b-button>
+          <button v-show="ratingState!=undefined" type="submit" class="button is-light" @click="toggleProperty($event, 'star_rating', false)">
+            <b-icon pack="fas" icon="times" size="is-small"></b-icon>
+          </button>
+        </b-field>
       </div>
     </div>
 

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -8,22 +8,54 @@
 
     <div class="columns is-multiline is-gapless">
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="watchlist" type="is-primary">
+        <b-button expanded
+          :type="watchlistState==false ? 'is-danger': (watchlistState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'watchlist', watchlistState)">
+          <b-icon pack="mdi" v-if="watchlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="watchlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="calendar-check"/>
           <span>{{ $t('Watchlist') }}</span>
-        </b-checkbox-button>
+        </b-button>
       </div>
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="favourite" type="is-danger">
+        <b-button expanded
+          :type="favouriteState==false ? 'is-danger': (favouriteState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'favourite', favouriteState)">
+          <b-icon pack="mdi" v-if="favouriteState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="favouriteState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="heart"/>
           <span>{{ $t('Favourite') }}</span>
-        </b-checkbox-button>
+        </b-button>
       </div>
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="scripted" type="is-info">
+        <b-button expanded
+          :type="scriptedState==false ? 'is-danger': (scriptedState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'scripted', scriptedState)">
+          <b-icon pack="mdi" v-if="scriptedState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="scriptedState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="pulse"/>
           <span>{{ $t('Scripted') }}</span>
-        </b-checkbox-button>
+        </b-button>
+      </div>
+      <div class="column is-half" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist">
+        <b-button expanded
+          :type="trailerlistState==false ? 'is-danger': (trailerlistState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'trailerlist', trailerlistState)">
+          <b-icon pack="mdi" v-if="trailerlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="trailerlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" icon="movie-search-outline"/>
+          <span>{{ $t('Trailer List') }}</span>
+        </b-button>
+      </div>
+      <div class="column is-half">
+        <b-button expanded
+          :type="ratingState==false ? 'is-danger': (ratingState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'star_rating', ratingState)">
+          <b-icon pack="mdi" v-if="ratingState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="ratingState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" icon="star"/>
+          <span>{{ $t('Rating') }}</span>
+        </b-button>
       </div>
     </div>
 
@@ -217,10 +249,76 @@ export default {
     return {
       filteredCast: [],
       filteredSites: [],
-      filteredTags: []
+      filteredTags: [],
+      watchlistState: undefined,
+      favouriteState: undefined,
+      scriptedState: undefined,
+      trailerlistState: undefined,
+      ratingState: undefined
     }
   },
+  watch: {    
+    lists(newList, oldList) {      
+      this.watchlistState= undefined
+      this.favouriteState= undefined
+      this.scriptedState= undefined
+      this.trailerlistState= undefined
+      this.ratingState= undefined 
+      newList.forEach((element) => { 
+        let truefalse = true
+        let field=element
+        if (element.startsWith("!")) {
+          truefalse=false
+          field=element.replace("!","")
+        }
+        switch (field) {
+          case "watchlist":      
+            this.watchlistState=truefalse
+            break
+          case "favourite":      
+            this.favouriteState=truefalse
+            break
+          case "scripted":      
+            this.scriptedState=truefalse
+            break
+          case "trailerlist":      
+            this.trailerlistState=truefalse
+            break
+          case "star_rating":      
+            this.ratingState=truefalse
+            break
+        }
+      })
+    }
+  },  
   methods: {
+    toggleProperty(e, propertyName, propertyValue) {      
+      let tmpList=this.lists
+      // find and replace the property in tmpList
+      let found = tmpList.findIndex((element) => element.endsWith(propertyName))
+      // toggle undefined->true->false->undefined
+      if (propertyValue==true) {
+        if (found>=0) {
+          tmpList.splice(found,1,'!'+propertyName)
+        } else {
+          tmpList.push('!'+propertyName)
+        }
+        propertyValue = false
+      } else if (propertyValue === undefined) {
+        if (found>=0) {
+          tmpList.splice(found,1,propertyName)
+        } else {
+          tmpList.push(propertyName)
+        }
+        propertyValue = true
+      } else {
+        if (found>=0) {
+          tmpList.splice(found,1)
+        } 
+        propertyValue = undefined
+      }      
+      this.lists=tmpList        
+},
     reloadList () {
       this.$router.push({
         name: 'scenes',
@@ -422,8 +520,7 @@ export default {
       },
       set (value) {
         this.$store.state.sceneList.filters.tags = value
-        this.reloadList()
-        console.log('reloaded',value)
+        this.reloadList()        
       }
     },
     cuepoint: {


### PR DESCRIPTION
This feature adds some enhancements to scene filtering using the fields under "Properties", i.e., Watchlist, Scripted, etc.

- Changed the buttons to have 3 states for searching, similar to what was added to other filters in the previous release, i.e., you can search any, must have and must exclude, e.g., any scene, scenes with scripts, scenes without scripts. The new state been must exclude.
- Added Trailer list as a new Property, (requested by a user)
- Added Ratings as a new Property, i.e., filtering scenes with Ratings or scenes without Ratings is now possible

Technical Details:
The three states are recognized by Transparent-undefined (Any), Green-true (must include) and Red-false (must exclude).  
Unfortunately, I couldn't find a way to toggle a Red color when the b-button-checkbox was false.  In the end I had to change to using a normal button, but this resulted in more code to do what the previous b-checkbox-button did for us.  If there is a way to toggle color of a b-checkbox-button, the code change could be simplified