### PR TITLE
 Separate Multi-Track Cuepoint Split Options

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -389,22 +389,71 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 			end = start + 1000
 		}
 
-		// split the name into position, action and and extras
-		var cuepointNames []string
-		if config.Config.Interfaces.Heresphere.MultitrackCuepoints {
-			cuepointNames = strings.Split(scene.Cuepoints[i].Name, "-")
-		} else {
-			cuepointNames = append(cuepointNames, scene.Cuepoints[i].Name)
-		}
-		for idx, cuepointName := range cuepointNames {
-			track := findTrack(idx, len(cuepointNames), cuepointName, &trackAssignments, scene)
-
+		if !config.Config.Interfaces.Heresphere.MultitrackCuepoints && !config.Config.Interfaces.Heresphere.MultitrackCastCuepoints {
+			track := 0
 			tags = append(tags, HeresphereTag{
-				Name:              cuepointName,
+				Name:              scene.Cuepoints[i].Name,
 				StartMilliseconds: float64(start),
 				EndMilliseconds:   float64(end),
 				Track:             &track,
 			})
+		} else {
+			// determine cast ve non-cast cuepoints
+			var cast []string
+			var cuepoints []string
+			for _, cuepointName := range strings.Split(scene.Cuepoints[i].Name, "-") {
+				if isCast(cuepointName, scene) {
+					cast = append(cast, cuepointName)
+				} else {
+					cuepoints = append(cuepoints, cuepointName)
+				}
+			}
+
+			if config.Config.Interfaces.Heresphere.MultitrackCuepoints {
+				for idx, cuepoint := range cuepoints {
+					track, _ := findTrack(idx, len(cuepoints), cuepoint, &trackAssignments, scene)
+					if track == 0 && !config.Config.Interfaces.Heresphere.MultitrackCastCuepoints && len(cast) > 0 {
+						cuepoint = strings.Join(cast, "-") + "-" + cuepoint
+					}
+					tags = append(tags, HeresphereTag{
+						Name:              cuepoint,
+						StartMilliseconds: float64(start),
+						EndMilliseconds:   float64(end),
+						Track:             &track,
+					})
+				}
+			} else {
+				track := 0
+				tags = append(tags, HeresphereTag{
+					Name:              strings.Join(cuepoints, "-"),
+					StartMilliseconds: float64(start),
+					EndMilliseconds:   float64(end),
+					Track:             &track,
+				})
+			}
+			if len(cast) > 0 {
+				if config.Config.Interfaces.Heresphere.MultitrackCastCuepoints {
+					for _, actor := range cast {
+						track, _ := findTrack(0, 0, actor, &trackAssignments, scene)
+						tags = append(tags, HeresphereTag{
+							Name:              actor,
+							StartMilliseconds: float64(start),
+							EndMilliseconds:   float64(end),
+							Track:             &track,
+						})
+					}
+				} else {
+					if len(cuepoints) == 0 {
+						track := 0
+						tags = append(tags, HeresphereTag{
+							Name:              strings.Join(cast, "-"),
+							StartMilliseconds: float64(start),
+							EndMilliseconds:   float64(end),
+							Track:             &track,
+						})
+					}
+				}
+			}
 		}
 	}
 
@@ -884,23 +933,30 @@ func (i HeresphereResource) getHeresphereLibrary(req *restful.Request, resp *res
 	})
 }
 
-func findTrack(indexpos int, cuepointCount int, name string, trackAssignments *[]string, scene models.Scene) int {
+func findTrack(indexpos int, cuepointCount int, name string, trackAssignments *[]string, scene models.Scene) (int, bool) {
 	// find the track number to use for the actor, actors get their own track
 	if isCast(name, scene) {
-		return getTrackAssignment(name, trackAssignments)
+		if config.Config.Interfaces.Heresphere.MultitrackCastCuepoints {
+			return getTrackAssignment(name, trackAssignments), true
+		} else {
+			return getTrackAssignment("cast", trackAssignments), true
+		}
 	}
 
+	if !config.Config.Interfaces.Heresphere.MultitrackCuepoints {
+		return -1, false
+	}
 	// if a position & action exist, make the action track zero, it is more likely the main cuepoint
 	if cuepointCount > 1 {
 		if indexpos == 0 {
-			return getTrackAssignment(fmt.Sprintf("group%v", indexpos), trackAssignments)
+			return getTrackAssignment(fmt.Sprintf("group%v", indexpos), trackAssignments), false
 		}
 		if indexpos == 1 {
-			return 0
+			return 0, false
 		}
 		getTrackAssignment(fmt.Sprintf("group%v", indexpos), trackAssignments)
 	}
-	return 0
+	return 0, false
 }
 
 func isCast(name string, scene models.Scene) bool {

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -59,21 +59,22 @@ type RequestSaveOptionsDLNA struct {
 }
 
 type RequestSaveOptionsDeoVR struct {
-	Enabled               bool   `json:"enabled"`
-	AuthEnabled           bool   `json:"auth_enabled"`
-	Username              string `json:"username"`
-	Password              string `json:"password"`
-	RemoteEnabled         bool   `json:"remote_enabled"`
-	TrackWatchTime        bool   `json:"track_watch_time"`
-	RenderHeatmaps        bool   `json:"render_heatmaps"`
-	AllowFileDeletes      bool   `json:"allow_file_deletes"`
-	AllowRatingUpdates    bool   `json:"allow_rating_updates"`
-	AllowFavoriteUpdates  bool   `json:"allow_favorite_updates"`
-	AllowHspData          bool   `json:"allow_hsp_data"`
-	AllowTagUpdates       bool   `json:"allow_tag_updates"`
-	AllowCuepointUpdates  bool   `json:"allow_cuepoint_updates"`
-	AllowWatchlistUpdates bool   `json:"allow_watchlist_updates"`
-	MultitrackCuepoints   bool   `json:"multitrack_cuepoints"`
+	Enabled                 bool   `json:"enabled"`
+	AuthEnabled             bool   `json:"auth_enabled"`
+	Username                string `json:"username"`
+	Password                string `json:"password"`
+	RemoteEnabled           bool   `json:"remote_enabled"`
+	TrackWatchTime          bool   `json:"track_watch_time"`
+	RenderHeatmaps          bool   `json:"render_heatmaps"`
+	AllowFileDeletes        bool   `json:"allow_file_deletes"`
+	AllowRatingUpdates      bool   `json:"allow_rating_updates"`
+	AllowFavoriteUpdates    bool   `json:"allow_favorite_updates"`
+	AllowHspData            bool   `json:"allow_hsp_data"`
+	AllowTagUpdates         bool   `json:"allow_tag_updates"`
+	AllowCuepointUpdates    bool   `json:"allow_cuepoint_updates"`
+	AllowWatchlistUpdates   bool   `json:"allow_watchlist_updates"`
+	MultitrackCuepoints     bool   `json:"multitrack_cuepoints"`
+	MultitrackCastCuepoints bool   `json:"multitrack_cast_cuepoints"`
 }
 
 type RequestSaveOptionsPreviews struct {
@@ -313,6 +314,7 @@ func (i ConfigResource) saveOptionsDeoVR(req *restful.Request, resp *restful.Res
 	config.Config.Interfaces.Heresphere.AllowCuepointUpdates = r.AllowCuepointUpdates
 	config.Config.Interfaces.Heresphere.AllowWatchlistUpdates = r.AllowWatchlistUpdates
 	config.Config.Interfaces.Heresphere.MultitrackCuepoints = r.MultitrackCuepoints
+	config.Config.Interfaces.Heresphere.MultitrackCastCuepoints = r.MultitrackCastCuepoints
 	if r.Password != config.Config.Interfaces.DeoVR.Password && r.Password != "" {
 		hash, _ := bcrypt.GenerateFromPassword([]byte(r.Password), bcrypt.DefaultCost)
 		config.Config.Interfaces.DeoVR.Password = string(hash)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,14 +60,15 @@ type ObjectConfig struct {
 			Password       string `default:"" json:"password"`
 		} `json:"deovr"`
 		Heresphere struct {
-			AllowFileDeletes      bool `default:"false" json:"allow_file_deletes"`
-			AllowRatingUpdates    bool `default:"false" json:"allow_rating_updates"`
-			AllowFavoriteUpdates  bool `default:"false" json:"allow_favorite_updates"`
-			AllowHspData          bool `default:"false" json:"allow_hsp_data"`
-			AllowTagUpdates       bool `default:"false" json:"allow_tag_updates"`
-			AllowCuepointUpdates  bool `default:"false" json:"allow_cuepoint_updates"`
-			AllowWatchlistUpdates bool `default:"false" json:"allow_watchlist_updates"`
-			MultitrackCuepoints   bool `default:"true" json:"multitrack_cuepoints"`
+			AllowFileDeletes        bool `default:"false" json:"allow_file_deletes"`
+			AllowRatingUpdates      bool `default:"false" json:"allow_rating_updates"`
+			AllowFavoriteUpdates    bool `default:"false" json:"allow_favorite_updates"`
+			AllowHspData            bool `default:"false" json:"allow_hsp_data"`
+			AllowTagUpdates         bool `default:"false" json:"allow_tag_updates"`
+			AllowCuepointUpdates    bool `default:"false" json:"allow_cuepoint_updates"`
+			AllowWatchlistUpdates   bool `default:"false" json:"allow_watchlist_updates"`
+			MultitrackCuepoints     bool `default:"true" json:"multitrack_cuepoints"`
+			MultitrackCastCuepoints bool `default:"true" json:"multitrack_cast_cuepoints"`
 		} `json:"heresphere"`
 	} `json:"interfaces"`
 	Library struct {

--- a/ui/src/store/optionsDeoVR.js
+++ b/ui/src/store/optionsDeoVR.js
@@ -20,7 +20,8 @@ const state = {
     allow_cuepoint_updates: false,
     allow_watchlist_updates: false,
     allow_hsp_data: false,
-    multitrack_cuepoints: true
+    multitrack_cuepoints: true,
+    multitrack_cast_cuepoints: true
   }
 }
 
@@ -48,6 +49,7 @@ const actions = {
         state.heresphere.allow_watchlist_updates = data.config.interfaces.heresphere.allow_watchlist_updates
         state.heresphere.allow_hsp_data = data.config.interfaces.heresphere.allow_hsp_data
         state.heresphere.multitrack_cuepoints = data.config.interfaces.heresphere.multitrack_cuepoints
+        state.heresphere.multitrack_cast_cuepoints = data.config.interfaces.heresphere.multitrack_cast_cuepoints
         state.loading = false        
       })
   },

--- a/ui/src/views/options/sections/InterfaceDeoVR.vue
+++ b/ui/src/views/options/sections/InterfaceDeoVR.vue
@@ -136,15 +136,30 @@
               Enabled
             </b-switch>
           </b-field>
-          <b-tooltip
-            label="This option will split Cuepoint into multiple tracks, eg Standing-Doggy will split into 2 tracks in Heresphere"
-            size="is-large" type="is-primary" multilined :delay="250" >
-            <b-field label="Use Multi-Track Cuepoints">
-              <b-switch v-model="multiTrackCuepoints">
-                Enabled
-              </b-switch>
-            </b-field>
-          </b-tooltip>
+          <div class="columns">
+            <div class="column is-one-half"> 
+              <b-tooltip
+                label="This option will split Cuepoints into multiple tracks, eg Standing-Doggy will split into 2 tracks in Heresphere"
+                size="is-large" type="is-primary" multilined :delay="250" >
+                <b-field label="Use Multi-Track Cuepoints">
+                  <b-switch v-model="multiTrackCuepoints">
+                    Enabled
+                  </b-switch>
+                </b-field>
+              </b-tooltip>
+            </div>
+            <div class="column is-one-half"> 
+              <b-tooltip
+                label="This option will split Cuepoints matching the Actors Name into seperate tracks in Heresphere"
+                size="is-large" type="is-primary" multilined :delay="250" >
+                <b-field label="Use Multi-Track Cast Cuepoints">
+                  <b-switch v-model="multiTrackCastCuepoints">
+                    Enabled
+                  </b-switch>
+                </b-field>
+              </b-tooltip>
+            </div>
+          </div>
       </div>
       <b-field>
         <b-button type="is-primary" @click="save">Save and apply changes</b-button>
@@ -303,6 +318,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsDeoVR.heresphere.multitrack_cuepoints = value
+      }
+    },
+    multiTrackCastCuepoints: {
+      get () {        
+        return this.$store.state.optionsDeoVR.heresphere.multitrack_cast_cuepoints
+      },
+      set (value) {
+        this.$store.state.optionsDeoVR.heresphere.multitrack_cast_cuepoints = value
       }
     },
     isLoading: function () {


### PR DESCRIPTION
 Separate options to split multi-track cuepoints by cast or non-cast elements

You can split choose to split Cuepoints such as "Standing-Doggy" or "Cindy Shine-Missionary" into separate Track in Heresphere. This is controlled by a single option that controls both types of multi-track cuepoints

This change creates a second option so you can control splitting the different types of multi-track cuepoints independantly. You can choose to split none, one type or both.

Requested by a user who want to split the Cast Cuepoints, but not the others
