### PR TITLE
Is hidden (using dl state)

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -412,6 +412,10 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		addFeatureTag("Has cuepoints")
 	}
 
+	if scene.IsHidden {
+		addFeatureTag("Hidden")
+	}
+
 	tags = append(tags, HeresphereTag{
 		Name: "Studio:" + scene.Site,
 	})

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -362,6 +362,9 @@ func (i SceneResource) toggleList(req *restful.Request, resp *restful.Response) 
 		scene.IsWatched = !scene.IsWatched
 	}
 
+	if r.List == "is_hidden" {
+		scene.IsHidden = !scene.IsHidden
+	}
 	scene.Save()
 }
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -495,7 +495,16 @@ func Migrate() {
 				return tx.AutoMigrate(Scene{}).Error
 			},
 		},
+		{
+			ID: "0049-Add-Is_Hidden-To-Cuepoints",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					IsHidden bool `json:"is_hidden" gorm:"default:false" xbvrbackup:"is_hidden"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
 
+			},
+		},
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below
 		// ===============================================================================================

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -98,6 +98,7 @@ type Scene struct {
 	TrailerType   string `json:"trailer_type" xbvrbackup:"trailer_type"`
 	TrailerSource string `gorm:"size:1000" json:"trailer_source" xbvrbackup:"trailer_source"`
 	Trailerlist   bool   `json:"trailerlist" gorm:"default:false" xbvrbackup:"trailerlist"`
+	IsHidden      bool   `json:"is_hidden" gorm:"default:false" xbvrbackup:"is_hidden"`
 
 	Description string  `gorm:"-" json:"description" xbvrbackup:"-"`
 	Score       float64 `gorm:"-" json:"_score" xbvrbackup:"-"`
@@ -466,6 +467,7 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 }
 
 type RequestSceneList struct {
+	DlState      optional.String   `json:"dlState"`
 	Limit        optional.Int      `json:"limit"`
 	Offset       optional.Int      `json:"offset"`
 	IsAvailable  optional.Bool     `json:"isAvailable"`

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -28,7 +28,8 @@
               </vue-load-image>
             </div>
             <div class="media-content">
-              {{ props.option.site}}<br/>
+              {{ props.option.site}} 
+              <b-icon v-if="props.option.is_hidden" pack="mdi" icon="eye-off-outline" size="is-small"/><br/>
               <div class="truncate"><strong>{{ props.option.title }}</strong></div>
               <div style="margin-top:0.5em">
                 <small>

--- a/ui/src/components/HiddenButton.vue
+++ b/ui/src/components/HiddenButton.vue
@@ -1,0 +1,22 @@
+<template>
+  <a :class="buttonClass"
+     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'is_hidden'})"
+     :title="item.is_hidden ? 'Unhide' : 'Mark as hidden'">
+    <b-icon pack="mdi" :icon="item.is_hidden ? 'eye-off-outline' : 'eye-off-outline'" size="is-small"/>
+  </a>
+</template>
+
+<script>
+export default {
+  name: 'HiddenButton',
+  props: { item: Object },
+  computed: {
+    buttonClass () {
+      if (this.item.is_hidden) {
+        return 'button is-danger is-small'
+      }
+      return 'button is-danger is-outlined is-small'
+    }
+  }
+}
+</script>

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -109,5 +109,6 @@
   "JAVR scraper": "JAVR scraper",
   "Preview Generation": "Preview Generation",
   "Reset Rating": "Reset Rating",
+  "Hidden": "Hidden",
   "Go": "Go"
 }

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -15,6 +15,7 @@ const defaultFilterState = {
   lists: [],
   isAvailable: true,
   isAccessible: true,
+  isHidden: false,
   isWatched: null,
   releaseMonth: '',
   cast: [],
@@ -36,7 +37,8 @@ const state = {
     any: 0,
     available: 0,
     downloaded: 0,
-    not_downloaded: 0
+    not_downloaded: 0,
+    hidden: 0
   },
   filterOpts: {
     cast: [],
@@ -98,6 +100,9 @@ const mutations = {
         if (payload.list === 'needs_update') {
           obj.needs_update = !obj.needs_update
         }
+        if (payload.list === 'is_hidden') {
+          obj.is_hidden = !obj.is_hidden
+        }        
       }
       return obj
     })
@@ -172,6 +177,7 @@ const actions = {
     state.counts.available = data.count_available
     state.counts.downloaded = data.count_downloaded
     state.counts.not_downloaded = data.count_not_downloaded
+    state.counts.hidden = data.count_hidden
   }
 }
 

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -38,6 +38,11 @@
             </b-table-column>
             <b-table-column field="site" :label="$t('Site')" sortable v-slot="props">
               <a :href="props.row.scene_url" target="_blank" rel="noreferrer">{{ props.row.site }}</a><br>
+              <b-tooltip v-if="props.row.is_hidden" label="Flagged as Hidden"  :delay="250" >
+                <b-tag type="is-info is-light" >
+                  <b-icon pack="mdi" icon="eye-off-outline" size="is-small" style="margin-right:0.1em"/>                
+                </b-tag>&nbsp;
+              </b-tooltip>
               <b-tag type="is-info is-light" v-if="videoFilesCount(props.row)">
                 <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
                 {{videoFilesCount(props.row)}}

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -93,6 +93,7 @@
                   </div>
                   <div class="column pt-0">
                     <div class="is-pulled-right">
+                      <hidden-button :item="item"/>&nbsp;  
                       <watchlist-button :item="item"/>&nbsp;                      
                       <trailerlist-button :item="item"/>&nbsp;
                       <favourite-button :item="item"/>&nbsp;
@@ -283,11 +284,11 @@ import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import RefreshButton from '../../components/RefreshButton'
 import TrailerlistButton from '../../components/TrailerlistButton'
-
+import HiddenButton from '../../components/HiddenButton'
 
 export default {
   name: 'Details',
-  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton, TrailerlistButton },
+  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WatchedButton, EditButton, RefreshButton, TrailerlistButton, HiddenButton },
   data () {
     return {
       index: 1,

--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -20,6 +20,9 @@
           <b-radio-button v-model="dlState" native-value="missing" size="is-small">
             {{$t("Not downloaded")}} ({{counts.not_downloaded}})
           </b-radio-button>
+          <b-radio-button v-model="dlState" native-value="hidden" size="is-small">
+            {{$t("Hidden")}} ({{counts.hidden}})
+          </b-radio-button>
         </div>
       </div>
       <div class="column">
@@ -94,18 +97,27 @@ export default {
           case 'any':
             this.$store.state.sceneList.filters.isAvailable = null
             this.$store.state.sceneList.filters.isAccessible = null
+            this.$store.state.sceneList.filters.isHidden = false
             break
           case 'available':
             this.$store.state.sceneList.filters.isAvailable = true
             this.$store.state.sceneList.filters.isAccessible = true
+            this.$store.state.sceneList.filters.isHidden = false
             break
           case 'downloaded':
             this.$store.state.sceneList.filters.isAvailable = true
             this.$store.state.sceneList.filters.isAccessible = null
+            this.$store.state.sceneList.filters.isHidden = false
             break
           case 'missing':
             this.$store.state.sceneList.filters.isAvailable = false
             this.$store.state.sceneList.filters.isAccessible = null
+            this.$store.state.sceneList.filters.isHidden = false
+            break
+          case 'hidden':
+            this.$store.state.sceneList.filters.isAvailable = null
+            this.$store.state.sceneList.filters.isAccessible = null
+            this.$store.state.sceneList.filters.isHidden = true
             break
         }
 

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -40,6 +40,7 @@
     <div style="padding-top:4px;">
       <div class="scene_title">{{item.title}}</div>
 
+      <hidden-button :item="item"/>
       <watchlist-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneWatchlist"/>
       <trailerlist-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneTrailerlist"/>
       <favourite-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneFavourite"/>
@@ -64,11 +65,12 @@ import FavouriteButton from '../../components/FavouriteButton'
 import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import TrailerlistButton from '../../components/TrailerlistButton'
+import HiddenButton from '../../components/HiddenButton'
 
 export default {
   name: 'SceneCard',
   props: { item: Object },
-  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton, TrailerlistButton },
+  components: { WatchlistButton, FavouriteButton, WatchedButton, EditButton, TrailerlistButton, HiddenButton },
   data () {
     return {
       preview: false,


### PR DESCRIPTION
This feature adds the ability to flag scenes as Hidden. A feature that has come up in the XBVR Discord a number of times.
This feature does not attempt to hide scenes through the whole code base, it uses a new Download State tab to separate them out from unhidden scenes.

A scene can be flagged as hidden in the Scene List or Scene Detail. 
![image](https://user-images.githubusercontent.com/104477758/210900324-7e2f8595-dd17-4965-9411-fa11d6403713.png)


The Quick Find and File matching lists will show all scenes; however, they will have an Icon to indicate they are flagged as hidden.

Quick Find, Hidden icon next to the Scene Title
![image](https://user-images.githubusercontent.com/104477758/210899592-cdbf47a5-ce8d-41d9-95d1-197f65b7525e.png)

File Matching Icon below the Scene Title
![image](https://user-images.githubusercontent.com/104477758/210899632-8049976a-bb3f-43ef-946c-3e69cae72594.png)


If a scene is flagged as Hidden, it will only be listed under Hidden, e.g. a Hidden scene with a downloaded video, it will not be listed under Downloaded.  I think this best reflects the intention people would usually have when hiding a scene.  

This PR replaces #1060 

