### PR TITLE
Fix Clearing Locks on Startup and Introduced in 1061

### DIFF
--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"strings"
+
 	"github.com/avast/retry-go/v3"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql"
@@ -105,6 +107,22 @@ func RemoveLock(lock string) {
 	db.Where(&KV{Key: "lock-" + lock}).Delete(&obj)
 
 	common.PublishWS("lock.change", map[string]interface{}{"name": lock, "locked": false})
+}
+
+func RemoveAllLocks() {
+	db, _ := GetDB()
+	defer db.Close()
+
+	var locks []KV
+	err := db.Where("`key` like 'lock-%'").Find(&locks).Error
+	if err != nil {
+		return
+	}
+
+	for _, lock := range locks {
+		lockName := strings.Replace(lock.Key, "lock-", "", 1)
+		RemoveLock(lockName)
+	}
 }
 
 func init() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,10 +59,7 @@ func StartServer(version, commit, branch, date string) {
 	analytics.Event("app-start", nil)
 
 	// Remove old locks
-	models.RemoveLock("index")
-	models.RemoveLock("scrape")
-	models.RemoveLock("update-scenes")
-	models.RemoveLock("previews")
+	models.RemoveAllLocks()
 
 	go tasks.CheckDependencies()
 	models.CheckVolumes()

--- a/pkg/tasks/heatmap.go
+++ b/pkg/tasks/heatmap.go
@@ -49,7 +49,7 @@ type GradientTable []struct {
 func GenerateHeatmaps(tlog *logrus.Entry) {
 	if !models.CheckLock("heatmaps") {
 		models.CreateLock("heatmaps")
-		defer models.RemoveLock("scrape")
+		defer models.RemoveLock("heatmaps")
 
 		db, _ := models.GetDB()
 		defer db.Close()

--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -18,7 +18,7 @@ import (
 func GeneratePreviews(endTime *time.Time) {
 	if !models.CheckLock("previews") {
 		models.CreateLock("previews")
-		defer models.RemoveLock("scrape")
+		defer models.RemoveLock("previews")
 		log.Infof("Generating previews")
 		db, _ := models.GetDB()
 		defer db.Close()

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -88,7 +88,7 @@ func (i *Index) PutScene(scene models.Scene) error {
 func SearchIndex() {
 	if !models.CheckLock("index") {
 		models.CreateLock("index")
-		defer models.RemoveLock("scrape")
+		defer models.RemoveLock("index")
 
 		tlog := log.WithFields(logrus.Fields{"task": "scrape"})
 

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -28,7 +28,7 @@ var allowedVideoExt = []string{".mp4", ".avi", ".wmv", ".mpeg4", ".mov", ".mkv"}
 func RescanVolumes(id int) {
 	if !models.CheckLock("rescan") {
 		models.CreateLock("rescan")
-		defer models.RemoveLock("scrape")
+		defer models.RemoveLock("rescan")
 
 		tlog := log.WithFields(logrus.Fields{"task": "rescan"})
 		tlog.Infof("Start scanning volumes")


### PR DESCRIPTION
PR #1061 cleared the incorrect process locks in some cases.
Also addressed a separate issue found that where the "files" and "heatmaps" process locks are not cleared at startup.  Changed the startup logic to clear all locks, rather than rely on clearing a list of locks