### PR TITLE
Add 5K filenames to VirtualPorn scrapper

### DIFF
--- a/pkg/scrape/virtualporn.go
+++ b/pkg/scrape/virtualporn.go
@@ -44,6 +44,16 @@ func VirtualPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			})
 		})
 
+		file5kExists := false
+		for _, filename := range sc.Filenames {
+			if strings.Contains(filename, "5k") {
+				file5kExists = true
+			}
+		}
+		if !file5kExists {
+			sc.Filenames = append(sc.Filenames, strings.Replace(sc.SceneID, "bvr-", "bvr", -1)+"-5k.mp4")
+		}
+
 		// Gallery
 		e.ForEach(`div.player__thumbs img`, func(id int, e *colly.HTMLElement) {
 			sc.Gallery = append(sc.Gallery, e.Attr("src"))


### PR DESCRIPTION
This mod adds 5K filenames to the VirtualPorn scrapper

VirtualPorn has been releasing content in 5K since about Feb 2022.

The list of filenames for matching is built from the list of Trailers.  But the site doesn't have 5K trailers, so this filename is missing. The change will add a 5k FIlename regardless
Their file naming also makes it difficult to manually match 5k files to a scene, e.g., bvr18991-5k.mp4, you would need to know to search for bvr-18991 (bvr18991 won't work).

The mod checks a 5k Filename doesn't already exist before adding it, in case they start providing 5k Trailers

