### PR TITLE
Fix Process Locking

### DIFF
--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -212,6 +212,7 @@ func ReapplyEdits() {
 func Scrape(toScrape string) {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
+		defer models.RemoveLock("scrape")
 		t0 := time.Now()
 		tlog := log.WithField("task", "scrape")
 		tlog.Infof("Scraping started at %s", t0.Format("Mon Jan _2 15:04:05 2006"))
@@ -265,13 +266,12 @@ func Scrape(toScrape string) {
 				time.Now().Sub(t0).Round(time.Second))
 		}
 	}
-
-	models.RemoveLock("scrape")
 }
 
 func ScrapeJAVR(queryString string) {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
+		defer models.RemoveLock("scrape")
 		t0 := time.Now()
 		tlog := log.WithField("task", "scrape")
 		tlog.Infof("Scraping started at %s", t0.Format("Mon Jan _2 15:04:05 2006"))
@@ -312,12 +312,12 @@ func ScrapeJAVR(queryString string) {
 		}
 
 	}
-	models.RemoveLock("scrape")
 }
 
 func ScrapeTPDB(apiToken string, sceneUrl string) {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
+		defer models.RemoveLock("scrape")
 		t0 := time.Now()
 		tlog := log.WithField("task", "scrape")
 		tlog.Infof("Scraping started at %s", t0.Format("Mon Jan _2 15:04:05 2006"))
@@ -367,12 +367,12 @@ func ScrapeTPDB(apiToken string, sceneUrl string) {
 		}
 
 	}
-	models.RemoveLock("scrape")
 }
 
 func ExportBundle() {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
+		defer models.RemoveLock("scrape")
 		t0 := time.Now()
 
 		tlog := log.WithField("task", "scrape")
@@ -401,7 +401,6 @@ func ExportBundle() {
 			}
 		}
 	}
-	models.RemoveLock("scrape")
 }
 
 func ImportBundle(uploadData string) {
@@ -451,6 +450,7 @@ func BackupBundle(inclAllSites bool, inclScenes bool, inclFileLinks bool, inclCu
 
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
+		defer models.RemoveLock("scrape")
 		t0 := time.Now()
 
 		tlog := log.WithField("task", "scrape")
@@ -596,7 +596,6 @@ func BackupBundle(inclAllSites bool, inclScenes bool, inclFileLinks bool, inclCu
 			}
 		}
 	}
-	models.RemoveLock("scrape")
 	return string(content)
 }
 

--- a/pkg/tasks/heatmap.go
+++ b/pkg/tasks/heatmap.go
@@ -49,6 +49,7 @@ type GradientTable []struct {
 func GenerateHeatmaps(tlog *logrus.Entry) {
 	if !models.CheckLock("heatmaps") {
 		models.CreateLock("heatmaps")
+		defer models.RemoveLock("scrape")
 
 		db, _ := models.GetDB()
 		defer db.Close()
@@ -79,8 +80,6 @@ func GenerateHeatmaps(tlog *logrus.Entry) {
 			}
 		}
 	}
-
-	models.RemoveLock("heatmaps")
 }
 
 func LoadFunscriptData(path string) (Script, error) {

--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -18,6 +18,7 @@ import (
 func GeneratePreviews(endTime *time.Time) {
 	if !models.CheckLock("previews") {
 		models.CreateLock("previews")
+		defer models.RemoveLock("scrape")
 		log.Infof("Generating previews")
 		db, _ := models.GetDB()
 		defer db.Close()
@@ -60,7 +61,6 @@ func GeneratePreviews(endTime *time.Time) {
 		}
 	}
 	log.Infof("Previews generated")
-	models.RemoveLock("previews")
 }
 
 func RenderPreview(inputFile string, destFile string, videoProjection string, startTime int, snippetLength float64, snippetAmount int, resolution int, extraSnippet bool) error {

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -88,6 +88,7 @@ func (i *Index) PutScene(scene models.Scene) error {
 func SearchIndex() {
 	if !models.CheckLock("index") {
 		models.CreateLock("index")
+		defer models.RemoveLock("scrape")
 
 		tlog := log.WithFields(logrus.Fields{"task": "scrape"})
 
@@ -133,7 +134,5 @@ func SearchIndex() {
 		idx.Bleve.Close()
 
 		tlog.Infof("Search index built!")
-
-		models.RemoveLock("index")
 	}
 }

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -28,6 +28,7 @@ var allowedVideoExt = []string{".mp4", ".avi", ".wmv", ".mpeg4", ".mov", ".mkv"}
 func RescanVolumes(id int) {
 	if !models.CheckLock("rescan") {
 		models.CreateLock("rescan")
+		defer models.RemoveLock("scrape")
 
 		tlog := log.WithFields(logrus.Fields{"task": "rescan"})
 		tlog.Infof("Start scanning volumes")
@@ -129,8 +130,6 @@ func RescanVolumes(id int) {
 		r = models.RequestSceneList{IsWatched: optional.NewBool(false), IsAvailable: optional.NewBool(true)}
 		common.AddMetricPoint("scenes_downloaded_unwatched", float64(models.QueryScenes(r, false).Results))
 	}
-
-	models.RemoveLock("rescan")
 }
 
 func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {


### PR DESCRIPTION
A number of processes create a Lock to stop multiple instances from running.  This works most of the time, but it can fail.

The Processes follow a pattern of
```
	if !models.CheckLock("scrape") {
		models.CreateLock("scrape")

			do something
	}
	models.RemoveLock("scrape")
```

- The first time a process runs, the CheckLock will be False, and the process WILL start to do something and Remove the Lock just before exiting
- If the first process is still running and a second process tries to run, the CheckLock  will be True, and it will NOT do something and Remove the Lock just before exiting
- If the first process is still running and a third process tries to run, the CheckLock will now be False and the process WILL do something, even though the first process is still running.  This is because the second process that failed to run, removed the lock before exiting

I have changed the pattern to put the RemoveLock inside the If statement, so only processes that did run, will remove it.

```
	if !models.CheckLock("scrape") {
		models.CreateLock("scrape")
		defer models.RemoveLock("scrape")
	
			do some something			
	}
```

I have also done a defer for the RemoveLock at the start of processing, in the unlikely event of a Panic, the Lock will still be removed, otherwise the user has to restart xbvr, when it removes all locks anyway
