### PR TITLE
hide preview gen exec cmd window on windows os

### DIFF
--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -92,7 +91,7 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 	for i := 1; i <= snippetAmount; i++ {
 		start := time.Duration(float64(i)*interval+float64(startTime)) * time.Second
 		snippetFile := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i))
-		cmd := []string{
+		args := []string{
 			"-y",
 			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
 			"-i", inputFile,
@@ -101,8 +100,8 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 			"-t", fmt.Sprintf("%v", snippetLength),
 			"-an", snippetFile,
 		}
-
-		err := exec.Command(GetBinPath("ffmpeg"), cmd...).Run()
+		cmd := buildCmd(GetBinPath("ffmpeg"), args...)
+		err := cmd.Run()
 		if err != nil {
 			return err
 		}
@@ -114,7 +113,7 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 
 		start := time.Duration(dur-float64(150)) * time.Second
 		snippetFile := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", snippetAmount))
-		cmd := []string{
+		args := []string{
 			"-y",
 			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
 			"-i", inputFile,
@@ -123,7 +122,8 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 			"-an", snippetFile,
 		}
 
-		err = exec.Command(GetBinPath("ffmpeg"), cmd...).Run()
+		cmd := buildCmd(GetBinPath("ffmpeg"), args...)
+		err := cmd.Run()
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 	f.Close()
 
 	// Save result
-	cmd := []string{
+	args := []string{
 		"-y",
 		"-f", "concat",
 		"-safe", "0",
@@ -149,7 +149,8 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 		"-c", "copy",
 		filepath.ToSlash(destFile),
 	}
-	err = exec.Command(GetBinPath("ffmpeg"), cmd...).Run()
+	cmd := buildCmd(GetBinPath("ffmpeg"), args...)
+	err = cmd.Run()
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/task_utils_others.go
+++ b/pkg/tasks/task_utils_others.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package tasks
+
+import "os/exec"
+
+func buildCmd(name string, arg ...string) *exec.Cmd {
+	return exec.Command(name, arg...)
+}

--- a/pkg/tasks/task_utils_windows.go
+++ b/pkg/tasks/task_utils_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+// +build windows
+
+package tasks
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func buildCmd(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	return cmd
+}


### PR DESCRIPTION
this will allow on windows to hide the cmd prompt from being shown when generating preview.

tested locally on windows and working for me there. took me a min to figure out your build steps to compile but figured it out. using my version locally until we can get this merged into master/released.

need someone to check that the non-windows versions working as expected/normally as well since that is not something i have access to locally at this time.