### PR TITLE
cuepoints: add autocomplete on cuepoint filter input

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -73,6 +73,7 @@ type ResponseGetFilters struct {
 	ReleaseMonths []string        `json:"release_month"`
 	Volumes       []models.Volume `json:"volumes"`
 	Attributes    []string        `json:"attributes"`
+	Cuepoints     []string        `json:"cuepoints"`
 }
 
 type SceneResource struct{}
@@ -380,6 +381,16 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	for _, r := range results {
 		outAttributes = append(outAttributes, "Codec "+r.Result)
 	}
+
+	// cuepoints
+	var outCuepoints []string
+	db.Table("scene_cuepoints").Select("distinct name as result").
+		Order("name").
+		Find(&results)
+	for _, r := range results {
+		outCuepoints = append(outCuepoints, r.Result)
+	}
+
 	resp.WriteHeaderAndEntity(http.StatusOK, ResponseGetFilters{
 		Tags:          outTags,
 		Cast:          outCast,
@@ -387,6 +398,7 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 		ReleaseMonths: outRelease,
 		Volumes:       outVolumes,
 		Attributes:    outAttributes,
+		Cuepoints:     outCuepoints,
 	})
 }
 

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -157,7 +157,7 @@
       </b-field>
 
       <b-field label="Cuepoint" label-position="on-border" class="field-extra">
-        <b-taginput v-model="cuepoint" allow-new>
+        <b-taginput v-model="cuepoint" autocomplete :data="filteredCuepoints" @typing="getFilteredCuepoints">
           <template slot-scope="props">{{ props.option }}</template>
           <template slot="empty">No matching cuepoints</template>
           <template #selected="props">
@@ -236,6 +236,7 @@ export default {
       filteredCast: [],
       filteredSites: [],
       filteredTags: [],
+      filteredCuepoints: [],
       filteredAttributes: [],
     }
   },
@@ -264,6 +265,12 @@ export default {
       this.filteredTags = this.filters.tags.filter(option => (
         option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
         !this.tags.some(entry => this.removeConditionPrefix(entry.toString()) === option.toString())
+      ))
+    },
+    getFilteredCuepoints (text) {
+      this.filteredCuepoints = this.filters.cuepoints.filter(option => (
+        option.toString().toLowerCase().indexOf(text.toLowerCase()) >= 0 &&
+        !this.cuepoint.some(entry => this.removeConditionPrefix(entry.toString()) === option.toString())
       ))
     },
     getFilteredAttributes (text) {


### PR DESCRIPTION
The Cuepoint filter doesn't autocomplete in the Scenes view. The other four filters do autocomplete (Cast, Site, Tags, Attributes). This commit adds autocomplete on the Cuepoints the same way it is done for the other filters.