### PR TITLE
VirtualRealPorn studio titles fix

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -18,7 +18,7 @@ type EnvConfigSpec struct {
 	DebugWS          bool   `envconfig:"DEBUG_WS" default:"false"`
 	UIUsername       string `envconfig:"UI_USERNAME" required:"false"`
 	UIPassword       string `envconfig:"UI_PASSWORD" required:"false"`
-	DisableAnalytics bool   `envconfig:"DISABLE_ANALYTICS" default:"false"`
+	DisableAnalytics bool   `envconfig:"DISABLE_ANALYTICS" default:"true"`
 	DatabaseURL      string `envconfig:"DATABASE_URL" required:"false" default:""`
 }
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1135,6 +1135,25 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0050-remove-VirtualRealPorn-from-title",
+			Migrate: func(tx *gorm.DB) error {
+				var scenes []models.Scene
+				err := tx.Where("title LIKE ?", "% | VirtualReal%").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+
+				for _, scene := range scenes {
+					scene.Title = strings.TrimSpace(strings.Split(scene.Title, "|")[0])
+					err = tx.Save(&scene).Error
+					if err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -46,7 +46,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 
 		// Title
 		e.ForEach(`title`, func(id int, e *colly.HTMLElement) {
-			sc.Title = e.Text
+			sc.Title = strings.TrimSpace(strings.Split(e.Text, "|")[0])
 			sc.Title = strings.TrimSpace(strings.Replace(sc.Title, "▷ ", "", -1))
 			sc.Title = strings.TrimSpace(strings.Replace(sc.Title, fmt.Sprintf(" - %v.com", sc.Site), "", -1))
 		})


### PR DESCRIPTION
Removes site name from titles (new & existing).

Turn off broken analytics by default (404 errors)