### PR TITLE
Fix Visual State of Toggle Buttons from Quick Find

### DIFF
--- a/ui/src/components/FavouriteButton.vue
+++ b/ui/src/components/FavouriteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'favourite'})"
+     @click="toggleState()"
      :title="item.favourite ? 'Remove from favourites' : 'Add to favourites'">
     <b-icon pack="mdi" :icon="item.favourite ? 'heart' : 'heart-outline'" size="is-small"/>
   </a>
@@ -16,6 +16,13 @@ export default {
         return 'button is-danger is-small'
       }
       return 'button is-danger is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.favourite
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'favourite'})
+      this.item.favourite=!currentToggle
     }
   }
 }

--- a/ui/src/components/HiddenButton.vue
+++ b/ui/src/components/HiddenButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'is_hidden'})"
+     @click="toggleState()"
      :title="item.is_hidden ? 'Unhide' : 'Mark as hidden'">
     <b-icon pack="mdi" :icon="item.is_hidden ? 'eye-off-outline' : 'eye-off-outline'" size="is-small"/>
   </a>
@@ -16,6 +16,13 @@ export default {
         return 'button is-danger is-small'
       }
       return 'button is-danger is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.is_hidden
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'is_hidden'})
+      this.item.is_hidden=!currentToggle
     }
   }
 }

--- a/ui/src/components/RefreshButton.vue
+++ b/ui/src/components/RefreshButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a :class="buttonClass"
-    @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'needs_update'})"
+    @click="toggleState()"
      :title="item.needs_update ? 'Do not refresh scene' : 'Refresh scene on next scrape'">
     <b-icon pack="mdi" icon="refresh" size="is-small"/>
   </a>
@@ -16,6 +16,13 @@ export default {
         return 'button is-dark is-small'
       }
       return 'button is-dark is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.needs_update
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'needs_update'})
+      this.item.needs_update=!currentToggle
     }
   }
 }

--- a/ui/src/components/TrailerlistButton.vue
+++ b/ui/src/components/TrailerlistButton.vue
@@ -1,7 +1,7 @@
 <template>
   <a :class="buttonClass"
    v-if="!item.is_available & item.trailer_source !=='' & this.$store.state.optionsWeb.web.sceneTrailerlist"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'trailerlist'})"
+     @click="toggleState()"
      :title="item.trailerlist ? 'Remove from Trailer List' : 'Add to Trailer List'">
     <b-icon pack="mdi" :icon="item.watchlist ? 'movie-search-outline' : 'movie-search-outline'" size="is-small"/>
   </a>
@@ -17,6 +17,13 @@ export default {
         return 'button is-primary is-small'
       }
       return 'button is-primary is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.trailerlist
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'trailerlist'})
+      this.item.trailerlist=!currentToggle
     }
   }
 }

--- a/ui/src/components/WatchedButton.vue
+++ b/ui/src/components/WatchedButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watched'})"
+     @click="toggleState()"
      :title="item.is_watched ? 'Mark as unwatched' : 'Mark as watched'">
     <b-icon pack="mdi" :icon="item.is_watched ? 'eye-check' : 'eye'" size="is-small"/>
   </a>
@@ -16,6 +16,15 @@ export default {
         return 'button is-dark is-small'
       }
       return 'button is-dark is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.is_watched
+      console.log("watched toggleState", this.item.is_watched)
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'watched'})
+      this.item.is_watched=!currentToggle
+      console.log("watched toggleState", this.item.is_watched)
     }
   }
 }

--- a/ui/src/components/WatchlistButton.vue
+++ b/ui/src/components/WatchlistButton.vue
@@ -1,6 +1,6 @@
 <template>
   <a :class="buttonClass"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'watchlist'})"
+     @click="toggleState()"
      :title="item.watchlist ? 'Remove from watchlist' : 'Add to watchlist'">
     <b-icon pack="mdi" :icon="item.watchlist ? 'calendar-check' : 'calendar-blank'" size="is-small"/>
   </a>
@@ -16,6 +16,13 @@ export default {
         return 'button is-primary is-small'
       }
       return 'button is-primary is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle=this.item.watchlist
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'watchlist'})
+      this.item.watchlist=!currentToggle
     }
   }
 }


### PR DESCRIPTION
Fixes #1116

This fixes an issue when you go to the Scene Detail from Quick Find.  If you use the any of the Toggle buttons, e.g. Favorites, Watchlist, etc., the Scene data is updated, but the Visual State of the button does not change.

Pressing the Toggle buttons calls the scenelist/toggleSceneList which finds the Scene been updated in the List of Scenes and updates the appropriate switch and calls the API to update the Scene Data.  This works fine when you go to the Scene Detail from the Scene List, I expect the scene instance passed to the Scene Detail is an instance in the list.

I suspect it fails from the Quick Find, because the scene record passed to the Scene Detail for the selected Scene, is not an instance from the Scene List updated by toggleSceneList, even if the selected scene is in the list as well.

The fix saves the switch value from the local instance of the scene, calls toggleSceneList and then updates the local instance of the scenes switch.