### PR TITLE
JAVR Tag Update

### DIFF
--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -38,15 +38,16 @@ func ProcessJavrTag(tag string) string {
 	// Map some tags to normalize so different sources match
 	// TODO: this mapping is totally incomplete and needs help from community to fill
 	maptags := map[string]string{
-		"blow":         "blowjob",
-		"blow job":     "blowjob",
-		"kiss":         "kiss kiss",
-		"kiss / kiss":  "kiss kiss",
-		"prostitute":   "club hostess & sex worker",
-		"prostitutes":  "club hostess & sex worker",
-		"sun tan":      "suntan",
-		"huge cock":    "huge dick - large dick",
-		"other fetish": "other fetishes",
+		"blow":               "blowjob",
+		"blow job":           "blowjob",
+		"kiss":               "kiss kiss",
+		"kiss / kiss":        "kiss kiss",
+		"prostitute":         "club hostess & sex worker",
+		"prostitutes":        "club hostess & sex worker",
+		"sun tan":            "suntan",
+		"huge cock":          "huge dick - large dick",
+		"other fetish":       "other fetishes",
+		"threesome/foursome": "threesome / foursome",
 	}
 	if maptags[taglower] != "" {
 		return maptags[taglower]

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -44,6 +44,7 @@ func ProcessJavrTag(tag string) string {
 		"prostitute":  "club hostess & sex worker",
 		"prostitutes": "club hostess & sex worker",
 		"sun tan":     "suntan",
+		"huge cock":   "huge dick - large dick",
 	}
 	if maptags[taglower] != "" {
 		return maptags[taglower]

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -28,6 +28,7 @@ func ProcessJavrTag(tag string) string {
 		"single work":            true,
 		"solo work":              true,
 		"solowork":               true,
+		"dmm exclusive":          true,
 	}
 	if skiptags[taglower] {
 		return ""

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -29,6 +29,7 @@ func ProcessJavrTag(tag string) string {
 		"solo work":              true,
 		"solowork":               true,
 		"dmm exclusive":          true,
+		"over 4 hours":           true,
 	}
 	if skiptags[taglower] {
 		return ""

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -37,14 +37,15 @@ func ProcessJavrTag(tag string) string {
 	// Map some tags to normalize so different sources match
 	// TODO: this mapping is totally incomplete and needs help from community to fill
 	maptags := map[string]string{
-		"blow":        "blowjob",
-		"blow job":    "blowjob",
-		"kiss":        "kiss kiss",
-		"kiss / kiss": "kiss kiss",
-		"prostitute":  "club hostess & sex worker",
-		"prostitutes": "club hostess & sex worker",
-		"sun tan":     "suntan",
-		"huge cock":   "huge dick - large dick",
+		"blow":			"blowjob",
+		"blow job":		"blowjob",
+		"kiss":			"kiss kiss",
+		"kiss / kiss":	"kiss kiss",
+		"prostitute":	"club hostess & sex worker",
+		"prostitutes":	"club hostess & sex worker",
+		"sun tan":		"suntan",
+		"huge cock":	"huge dick - large dick",
+		"other fetish":	"other fetishes",
 	}
 	if maptags[taglower] != "" {
 		return maptags[taglower]

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -48,6 +48,7 @@ func ProcessJavrTag(tag string) string {
 		"huge cock":          "huge dick - large dick",
 		"other fetish":       "other fetishes",
 		"threesome/foursome": "threesome / foursome",
+		"3P, 4P":             "threesome / foursome",
 	}
 	if maptags[taglower] != "" {
 		return maptags[taglower]

--- a/pkg/scrape/javutil.go
+++ b/pkg/scrape/javutil.go
@@ -37,15 +37,15 @@ func ProcessJavrTag(tag string) string {
 	// Map some tags to normalize so different sources match
 	// TODO: this mapping is totally incomplete and needs help from community to fill
 	maptags := map[string]string{
-		"blow":			"blowjob",
-		"blow job":		"blowjob",
-		"kiss":			"kiss kiss",
-		"kiss / kiss":	"kiss kiss",
-		"prostitute":	"club hostess & sex worker",
-		"prostitutes":	"club hostess & sex worker",
-		"sun tan":		"suntan",
-		"huge cock":	"huge dick - large dick",
-		"other fetish":	"other fetishes",
+		"blow":         "blowjob",
+		"blow job":     "blowjob",
+		"kiss":         "kiss kiss",
+		"kiss / kiss":  "kiss kiss",
+		"prostitute":   "club hostess & sex worker",
+		"prostitutes":  "club hostess & sex worker",
+		"sun tan":      "suntan",
+		"huge cock":    "huge dick - large dick",
+		"other fetish": "other fetishes",
 	}
 	if maptags[taglower] != "" {
 		return maptags[taglower]


### PR DESCRIPTION
For the sake of avoiding clutter/multiple PRs, would it be possible to leave this one open until right before the next release? I might make a few more commits over the next week or so as I scrape the last few unmatched JAVR scenes in my library and encounter more tags. Also thought about opening a tracking ticket for this but wasn't sure if it was worth it.

TL;DR The new JAVR scrapers both drop some annoying tags at scrape time, and make some tag substitutions.

1. Added one new entry, `dmm exclusive`, to the drop list.
2. Added two new tag substitutions for cases where JAVLibrary uses a different tag than JAVBUS and JAVDatabase, but most importantly, different vs. the old R18 tags.

I have ~1-2k old scenes that were scraped from R18, as well as a JSON dump (unfortunately not as XBVR manifests) of all of R18's VR scene data from right before it closed, so that's the source I'll be focused on for tag substitution. "If the tag existed on R18, that one is automatically the 'right' one.