### PR TITLE
search index: faster method of adding newly scraped scenes

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -181,7 +181,7 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 		return
 	}
 
-    // Update search index with new scene
+	// Update search index with new scene
 	scenes := []models.Scene{resultingScene}
 	tasks.IndexScenes(&scenes)
 

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -723,6 +723,10 @@ func (i SceneResource) editScene(req *restful.Request, resp *restful.Response) {
 
 		scene.Save()
 
+		// Update search index with new data
+		scenes := []models.Scene{scene}
+		tasks.IndexScenes(&scenes)
+
 		resp.WriteHeaderAndEntity(http.StatusOK, scene)
 	}
 }

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -181,6 +181,10 @@ func (i SceneResource) createCustomScene(req *restful.Request, resp *restful.Res
 		return
 	}
 
+    // Update search index with new scene
+	scenes := []models.Scene{resultingScene}
+	tasks.IndexScenes(&scenes)
+
 	resp.WriteHeaderAndEntity(http.StatusOK, resultingScene)
 }
 

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -669,7 +669,7 @@ func RestoreBundle(request RequestRestore) {
 			}
 			if request.InclScenes {
 				CountTags()
-				SearchIndex()
+				IndexScenes(&(bundleData.Scenes))
 			}
 
 			if request.InclScenes || request.InclActorAkas {

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -302,7 +302,7 @@ func ScrapeJAVR(queryString string) {
 
 			tlog.Infof("Updating tag counts")
 			CountTags()
-			SearchIndex()
+			IndexScrapedScenes(&collectedScenes)
 
 			tlog.Infof("Scraped %v new scenes in %s",
 				len(collectedScenes),

--- a/pkg/tasks/search.go
+++ b/pkg/tasks/search.go
@@ -174,11 +174,9 @@ func IndexScenes(scenes *[]models.Scene) {
 			}
 		}
 
-		tlog.Infof("Indexed %v new scenes", total)
-
 		idx.Bleve.Close()
 
-		tlog.Infof("Search index built!")
+		tlog.Infof("Indexed %v scenes", total)
 	}
 }
 


### PR DESCRIPTION
After adding 1 or more scraped scenes from the JAVR scene importers, XBVR would check all existing scenes in the database for their presence in the search index. If you have scraped a large amount of scenes, this takes a very long time after every single scene import.

This commit changes that by _only_ adding the newly scraped scenes into the index.

Furthermore, the previous code would keep the index as-is if a scene with the same SceneID already existed in the index. But if you re-scrape the same scene, the data may have been updated and the search index should now be updated as well.

This commit only uses the new code for the JAVR scene importers to start with, but in theory the other importers can use the same new method after a scrape as well..