### PR TITLE
Add is hidden status

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -412,6 +412,10 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		addFeatureTag("Has cuepoints")
 	}
 
+	if scene.IsHidden {
+		addFeatureTag("Hidden")
+	}
+
 	tags = append(tags, HeresphereTag{
 		Name: "Studio:" + scene.Site,
 	})

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -362,6 +362,9 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 		scene.IsWatched = !scene.IsWatched
 	}
 
+	if r.List == "is_hidden" {
+		scene.IsHidden = !scene.IsHidden
+	}
 	scene.Save()
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type ObjectConfig struct {
 		SceneCuepoint    bool   `default:"true" json:"sceneCuepoint"`
 		ShowHspFile      bool   `default:"true" json:"showHspFile"`
 		SceneTrailerlist bool   `default:"true" json:"sceneTrailerlist"`
+		HiddenScenes     bool   `default:"false" json:"hiddenScenes"`
 		UpdateCheck      bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Vendor struct {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -20,6 +20,7 @@ type ObjectState struct {
 		SceneCuepoint    bool   `json:"sceneCuepoint"`
 		ShowHspFile      bool   `json:"showHspFile"`
 		SceneTrailerlist bool   `json:"sceneTrailerlist"`
+		HiddenScenes     bool   `json:"hiddenScenes"`
 		UpdateCheck      bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -486,7 +486,16 @@ func Migrate() {
 				return tx.AutoMigrate(Scene{}).Error
 			},
 		},
+		{
+			ID: "0049-Add-Is_Hidden-To-Cuepoints",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					IsHidden bool `json:"is_hidden" gorm:"default:false" xbvrbackup:"is_hidden"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
 
+			},
+		},
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below
 		// ===============================================================================================

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -538,14 +538,26 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 	}
 
 	for _, i := range r.Lists {
-		if i.OrElse("") == "watchlist" {
-			tx = tx.Where("watchlist = ?", true)
-		}
-		if i.OrElse("") == "favourite" {
-			tx = tx.Where("favourite = ?", true)
-		}
-		if i.OrElse("") == "scripted" {
-			tx = tx.Where("is_scripted = ?", true)
+		truefalse := true
+		fieldName := i.OrElse("")
+
+		if fieldName != "" {
+			if strings.HasPrefix(fieldName, "!") { // ! prefix indicate NOT filtering
+				truefalse = false
+				fieldName = fieldName[1:]
+			}
+			switch fieldName {
+			case "star_rating":
+				if truefalse {
+					tx = tx.Where("star_rating > ?", 0)
+				} else {
+					tx = tx.Where("star_rating = ?", 0)
+				}
+			case "scripted":
+				tx = tx.Where("is_scripted = ?", truefalse)
+			default:
+				tx = tx.Where(fieldName+" = ?", truefalse)
+			}
 		}
 	}
 

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -28,7 +28,8 @@
               </vue-load-image>
             </div>
             <div class="media-content">
-              {{ props.option.site}}<br/>
+              {{ props.option.site}} 
+              <b-icon v-if="props.option.is_hidden" pack="mdi" icon="eye-off-outline" size="is-small"/><br/>
               <div class="truncate"><strong>{{ props.option.title }}</strong></div>
               <div style="margin-top:0.5em">
                 <small>

--- a/ui/src/components/HiddenButton.vue
+++ b/ui/src/components/HiddenButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <a :class="buttonClass"
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'is_hidden'})"
+     :title="item.is_hidden ? 'Unhide' : 'Mark as hidden'">
+    <b-icon pack="mdi" :icon="item.is_hidden ? 'eye-off-outline' : 'eye-off-outline'" size="is-small"/>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'HiddenButton',
+  props: { item: Object },
+  computed: {
+    buttonClass () {
+      if (this.item.is_hidden) {
+        return 'button is-danger is-small'
+      }
+      return 'button is-danger is-outlined is-small'
+    }
+  }
+}
+</script>

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -11,6 +11,7 @@ const state = {
     sceneCuepoint: true,
     showHspFile: true,
     sceneTrailerlist: true,
+    hiddenScenes: false,
     updateCheck: true
   }
 }
@@ -31,7 +32,8 @@ const actions = {
         state.web.sceneCuepoint = data.config.web.sceneCuepoint
         state.web.showHspFile = data.config.web.showHspFile
         state.web.sceneTrailerlist = data.config.web.sceneTrailerlist
-        state.web.updateCheck = data.config.web.updateCheck
+        state.web.hiddenScenes=data.config.web.hiddenScenes
+        state.web.updateCheck = data.config.web.updateCheck        
         state.loading = false
       })
   },
@@ -48,6 +50,7 @@ const actions = {
         state.web.sceneCuepoint = data.sceneCuepoint
         state.web.showHspFile = data.showHspFile
         state.web.sceneTrailerlist = data.sceneTrailerlist
+        state.web.hiddenScenes=data.hiddenScenes
         state.web.updateCheck = data.updateCheck
         state.loading = false
       })

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -12,7 +12,7 @@ const defaultFilterState = {
   dlState: 'available',
   cardSize: '1',
 
-  lists: [],
+  lists: ['visibleOnly'],
   isAvailable: true,
   isAccessible: true,
   isWatched: null,
@@ -97,6 +97,9 @@ const mutations = {
         }
         if (payload.list === 'needs_update') {
           obj.needs_update = !obj.needs_update
+        }
+        if (payload.list === 'is_hidden') {
+          obj.is_hidden = !obj.is_hidden
         }
       }
       return obj

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -38,6 +38,11 @@
             </b-table-column>
             <b-table-column field="site" :label="$t('Site')" sortable v-slot="props">
               <a :href="props.row.scene_url" target="_blank" rel="noreferrer">{{ props.row.site }}</a><br>
+              <b-tooltip v-if="props.row.is_hidden" label="Flagged as Hidden"  :delay="250" >
+                <b-tag type="is-info is-light" >
+                  <b-icon pack="mdi" icon="eye-off-outline" size="is-small" style="margin-right:0.1em"/>                
+                </b-tag>&nbsp;
+              </b-tooltip>
               <b-tag type="is-info is-light" v-if="videoFilesCount(props.row)">
                 <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
                 {{videoFilesCount(props.row)}}

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -56,6 +56,15 @@
               </b-switch>
             </b-field>
 
+            <b-tooltip label="Enables Hidden Scenes. This will allow you to flag scenes to not be displayed in the filtered scene list, Saved Searches or Players"
+              size="is-large" type="is-primary is-light" multilined :delay="1000" >
+              <b-field label="Hidden Scenes">
+                <b-switch v-model="hiddenScenes">
+                  Enabled
+                </b-switch>
+              </b-field>
+            </b-tooltip>
+
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
                 Enabled
@@ -130,6 +139,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.sceneEdit = value
+      }
+    },
+    hiddenScenes: {
+      get () {
+        return this.$store.state.optionsWeb.web.hiddenScenes
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.hiddenScenes = value
       }
     },
     updateCheck: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -85,6 +85,7 @@
                   </div>
                   <div class="column pt-0">
                     <div class="is-pulled-right">
+                      <hidden-button :item="item"/>&nbsp;  
                       <watchlist-button :item="item"/>&nbsp;                      
                       <trailerlist-button :item="item"/>&nbsp;
                       <favourite-button :item="item"/>&nbsp;
@@ -273,11 +274,11 @@ import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import RefreshButton from '../../components/RefreshButton'
 import TrailerlistButton from '../../components/TrailerlistButton'
-
+import HiddenButton from '../../components/HiddenButton'
 
 export default {
   name: 'Details',
-  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton, TrailerlistButton },
+  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton, TrailerlistButton, HiddenButton },
   data () {
     return {
       index: 1,

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -7,7 +7,17 @@
     <div class="is-divider" data-content="Properties"></div>
 
     <div class="columns is-multiline is-gapless">
-      <div class="column is-half">
+      <div class="column is-half" v-if="this.$store.state.optionsWeb.web.hiddenScenes">      
+        <b-button expanded
+          :type="visibleState==false ? 'is-danger': (visibleState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'visibleOnly', visibleState)">
+          <b-icon pack="mdi" v-if="visibleState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="visibleState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" :icon="visibleState==false ? 'eye-off-outline' : 'eye-outline'" />
+          <span>{{ $t( visibleState==undefined ? 'Show All' : (visibleState==false ? 'Hidden Only' : 'Visible Only')) }}</span>
+        </b-button>
+      </div>
+      <div class="column is-half" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist">
         <b-button expanded
           :type="watchlistState==false ? 'is-danger': (watchlistState ? 'is-success' : '')"
           @click.native.prevent="toggleProperty($event, 'watchlist', watchlistState)">
@@ -250,6 +260,7 @@ export default {
       filteredCast: [],
       filteredSites: [],
       filteredTags: [],
+      visibleState: true,
       watchlistState: undefined,
       favouriteState: undefined,
       scriptedState: undefined,
@@ -259,6 +270,7 @@ export default {
   },
   watch: {    
     lists(newList, oldList) {      
+      this.visibleState= undefined
       this.watchlistState= undefined
       this.favouriteState= undefined
       this.scriptedState= undefined
@@ -272,6 +284,9 @@ export default {
           field=element.replace("!","")
         }
         switch (field) {
+          case "visibleOnly":
+            this.visibleState=truefalse
+            break
           case "watchlist":      
             this.watchlistState=truefalse
             break

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -8,22 +8,54 @@
 
     <div class="columns is-multiline is-gapless">
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="watchlist" type="is-primary">
+        <b-button expanded
+          :type="watchlistState==false ? 'is-danger': (watchlistState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'watchlist', watchlistState)">
+          <b-icon pack="mdi" v-if="watchlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="watchlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="calendar-check"/>
           <span>{{ $t('Watchlist') }}</span>
-        </b-checkbox-button>
+        </b-button>
       </div>
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="favourite" type="is-danger">
+        <b-button expanded
+          :type="favouriteState==false ? 'is-danger': (favouriteState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'favourite', favouriteState)">
+          <b-icon pack="mdi" v-if="favouriteState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="favouriteState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="heart"/>
           <span>{{ $t('Favourite') }}</span>
-        </b-checkbox-button>
+        </b-button>
       </div>
       <div class="column is-half">
-        <b-checkbox-button v-model="lists" native-value="scripted" type="is-info">
+        <b-button expanded
+          :type="scriptedState==false ? 'is-danger': (scriptedState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'scripted', scriptedState)">
+          <b-icon pack="mdi" v-if="scriptedState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="scriptedState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
           <b-icon pack="mdi" icon="pulse"/>
           <span>{{ $t('Scripted') }}</span>
-        </b-checkbox-button>
+        </b-button>
+      </div>
+      <div class="column is-half" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist">
+        <b-button expanded
+          :type="trailerlistState==false ? 'is-danger': (trailerlistState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'trailerlist', trailerlistState)">
+          <b-icon pack="mdi" v-if="trailerlistState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="trailerlistState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" icon="movie-search-outline"/>
+          <span>{{ $t('Trailer List') }}</span>
+        </b-button>
+      </div>
+      <div class="column is-half">
+        <b-button expanded
+          :type="ratingState==false ? 'is-danger': (ratingState ? 'is-success' : '')"
+          @click.native.prevent="toggleProperty($event, 'star_rating', ratingState)">
+          <b-icon pack="mdi" v-if="ratingState==false" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" v-if="ratingState==true" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+          <b-icon pack="mdi" icon="star"/>
+          <span>{{ $t('Rating') }}</span>
+        </b-button>
       </div>
     </div>
 
@@ -217,10 +249,76 @@ export default {
     return {
       filteredCast: [],
       filteredSites: [],
-      filteredTags: []
+      filteredTags: [],
+      watchlistState: undefined,
+      favouriteState: undefined,
+      scriptedState: undefined,
+      trailerlistState: undefined,
+      ratingState: undefined
     }
   },
+  watch: {    
+    lists(newList, oldList) {      
+      this.watchlistState= undefined
+      this.favouriteState= undefined
+      this.scriptedState= undefined
+      this.trailerlistState= undefined
+      this.ratingState= undefined 
+      newList.forEach((element) => { 
+        let truefalse = true
+        let field=element
+        if (element.startsWith("!")) {
+          truefalse=false
+          field=element.replace("!","")
+        }
+        switch (field) {
+          case "watchlist":      
+            this.watchlistState=truefalse
+            break
+          case "favourite":      
+            this.favouriteState=truefalse
+            break
+          case "scripted":      
+            this.scriptedState=truefalse
+            break
+          case "trailerlist":      
+            this.trailerlistState=truefalse
+            break
+          case "star_rating":      
+            this.ratingState=truefalse
+            break
+        }
+      })
+    }
+  },  
   methods: {
+    toggleProperty(e, propertyName, propertyValue) {      
+      let tmpList=this.lists
+      // find and replace the property in tmpList
+      let found = tmpList.findIndex((element) => element.endsWith(propertyName))
+      // toggle undefined->true->false->undefined
+      if (propertyValue==true) {
+        if (found>=0) {
+          tmpList.splice(found,1,'!'+propertyName)
+        } else {
+          tmpList.push('!'+propertyName)
+        }
+        propertyValue = false
+      } else if (propertyValue === undefined) {
+        if (found>=0) {
+          tmpList.splice(found,1,propertyName)
+        } else {
+          tmpList.push(propertyName)
+        }
+        propertyValue = true
+      } else {
+        if (found>=0) {
+          tmpList.splice(found,1)
+        } 
+        propertyValue = undefined
+      }      
+      this.lists=tmpList        
+},
     reloadList () {
       this.$router.push({
         name: 'scenes',
@@ -422,8 +520,7 @@ export default {
       },
       set (value) {
         this.$store.state.sceneList.filters.tags = value
-        this.reloadList()
-        console.log('reloaded',value)
+        this.reloadList()        
       }
     },
     cuepoint: {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -40,6 +40,7 @@
     <div style="padding-top:4px;">
       <div class="scene_title">{{item.title}}</div>
 
+      <hidden-button :item="item"/>
       <watchlist-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneWatchlist"/>
       <trailerlist-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist"/>
       <favourite-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneFavourite"/>
@@ -63,11 +64,12 @@ import FavouriteButton from '../../components/FavouriteButton'
 import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import TrailerlistButton from '../../components/TrailerlistButton'
+import HiddenButton from '../../components/HiddenButton'
 
 export default {
   name: 'SceneCard',
   props: { item: Object },
-  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton, TrailerlistButton },
+  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton, TrailerlistButton, HiddenButton },
   data () {
     return {
       preview: false,


### PR DESCRIPTION
This feature adds the ability to flag scenes as Hidden.  A feature that has come up in the XBVR Discord a number of times.
NOTE: this PR is built on #1049 If the Property Field Filter Enhancements PR is not merged into main, I will need to rewrite parts of it and resubmit.

This feature does not attempt to hide scenes through the whole code base, it adds the ability to hide them in the Filtered Scene List/Saved Searches, where you can easily hide them (default behavior) or show them as required. This flows through to the Player APIs as they are driven by Saved Searches.

The Option needs to be enabled in Options/Web UI/Hidden Scenes

A new Property has been added to the Filters.  You can filter All Scenes, Only Scenes that are not Hidden (default) and Only Hidden Scenes.

If you Disable the option, they system will revert to the current state.  If you re-enable the option again, and Scenes that were previously flagged as hidden before disabling the feature, will still be flagged as hidden, they won't have to be redone.

The Quick Find and File matching lists will show all scenes; however, they will have an Icon to indicate they are flagged as hidden.

Quick Find, icon next to the Scene Title
![image](https://user-images.githubusercontent.com/104477758/207243407-80374141-c9b7-4d3a-b5fd-d8ebc132d033.png)

File Matching below the Scene Title
![image](https://user-images.githubusercontent.com/104477758/207243805-8c7c2e0e-9e34-463c-8da7-cac7144ca59e.png)

