### PR TITLE
VRHush/VRAllure updates to Cover/Title code

### DIFF
--- a/pkg/scrape/vrallure.go
+++ b/pkg/scrape/vrallure.go
@@ -27,7 +27,7 @@ func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 	sceneCollector := createCollector("vrallure.com")
 	siteCollector := createCollector("vrallure.com")
 
-	// Regex for original resolution of both covers and gallery
+	// Regex for original resolution of gallery
 	reGetOriginal := regexp.MustCompile(`^(https?:\/\/b8h6h9v9\.ssl\.hwcdn\.net\/vra\/)(?:largethumbs|hugethumbs|rollover_large|rollover_huge)(\/.+)-c\d{3,4}x\d{3,4}(\.\w{3,4})$`)
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
@@ -52,9 +52,7 @@ func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		// Title / Cover
 		e.ForEach(`deo-video`, func(id int, e *colly.HTMLElement) {
 			sc.Title = strings.TrimSpace(e.Attr("title"))
-
-			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("cover-image")))
-			sc.Covers = append(sc.Covers, tmpParts[1]+"largethumbs"+tmpParts[2]+tmpParts[3])
+			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("cover-image")))
 		})
 
 		// Gallery

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -39,18 +39,12 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.SiteID = strings.Replace(tmp2, "vrh", "", -1)
 		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 
-		// Title
-		e.ForEach(`h1.latest-scene-title`, func(id int, e *colly.HTMLElement) {
-			sc.Title = strings.TrimSpace(e.Text)
-		})
-
-		// Regex for original resolution of both covers and gallery
+		// Regex for original resolution of gallery
 		reGetOriginal := regexp.MustCompile(`^(https?:\/\/b8h6h9v9\.ssl\.hwcdn\.net\/vrh\/)(?:largethumbs|hugethumbs|rollover_large|rollover_huge)(\/.+)-c\d{3,4}x\d{3,4}(\.\w{3,4})$`)
 
-		// Cover URLs
-		// note 'largethumbs' could be changed to 'hugethumbs' for HQ original but those are easily 5Mb+
+		// Title / Cover
 		e.ForEach(`deo-video`, func(id int, e *colly.HTMLElement) {
-			//			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("cover-image")))
+			sc.Title = strings.TrimSpace(e.Attr("title"))
 			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("cover-image")))
 		})
 

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -50,8 +50,8 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		// Cover URLs
 		// note 'largethumbs' could be changed to 'hugethumbs' for HQ original but those are easily 5Mb+
 		e.ForEach(`deo-video`, func(id int, e *colly.HTMLElement) {
-			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("cover-image")))
-			sc.Covers = append(sc.Covers, tmpParts[1]+"largethumbs"+tmpParts[2]+tmpParts[3])
+			//			tmpParts := reGetOriginal.FindStringSubmatch(e.Request.AbsoluteURL(e.Attr("cover-image")))
+			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("cover-image")))
 		})
 
 		// Gallery


### PR DESCRIPTION
Fix cover images.

Latest videos (vrhush-0434 & vrhush-0435) are missing 960x540 sized cover image. Change to use the default 1110x624 size.