### PR TITLE
Add Members_url to scene

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -486,6 +486,15 @@ func Migrate() {
 				return tx.AutoMigrate(Scene{}).Error
 			},
 		},
+		{
+			ID: "0050-members-url",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					MemberURL string `json:"members_url" xbvrbackup:"members_url"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -73,6 +73,7 @@ type Scene struct {
 	ReleaseDateText string    `json:"release_date_text" xbvrbackup:"release_date_text"`
 	CoverURL        string    `json:"cover_url" xbvrbackup:"cover_url"`
 	SceneURL        string    `json:"scene_url" xbvrbackup:"scene_url"`
+	MemberURL       string    `json:"members_url" xbvrbackup:"members_url"`
 	IsMultipart     bool      `json:"is_multipart" xbvrbackup:"is_multipart"`
 
 	StarRating     float64         `json:"star_rating" xbvrbackup:"star_rating"`
@@ -393,6 +394,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 		o.CoverURL = ext.Covers[0]
 	}
 	o.SceneURL = ext.HomepageURL
+	o.MemberURL = ext.MembersUrl
 
 	// Trailers
 	o.TrailerType = ext.TrailerType

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -32,6 +32,7 @@ type ScrapedScene struct {
 	Synopsis    string   `json:"synopsis"`
 	Released    string   `json:"released"`
 	HomepageURL string   `json:"homepage_url"`
+	MembersUrl  string   `json:"members_url"`
 	TrailerType string   `json:"trailer_type"`
 	TrailerSrc  string   `json:"trailer_source"`
 }

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -27,6 +27,7 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 		sc.Studio = "CzechVR"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://www.czechvrnetwork.com/", "https://www.czechvrnetwork.com/members/", 1)
 
 		// Title
 		e.ForEach(`div.post div.nazev h1`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -30,6 +30,7 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 		sc.Site = siteID
 		sc.Title = ""
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://www.naughtyamerica.com/", "https://members.naughtyamerica.com/", 1)
 
 		// Scene ID - get from URL
 		tmp := strings.Split(sc.HomepageURL, "-")

--- a/pkg/scrape/virtualporn.go
+++ b/pkg/scrape/virtualporn.go
@@ -27,6 +27,7 @@ func VirtualPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		sc.Studio = "BangBros"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = "https://members.bangbros.com/product/655/movie/" + strings.Replace(strings.Split(e.Request.URL.String(), "/")[3], "video", "", 1)
 
 		// Title / Cover / ID / Filenames
 		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -31,6 +31,7 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.Studio = "VRHush"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://vrhush.com/scenes/", "https://ma.vrhush.com/scene/", 1)
 
 		// Scene ID - get from URL
 		tmp := strings.Split(sc.HomepageURL, "/")

--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -31,6 +31,7 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		sc.Studio = "WetVR"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://wetvr.com/", "https://members.wetvr.com/", 1)
 
 		// Scene ID - get from previous page
 		sc.SiteID = e.Request.Ctx.GetAny("scene-id").(string)

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -76,7 +76,9 @@
                   <small class="is-pulled-right">{{ format(parseISO(item.release_date), "yyyy-MM-dd") }}</small>
                 </h3>
                 <small>
-                  <a :href="item.scene_url" target="_blank" rel="noreferrer">{{ item.site }}</a>
+                  <a :href="item.scene_url" target="_blank" rel="noreferrer">{{ item.site }}</a>                  
+                  <br  v-if="item.members_url != ''"/>
+                  <a v-if="item.members_url != ''" :href="item.members_url" target="_blank" rel="noreferrer">Members Link</a>                  
                 </small>
                 <div class="columns mt-0">
                   <div class="column pt-0">

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -48,6 +48,7 @@
 
       <span class="is-pulled-right" style="font-size:11px;text-align:right;">
         <a :href="item.scene_url" target="_blank" rel="noreferrer">{{item.site}}</a><br/>
+        <a v-if="item.members_url != ''" :href="item.members_url" target="_blank" rel="noreferrer">Members Link</a><br/>
         <span v-if="item.release_date !== '0001-01-01T00:00:00Z'">
           {{format(parseISO(item.release_date), "yyyy-MM-dd")}}
         </span>


### PR DESCRIPTION
A number of sites have a separate member's area with no links or redirects to easily go between their public facing area and their members area.

To download content you have to search for the scene first.  This feature adds a Members Link so you can go straight to the scene in the members are.
Sites included in the new feature are

- All Czech VR Network sites
- NaughtyAmeric VR
- VirtualPorn
- WetVr
- VRHush

Member urls are not created for sites that don't benefit from the feature, i.e., they may redirect or if logged you get the member features anyway.

Note: VRHush is based on information provided, I don't have a membership, so the links are untested.

This feature in no way negates needing a valid membership and to be logged in.

Some users are redirecting across domains to other aggregator sites, e.g., if you had a POVR membership you could redirect from the public Milfvr scene to a POVR scenes.  However, if you don't have a POVR membership but you have a WankzVR one, redirecting to WankzVR  is also possible.  Since these redirects across different domains depends on what memberships they have and therefore are user specific, they have not been included.