### PR TITLE
Add New Features Filtering Options

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1135,6 +1135,19 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0049-Add features-to-playlist-searchparams",
+			Migrate: func(tx *gorm.DB) error {
+				var playlists []models.Playlist
+
+				db.Where("search_params not like '%\"features\":%'").Find(&playlists)
+				for _, playlist := range playlists {
+					playlist.SearchParams = strings.Replace(playlist.SearchParams, ",\"volume\":", ",\"features\":[],\"volume\":", 1)
+					playlist.Save()
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -474,6 +474,7 @@ type RequestSceneList struct {
 	Tags         []optional.String `json:"tags"`
 	Cast         []optional.String `json:"cast"`
 	Cuepoint     []optional.String `json:"cuepoint"`
+	Features     []optional.String `json:"features"`
 	Volume       optional.Int      `json:"volume"`
 	Released     optional.String   `json:"releaseMonth"`
 	Sort         optional.String   `json:"sort"`
@@ -548,6 +549,221 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 			tx = tx.Where("is_scripted = ?", true)
 		}
 	}
+
+	// handle Feature selections
+	var orFeature []string
+	var andFeature []string
+	combinedWhere := ""
+	for idx, feature := range r.Features {
+		truefalse := true
+		fieldName := feature.OrElse("")
+		sceneAlias := "scenes_f" + strconv.Itoa(idx)
+		fileAlias := "files_f" + strconv.Itoa(idx)
+		scenecastAlias := "scene_cast_f" + strconv.Itoa(idx)
+		actorsAlias := "actors_f" + strconv.Itoa(idx)
+
+		if strings.HasPrefix(fieldName, "!") { // ! prefix indicate NOT filtering
+			truefalse = false
+			fieldName = fieldName[1:]
+		}
+		if strings.HasPrefix(fieldName, "&") { // & prefix indicate must have filtering
+			fieldName = fieldName[1:]
+		}
+		value := ""
+		if strings.HasPrefix(fieldName, "Resolution ") {
+			value = strings.Replace(fieldName[11:], "K", "", 1)
+			fieldName = "Resolution"
+		}
+		if strings.HasPrefix(fieldName, "Frame Rate ") {
+			value = strings.Replace(fieldName[11:], "fps", "", 1)
+			fieldName = "Frame Rate"
+		}
+		if strings.HasPrefix(fieldName, "Codec ") {
+			value = fieldName[6:]
+			fieldName = "Codec"
+		}
+		where := ""
+		switch fieldName {
+		case "Multiple Video Files":
+			if truefalse {
+				where = "scenes.id in (select " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".`type` = 'video' group by " + fileAlias + ".scene_id having count(*) >1)"
+			} else {
+				where = "scenes.id not in (select " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".`type` = 'video' group by " + fileAlias + ".scene_id having count(*) >1)"
+			}
+		case "Single Video File":
+			if truefalse {
+				where = "scenes.id in (select " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".`type` = 'video' group by " + fileAlias + ".scene_id having count(*) =1)"
+			} else {
+				where = "scenes.id not in (select " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".`type` = 'video' group by " + fileAlias + ".scene_id having count(*) =1)"
+			}
+		case "Has Hsp File":
+			if truefalse {
+				where = "scenes.id in (select " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".`type` = 'hsp' group by " + fileAlias + ".scene_id having count(*) >0)"
+			} else {
+				where = "scenes.id not in (select " + sceneAlias + ".id from scenes " + sceneAlias + " join files " + fileAlias + " on " + fileAlias + ".scene_id = " + sceneAlias + ".id and " + fileAlias + ".`type` = 'hsp' where " + sceneAlias + ".id=scenes.id group by " + sceneAlias + ".id)"
+			}
+		case "Rating 0", "Rating .5", "Rating 1", "Rating 1.5", "Rating 2", "Rating 2.5", "Rating 3", "Rating 3.5", "Rating 4", "Rating 4.5", "Rating 5":
+			if truefalse {
+				where = "star_rating = " + fieldName[7:]
+			} else {
+				where = "star_rating <> " + fieldName[7:]
+			}
+		case "Cast 6+":
+			if truefalse {
+				where = "scenes.id in (select " + scenecastAlias + ".scene_id from scene_cast " + scenecastAlias + " join actors " + actorsAlias + " on " + actorsAlias + ".id =" + scenecastAlias + ".actor_id where " + scenecastAlias + ".scene_id =scenes.id and " + actorsAlias + ".name not like 'aka:%' group by " + scenecastAlias + ".scene_id having count(*)>5)"
+			} else {
+				where = "scenes.id not in (select " + scenecastAlias + ".scene_id from scene_cast " + scenecastAlias + " join actors " + actorsAlias + " on " + actorsAlias + ".id =" + scenecastAlias + ".actor_id where " + scenecastAlias + ".scene_id =scenes.id and " + actorsAlias + ".name not like 'aka:%' group by " + scenecastAlias + ".scene_id having count(*)>5)"
+			}
+		case "Cast 1", "Cast 2", "Cast 3", "Cast 4", "Cast 5":
+			if truefalse {
+				where = "scenes.id in (select " + scenecastAlias + ".scene_id from scene_cast " + scenecastAlias + " join actors " + actorsAlias + " on " + actorsAlias + ".id =" + scenecastAlias + ".actor_id where " + scenecastAlias + ".scene_id =scenes.id and " + actorsAlias + ".name not like 'aka:%' group by " + scenecastAlias + ".scene_id having count(*)=" + fieldName[5:] + ")"
+			} else {
+				where = "scenes.id not in (select " + scenecastAlias + ".scene_id from scene_cast " + scenecastAlias + " join actors " + actorsAlias + " on " + actorsAlias + ".id =" + scenecastAlias + ".actor_id where " + scenecastAlias + ".scene_id =scenes.id and " + actorsAlias + ".name not like 'aka:%' group by " + scenecastAlias + ".scene_id having count(*)=" + fieldName[5:] + ")"
+			}
+		case "Resolution":
+			switch db.Dialect().GetName() {
+			case "mysql":
+				if truefalse {
+					where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and case when " + fileAlias + ".video_projection = '360_tb' then (" + fileAlias + ".video_width+499)*2 div 1000 else (" + fileAlias + ".video_width+499) div 1000 end = " + value + ")"
+				} else {
+					where = "scenes.id not in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and case when " + fileAlias + ".video_projection = '360_tb' then (" + fileAlias + ".video_width+499)*2 div 1000 else (" + fileAlias + ".video_width+499) div 1000 end = " + value + ")"
+				}
+			default:
+				if truefalse {
+					where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and case when " + fileAlias + ".video_projection = '360_tb' then (" + fileAlias + ".video_width+499)*2 / 1000 else (" + fileAlias + ".video_width+499) / 1000 end = " + value + ")"
+				} else {
+					where = "scenes.id not in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and case when " + fileAlias + ".video_projection = '360_tb' then (" + fileAlias + ".video_width+499)*2 / 1000 else (" + fileAlias + ".video_width+499) / 1000 end = " + value + ")"
+				}
+			}
+		case "Frame Rate":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_avg_frame_rate_val = " + value + " and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id not in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_avg_frame_rate_val = " + value + " and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Flat video":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='flat' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='flat' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "FOV: 180°":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('180_mono','180_sbs','fisheye') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('180_mono','180_sbs','fisheye') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "FOV: 190°":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('rf52','fisheye190') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('rf52','fisheye190') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "FOV: 200°":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx200' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx200' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "FOV: 220°":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('mkx220','vrca220') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('mkx220','vrca220') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "FOV: 360°":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('360_mono','360_tb') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('360_mono','360_tb') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Projection Perspective":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='flat' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='flat' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Projection Equirectangular":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('180_mono','180_sbs') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('180_mono','180_sbs') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Projection Equirectangular360":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('360_tb','360_mono') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('360_tb','360_mono') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Projection Fisheye":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('mkx200','mkx220','vrca220','rf52','fisheye190','fisheye') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('mkx200','mkx220','vrca220','rf52','fisheye190','fisheye') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Mono":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('flat','180_mono','360_mono') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('flat','180_mono','360_mono') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Top/Bottom":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='360_tb' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='360_tb' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Side by Side":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection not in ('360_tb','flat','180_mono','360_mono') and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection in ('360_tb','flat','180_mono','360_mono') and " + fileAlias + ".`type` = 'video')"
+			}
+		case "MKX200":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx200' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx200' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "MKX220":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx220' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='mkx220' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "VRCA220":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='vrca220' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_projection ='vrca220' and " + fileAlias + ".`type` = 'video')"
+			}
+		case "Codec":
+			if truefalse {
+				where = "scenes.id in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_codec_name = '" + value + "' and " + fileAlias + ".`type` = 'video')"
+			} else {
+				where = "scenes.id not in (select distinct " + fileAlias + ".scene_id  from files " + fileAlias + " where " + fileAlias + ".scene_id = scenes.id and " + fileAlias + ".video_codec_name = '" + value + "' and " + fileAlias + ".`type` = 'video')"
+			}
+		}
+
+		switch firstchar := string(feature.OrElse(" ")[0]); firstchar {
+		case "&", "!":
+			andFeature = append(andFeature, where)
+		default:
+			orFeature = append(orFeature, where)
+		}
+	}
+
+	if len(orFeature) > 0 {
+		combinedWhere = "(" + strings.Join(orFeature, " or ") + ")"
+	}
+	if len(andFeature) > 0 {
+		if combinedWhere == "" {
+			combinedWhere = strings.Join(andFeature, " and ")
+		} else {
+			combinedWhere = combinedWhere + " and " + strings.Join(andFeature, " and ")
+		}
+	}
+	tx = tx.Where(combinedWhere)
 
 	var sites []string
 	var excludedSites []string

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -21,6 +21,7 @@ const defaultFilterState = {
   sites: [],
   tags: [],
   cuepoint: [],
+  features: [],
   volume: 0,
   sort: 'release_desc'
 }

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -175,6 +175,24 @@
         </b-taginput>
       </b-field>
 
+      <b-field label="Features" label-position="on-border" class="field-extra">
+        <b-taginput v-model="features" autocomplete :data="filteredFeatures" @typing="getFilteredFeatures">
+          <template slot-scope="props">{{ props.option }}</template>
+          <template slot="empty">No matching features</template>
+          <template #selected="props">
+            <b-tag v-for="(tag, index) in props.tags"
+              :type="tag.charAt(0)=='!' ? 'is-danger': (tag.charAt(0)=='&' ? 'is-success' : '')"
+              :key="tag+index" :tabstop="false" closable  @close="features=features.filter(e => e !== tag)" @click="toggle3way(tag,index,'features')"> 
+              <b-tooltip position="is-right" :delay="200"
+                  :label="tag.charAt(0)=='!' ? 'Exclude ' + removeConditionPrefix(tag) : tag.charAt(0)=='&' ? 'Must Have ' + removeConditionPrefix(tag) : 'Include ' + removeConditionPrefix(tag)">
+                <b-icon pack="mdi" v-if="tag.charAt(0)=='!'" icon="minus-circle-outline" size="is-small" class="tagicon"></b-icon>
+                <b-icon pack="mdi" v-if="tag.charAt(0)=='&'" icon="plus-circle-outline" size="is-small" class="tagicon"></b-icon>
+                {{removeConditionPrefix(tag)}}
+              </b-tooltip>
+            </b-tag>
+          </template>
+        </b-taginput>
+      </b-field>
     </div>
     <div class="is-divider" data-content="Actor Also Known As groups"></div>
     <b-field>
@@ -217,7 +235,8 @@ export default {
     return {
       filteredCast: [],
       filteredSites: [],
-      filteredTags: []
+      filteredTags: [],
+      filteredFeatures: [],
     }
   },
   methods: {
@@ -243,6 +262,12 @@ export default {
     },
     getFilteredTags (text) {
       this.filteredTags = this.filters.tags.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
+        !this.tags.some(entry => this.removeConditionPrefix(entry.toString()) === option.toString())
+      ))
+    },
+    getFilteredFeatures (text) {
+      this.filteredFeatures = this.filters.features.filter(option => (
         option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
         !this.tags.some(entry => this.removeConditionPrefix(entry.toString()) === option.toString())
       ))
@@ -318,6 +343,9 @@ export default {
         case 'cuepoints':
           tags=this.cuepoint
           break
+        case 'features':
+          tags=this.features
+          break
       }      
       switch(tags[idx].charAt(0)) {
         case '!':
@@ -338,6 +366,9 @@ export default {
           break
         case 'cuepoints':
           this.cuepoint=tags
+          break
+        case 'features':
+          this.features=tags
           break
       }
     },    
@@ -433,6 +464,15 @@ export default {
       set (value) {
         this.$store.state.sceneList.filters.cuepoint = value
         this.reloadList()
+      }
+    },
+    features: {
+      get () {
+        return this.$store.state.sceneList.filters.features
+      },
+      set (value) {
+        this.$store.state.sceneList.filters.features = value
+        this.reloadList()        
       }
     },
     sort: {


### PR DESCRIPTION
This feature adds a range of new filter options.  A new control for Features has been added to the Filters section on the left-hand side of the Scenes.

New filterable values are similar to the Features List sent in the Heresphere Api.  It excludes some items that already have their own button in the Properties section, these also seem like options that would be used often and therefore suit having a dedicated button.

I have also added, an entry for each rating values. Ratings could be a slider, but I opted to use discrete values in the new list rather than start to clutter up the UI with more controls.  Likewise, everything is in one list, rather than needing a control for Ratings, one for FOV, one for Multiple File, one for Frame Rate, etc, again this was to avoid adding multiple controls for each feature
