### PR TITLE
Clear All Process Locks at Startup

### DIFF
--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"strings"
+
 	"github.com/avast/retry-go/v3"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -105,6 +107,22 @@ func RemoveLock(lock string) {
 	db.Where(&KV{Key: "lock-" + lock}).Delete(&obj)
 
 	common.PublishWS("lock.change", map[string]interface{}{"name": lock, "locked": false})
+}
+
+func RemoveAllLocks() {
+	db, _ := GetDB()
+	defer db.Close()
+
+	var locks []KV
+	err := db.Where("`key` like 'lock-%'").Find(&locks).Error
+	if err != nil {
+		return
+	}
+
+	for _, lock := range locks {
+		lockName := strings.Replace(lock.Key, "lock-", "", 1)
+		RemoveLock(lockName)
+	}
 }
 
 func init() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,10 +59,7 @@ func StartServer(version, commit, branch, date string) {
 	analytics.Event("app-start", nil)
 
 	// Remove old locks
-	models.RemoveLock("index")
-	models.RemoveLock("scrape")
-	models.RemoveLock("update-scenes")
-	models.RemoveLock("previews")
+	models.RemoveAllLocks()
 
 	go tasks.CheckDependencies()
 	models.CheckVolumes()


### PR DESCRIPTION
When XBVR starts existing Process Locks are removed.  Process locks for "files" and "heatmaps" were not included in the list of locks removed
This was not an issue before, because the issue addressed in #1061 where processes tried to run and but was still locked would still have their lock removed and allowed it to run next time.

I have changed the startup code in server.go to remove kvs starting with 'lock-' rather than just add to the list of locks to remove.  This reduces the chance of new Process Locks been added in the future and missing they need to removed at startup.