### PR TITLE
Add ability to sort the file lists sent player Apis

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -320,7 +320,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 	var sources []DeoSceneEncoding
 	var sourcesSpatial []DeoSceneEncoding
 	var videoFiles []models.File
-	videoFiles, err = scene.GetVideoFiles()
+	videoFiles, err = scene.GetVideoFilesSorted(config.Config.Interfaces.Players.VideoSortSeq)
 	if err != nil {
 		log.Error(err)
 		return
@@ -359,7 +359,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 
 	var deoScriptFiles []DeoSceneScriptFile
 	var scriptFiles []models.File
-	scriptFiles, err = scene.GetScriptFiles()
+	scriptFiles, err = scene.GetScriptFilesSorted(config.Config.Interfaces.Players.ScriptSortSeq)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -269,7 +269,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 	}
 
 	var videoFiles []models.File
-	videoFiles, err = scene.GetVideoFiles()
+	videoFiles, err = scene.GetVideoFilesSorted(config.Config.Interfaces.Players.VideoSortSeq)
 	if err != nil {
 		log.Error(err)
 		return
@@ -443,7 +443,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 
 	var heresphereScriptFiles []HeresphereScript
 	var scriptFiles []models.File
-	scriptFiles, err = scene.GetScriptFiles()
+	scriptFiles, err = scene.GetScriptFilesSorted(config.Config.Interfaces.Players.ScriptSortSeq)
 	if err != nil {
 		log.Error(err)
 		return

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -74,6 +74,8 @@ type RequestSaveOptionsDeoVR struct {
 	AllowCuepointUpdates  bool   `json:"allow_cuepoint_updates"`
 	AllowWatchlistUpdates bool   `json:"allow_watchlist_updates"`
 	MultitrackCuepoints   bool   `json:"multitrack_cuepoints"`
+	VideoSortSeq          string `json:"video_sort_seq"`
+	ScriptSortSeq         string `json:"script_sort_seq"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -313,6 +315,8 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.Heresphere.AllowCuepointUpdates = r.AllowCuepointUpdates
 	config.Config.Interfaces.Heresphere.AllowWatchlistUpdates = r.AllowWatchlistUpdates
 	config.Config.Interfaces.Heresphere.MultitrackCuepoints = r.MultitrackCuepoints
+	config.Config.Interfaces.Players.VideoSortSeq = r.VideoSortSeq
+	config.Config.Interfaces.Players.ScriptSortSeq = r.ScriptSortSeq
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,10 @@ type ObjectConfig struct {
 			AllowWatchlistUpdates bool `default:"false" json:"allow_watchlist_updates"`
 			MultitrackCuepoints   bool `default:"true" json:"multitrack_cuepoints"`
 		} `json:"heresphere"`
+		Players struct {
+			VideoSortSeq  string `default:"" json:"video_sort_seq"`
+			ScriptSortSeq string `default:"" json:"script_sort_seq"`
+		} `json:"players"`
 	} `json:"interfaces"`
 	Library struct {
 		Preview struct {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -213,21 +213,37 @@ func (o *Scene) GetTotalWatchTime() int {
 }
 
 func (o *Scene) GetVideoFiles() ([]File, error) {
+	files, err := o.GetVideoFilesSorted("")
+	return files, err
+}
+func (o *Scene) GetVideoFilesSorted(sort string) ([]File, error) {
 	db, _ := GetDB()
 	defer db.Close()
 
 	var files []File
-	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Find(&files)
+	if sort == "" {
+		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Find(&files)
+	} else {
+		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Order(sort).Find(&files)
+	}
 
 	return files, nil
 }
 
 func (o *Scene) GetScriptFiles() ([]File, error) {
+	var files, err = o.GetScriptFilesSorted("is_selected_script DESC, created_time DESC")
+	return files, err
+}
+func (o *Scene) GetScriptFilesSorted(sort string) ([]File, error) {
 	db, _ := GetDB()
 	defer db.Close()
 
 	var files []File
-	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Order("is_selected_script DESC, created_time DESC").Find(&files)
+	if sort == "" {
+		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Find(&files)
+	} else {
+		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Order(sort).Find(&files)
+	}
 
 	return files, nil
 }

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -21,6 +21,10 @@ const state = {
     allow_watchlist_updates: false,
     allow_hsp_data: false,
     multitrack_cuepoints: true
+  },
+  players: {
+    video_sort_seq: '',
+    script_sort_seq: ''
   }
 }
 
@@ -48,12 +52,14 @@ const actions = {
         state.heresphere.allow_watchlist_updates = data.config.interfaces.heresphere.allow_watchlist_updates
         state.heresphere.allow_hsp_data = data.config.interfaces.heresphere.allow_hsp_data
         state.heresphere.multitrack_cuepoints = data.config.interfaces.heresphere.multitrack_cuepoints
+        state.players.video_sort_seq = data.config.interfaces.players.video_sort_seq
+        state.players.script_sort_seq = data.config.interfaces.players.script_sort_seq
         state.loading = false        
       })
   },
   async save ({ state }, enabled) {
     state.loading = true
-    ky.put('/api/options/interface/deovr', { json: { ...state.deovr, ...state.heresphere } })
+    ky.put('/api/options/interface/deovr', { json: { ...state.deovr, ...state.heresphere, ...state.players } })
       .json()
       .then(data => {
         state.loading = false

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -53,6 +53,64 @@
                   </b-switch>
                 </b-field>
               </div>
+              <hr/>
+              <div class="block">
+                <b-tooltip label="Specfy feilds if you wish control the sequence of the scenes video files" multilined :delay="750" >
+                  <b-field label="Video File Sorting">
+                    <b-input v-model="videoSequence" disabled></b-input>
+                  </b-field>
+                  <b-field>
+                    <b-button label="Add Field" @click="addVideoField('video')" />
+                    <b-button label="Clear Fields" @click="videoSequence=''" />                  
+                    <b-dropdown v-model="selectedVideoField" aria-role="list" :scrollable=true max-height="200">
+                        <template #trigger>
+                            <b-button :label="selectedVideoField" icon-right="menu-down"/>
+                        </template>
+                        <b-dropdown-item aria-role="listitem" value='Filename'>Filename</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Added'>Added</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Updated'>Updated</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Resolution'>Resolution</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Size'>Size</b-dropdown-item>                      
+                        <b-dropdown-item aria-role="listitem" value='Bitrate'>Bitrate</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Frame Rate'>Frame Rate</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Codec'>Codec</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Duration'>Duration</b-dropdown-item>
+                    </b-dropdown>
+                    <b-dropdown v-model="selectedVideoSequence" aria-role="list">
+                        <template #trigger>
+                            <b-button :label="selectedVideoSequence" icon-right="menu-down" />
+                        </template>
+                        <b-dropdown-item aria-role="listitem" value='Ascending'>Ascending</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Descending'>Descending</b-dropdown-item>
+                    </b-dropdown>
+                  </b-field>
+                </b-tooltip>
+                <b-tooltip label="Specfy feilds if you wish control the sequence of the scenes video files" multilined :delay="750" >
+                  <b-field label="Script File Sorting">
+                    <b-input v-model="scriptSequence" disabled></b-input>
+                  </b-field>
+                  <b-field>
+                    <b-button label="Add Field" @click="addVideoField('script')" />
+                    <b-button label="Clear Fields" @click="scriptSequence=''" />                  
+                    <b-dropdown v-model="selectedScriptField" aria-role="list">
+                        <template #trigger>
+                            <b-button :label="selectedScriptField" icon-right="menu-down" />
+                        </template>
+                        <b-dropdown-item aria-role="listitem" value='Filename'>Filename</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Added'>Added</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Updated'>Updated</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Selected'>Selected</b-dropdown-item>                      
+                    </b-dropdown>
+                    <b-dropdown v-model="selectedScriptSequence" aria-role="list">
+                        <template #trigger>
+                            <b-button :label="selectedScriptSequence" icon-right="menu-down" />
+                        </template>
+                        <b-dropdown-item aria-role="listitem" value='Ascending'>Ascending</b-dropdown-item>
+                        <b-dropdown-item aria-role="listitem" value='Descending'>Descending</b-dropdown-item>
+                    </b-dropdown>
+                  </b-field>
+                </b-tooltip>
+              </div>
             </div>
           </section>
         </div>
@@ -160,7 +218,11 @@ export default {
   },
   data () {
     return {
-      activeTab: 0
+      activeTab: 0,
+      selectedVideoField: 'Filename',
+      selectedVideoSequence: 'Ascending',
+      selectedScriptField: 'Filename',
+      selectedScriptSequence: 'Ascending'
     }
   },
   methods: {
@@ -177,6 +239,57 @@ export default {
     },
     hasDuplicates (array) {
       return (new Set(array)).size !== array.length
+    },
+    addVideoField(type) {      
+      let dbfield=''
+      let field=this.selectedVideoField            
+      if (type!='video'){        
+        field=this.selectedScriptField
+      }
+
+      switch (field) {
+        case 'Added':
+          dbfield = 'created_time'
+          break
+        case 'Updated':
+          dbfield = 'updated_time'
+          break
+        case 'Resolution':
+          dbfield = 'video_height'
+          break
+        case 'Bitrate':
+          dbfield = 'video_bit_rate'
+          break
+        case 'Frame Rate':
+          dbfield = 'video_avg_frame_rate_val'
+          break
+        case 'Codec':
+          dbfield = "case when video_codec_name in ('hevc', 'h265') then 0 when video_codec_name='h264' then 1 else 2 end"
+          break
+        case 'Duration':
+          dbfield = 'video_direction'
+          break
+        case 'Selected':
+          dbfield = 'is_selected_script'
+          break
+        default:
+          dbfield = field.toLowerCase()
+      }
+          
+      if (type=='video'){        
+        if (this.selectedVideoSequence=='Ascending') {
+          this.videoSequence=[this.videoSequence, dbfield ].filter(Boolean).join(',')
+        }else{
+          this.videoSequence=[this.videoSequence, dbfield+' desc' ].filter(Boolean).join(',')
+        }
+      }else{
+        if (this.selectedScriptSequence=='Ascending') {
+          this.scriptSequence=[this.scriptSequence, dbfield ].filter(Boolean).join(',')
+        }else{
+          this.scriptSequence=[this.scriptSequence, dbfield+' desc' ].filter(Boolean).join(',')
+        }
+      }
+
     }
   },
   computed: {
@@ -304,6 +417,22 @@ export default {
       set (value) {
         this.$store.state.optionsDeoVR.heresphere.multitrack_cuepoints = value
       }
+    },
+    videoSequence: {
+      get () {
+        return this.$store.state.optionsDeoVR.players.video_sort_seq
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.players.video_sort_seq = value
+      },
+    },
+    scriptSequence: {
+      get () {
+        return this.$store.state.optionsDeoVR.players.script_sort_seq
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.players.script_sort_seq = value
+      },
     },
     isLoading: function () {
       return this.$store.state.optionsDeoVR.loading


### PR DESCRIPTION
This change allows users to specify the sequence of files sent to the players in the APIs.

It is I response to an issue a user was having with a Multipart scene with a script for each.  The script files were in a strange order, the existing sequence is Selected Script, then Date Created.  They really just need by filename. As a work around they had to edit and resave the script files to achieve the order they needed.

I opted to make the solution more generic, rather than just by Filename, just for Script files. This was because I was doing a change anyway and maybe that wouldn't work for everyone. 

I have allowed for separate control of the sequence of both Video and Script files.  Users can choose one or more field, and each can be Ascending or Descending
Script files can be sorted by Filename, Added, Updated and Selected
Video Files can be sorted by Filename, Added, Updated, Resolution, File Size, Bit Rate, Frame Rate, Codec, Duration. 

Fields can be selected under Options/Players/Shared Player Options

The change has been applied to both Heresphere and DeoVR APIs