### PR TITLE
javr: replace r18.com scene importer with javdatabase.com

### DIFF
--- a/pkg/scrape/javdatabase.go
+++ b/pkg/scrape/javdatabase.go
@@ -1,0 +1,92 @@
+package scrape
+
+import (
+	"strings"
+
+	"github.com/gocolly/colly"
+	"github.com/nleeper/goment"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+func ScrapeJavDB(knownScenes []string, out *[]models.ScrapedScene, queryString string) {
+	sceneCollector := createCollector("www.javdatabase.com")
+
+	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+		sc := models.ScrapedScene{}
+		sc.SceneType = "VR"
+		sc.Site = "JAVR"
+		sc.HomepageURL = e.Request.URL.String()
+
+		// Cover image
+		e.ForEach(`td.moviepostermobile img`, func(id int, e *colly.HTMLElement) {
+			sc.Covers = append(sc.Covers, e.Attr(`src`))
+		})
+
+		// Cast
+		e.ForEach(`div.idol-name`, func(id int, e *colly.HTMLElement) {
+			sc.Cast = append(sc.Cast, e.Text)
+		})
+
+		// Tags
+		// Skipping some very generic and useless tags
+		skiptags := map[string]bool{
+			"featured actress": true,
+			"vr exclusive":     true,
+			"high-quality vr":  true,
+			"hi-def":           true,
+		}
+
+		e.ForEach(`div.movietable tr`, func(id int, e *colly.HTMLElement) {
+			label := e.ChildText(`td.tablelabel > h3 > b`)
+
+			// Studio
+			if label == `Studio:` {
+				sc.Studio = e.ChildText(`td.tablevalue > span`)
+
+			// Title, SceneID and SiteID all like 'IPVR-016' format
+			} else if label == `DVD ID:` {
+				sc.Title = e.ChildText(`td.tablevalue`)
+				sc.SceneID = sc.Title
+				sc.SiteID = sc.Title
+
+			// Release date
+			} else if label == `Release Date:` {
+				dateStr := e.ChildText(`td.tablevalue`)
+				tmpDate, _ := goment.New(strings.TrimSpace(dateStr), "YYYY-MM-DD")
+				sc.Released = tmpDate.Format("YYYY-MM-DD")
+
+			// Tags
+			} else if label == `Genre(s):` {
+				e.ForEach(`td.tablevalue > span.tags`, func(id2 int, e2 *colly.HTMLElement) {
+					tag := strings.ToLower(e2.Text)
+
+					if !skiptags[tag] {
+						sc.Tags = append(sc.Tags, tag)
+					}
+				})
+
+			// Synopsis / description
+			} else if label == `Translated Title:` {
+				sc.Synopsis = e.ChildText(`td.tablevalue`)
+			}
+		})
+
+		// Screenshots
+		e.ForEach(`img`, func(id int, e *colly.HTMLElement) {
+			alt := e.Attr(`alt`)
+			if strings.Contains(alt, "Screenshot") {
+				sc.Gallery = append(sc.Gallery, e.Attr(`src`))
+			}
+		})
+
+		*out = append(*out, sc)
+	})
+
+	// Allow comma-separated scene id's
+	scenes := strings.Split(queryString, ",")
+	for _, v := range scenes {
+		sceneCollector.Visit("https://www.javdatabase.com/movies/" + strings.ToLower(v) + "/")
+	}
+
+	sceneCollector.Wait()
+}

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -290,8 +290,8 @@ func ScrapeJAVR(queryString string) {
 		// Start scraping
 		var collectedScenes []models.ScrapedScene
 
-		tlog.Infof("Scraping R18")
-		scrape.ScrapeR18(knownScenes, &collectedScenes, queryString)
+		tlog.Infof("Scraping JavDB")
+		scrape.ScrapeJavDB(knownScenes, &collectedScenes, queryString)
 
 		if len(collectedScenes) > 0 {
 			db, _ := models.GetDB()

--- a/ui/src/views/options/sections/OptionsSceneCreate.vue
+++ b/ui/src/views/options/sections/OptionsSceneCreate.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="content">
-    <h3 class="title">{{$t('Import JAVR scene from R18')}}</h3>
+    <h3 class="title">{{$t('Import JAVR scene from javdatabase.com')}}</h3>
     <div class="card">
       <div class="card-content content">
         <b-field grouped>
-          <b-input v-model="javrQuery" placeholder="URL or ID (XXXX-001)" type="search"></b-input>
+          <b-input v-model="javrQuery" placeholder="ID (xxxx-001)" type="search"></b-input>
           <b-button class="button is-primary" v-on:click="scrapeJAVR()">{{$t('Go')}}</b-button>
         </b-field>
       </div>


### PR DESCRIPTION
The R18 scene importer isn't working anymore. Here's a potential replacement. Note that I don't know javdatabase.com and this parser would break easily if they change their syntax.

Usage: enter comma-separated list of one or more JAVR scene id's (like IPVR-001,SAVR-002, etc) in the "Import scene" section in the settings/options page.