### PR TITLE
Fix Trailerlist Button Tooltip

### DIFF
--- a/ui/src/components/TrailerlistButton.vue
+++ b/ui/src/components/TrailerlistButton.vue
@@ -2,7 +2,7 @@
   <a :class="buttonClass"
    v-if="!item.is_available & item.trailer_source !=='' & this.$store.state.optionsWeb.web.sceneTrailerlist"
      @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'trailerlist'})"
-     :title="item.watchlist ? 'Remove from Trailer List' : 'Add to Trailer List'">
+     :title="item.trailerlist ? 'Remove from Trailer List' : 'Add to Trailer List'">
     <b-icon pack="mdi" :icon="item.watchlist ? 'movie-search-outline' : 'movie-search-outline'" size="is-small"/>
   </a>
 </template>


### PR DESCRIPTION
The tooltip currently changes with the item's watchlist status, not the trailerlist status