### PR TITLE
imageproxy: forcefully cache images

### DIFF
--- a/pkg/server/cache.go
+++ b/pkg/server/cache.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/fcjr/aia-transport-go"
+)
+
+type ForceCacheTransport struct {
+	Transport http.RoundTripper
+}
+
+// RoundTrip transport function that will force a Cache-Control of 5 years
+// on all HTTP 2xx responses, so that httpcache used by imageproxy will continue
+// to handle the cache as fresh, even when no cache header is set by upstream
+// server.
+func (s *ForceCacheTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Perform original request
+	resp, err := s.Transport.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Overwrite cache behavior on 2xx responses
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		resp.Header.Set("Cache-Control", "public, max-age=157680000")
+	}
+
+	return resp, nil
+}
+
+func NewForceCacheTransport() *ForceCacheTransport {
+	fct := new(ForceCacheTransport)
+
+	// this is what willnorris.com/go/imageproxy does by default,
+	// so keep the same here
+	fct.Transport, _ = aia.NewTransport()
+
+	return fct
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -132,7 +132,7 @@ func StartServer(version, commit, branch, date string) {
 	// onto the imageproxy so that this can be respected. Not yet suppored in imageproxy v0.11.2 that XBVR
 	// is using... need commit d94e5610d66dee4e841be83576a3f9f229928aac from imageproxy to be included.
 	//p.PassRequestHeaders = append(p.PassRequestHeaders, "Cache-Control")
-	r.PathPrefix("/img/").Handler(http.StripPrefix("/img", p))
+	r.PathPrefix("/img/").Handler(ForceShortCacheHandler(http.StripPrefix("/img", p)))
 	hmp := NewHeatmapThumbnailProxy(p, diskCache(filepath.Join(common.AppDir, "heatmapthumbnailproxy")))
 	r.PathPrefix("/imghm/").Handler(http.StripPrefix("/imghm", hmp))
 	downloadhandler := DownloadHandler{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -126,8 +126,12 @@ func StartServer(version, commit, branch, date string) {
 
 	// Imageproxy
 	r := mux.NewRouter()
-	p := imageproxy.NewProxy(nil, diskCache(filepath.Join(common.AppDir, "imageproxy")))
-	p.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36"
+	p := imageproxy.NewProxy(NewForceCacheTransport(), diskCache(filepath.Join(common.AppDir, "imageproxy")))
+	p.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+	// If the client request has a cache-control header (such as 'no-cache'), pass them
+	// onto the imageproxy so that this can be respected. Not yet suppored in imageproxy v0.11.2 that XBVR
+	// is using... need commit d94e5610d66dee4e841be83576a3f9f229928aac from imageproxy to be included.
+	//p.PassRequestHeaders = append(p.PassRequestHeaders, "Cache-Control")
 	r.PathPrefix("/img/").Handler(http.StripPrefix("/img", p))
 	hmp := NewHeatmapThumbnailProxy(p, diskCache(filepath.Join(common.AppDir, "heatmapthumbnailproxy")))
 	r.PathPrefix("/imghm/").Handler(http.StripPrefix("/imghm", hmp))


### PR DESCRIPTION
This commit changes the behavior of the imageproxy disk cache. Right now, it fully respects the cache-control headers of the origin servers (as it should). However, the cache-control headers on the sources for the cover and gallery images vary wildly. Some example sources with their cache duration:

| Source | Cache-Control |
| --- | --- |
| czechvr | 1 year |
| virtualrealporn | 1 year |
| sexlikereal | 30 days |
| vrbangers | 4 hours |
| vrconk | 4 hours |
| vrphub | 4 hours |
| stasyq | no cache |
| dmm.co.jp (all JAVR) | no cache |

The ones with no cache at all are the worst, and it is noticeably slow to load cover images for javr scenes because of this. It also seems like a waste of bandwidth, and it is less than optimal from privacy point of view.

Would XBVR be open to include a change such as this? Once this is in though, your client devices accessing XBVR may also start to cache these images for the same duration and effectively make it hard to invalidate the cache without a feature on your client browser to reset it. This is something I could live with, but I don't know about you. I don't really know how HereSphere handles web cache and if it has a feature to clear it or not. We may also want to consider rewriting the XBVR _response_ header from a cache-hit, so that HereSphere will not cache it as long as XBVR does, but only for 1 day or such. That would make it more safe, as users can already wipe the image cache from the options menu if they wanted to.

There is a feature in the 'imageproxy' code to allow it to pass certain request headers to the upstream request, so that we can pass Cache-Control from the _request_ to the httpcache layer, which will then fetch the latest data if you include `Cache-Control: no-cache` (like you can do in your browser by enabling 'Disable cache' in the devtools). This feature however, is not yet included in the older version v0.11.2 of imageproxy that XBVR is using... so I unfortunately could not include it. I don't know how to include the newer version of that dependency, maybe somebody who knows more about golang dependencies has any idea? I'm talking about commit https://github.com/willnorris/imageproxy/commit/d94e5610d66dee4e841be83576a3f9f229928aac

Oh and also, I changed the User-Agent used for pulling these images to the latest "most used" user-agent, fwiw.

So anyway, what do you guys think?