### PR TITLE
Fix Playlist Create

### DIFF
--- a/ui/src/views/scenes/SavedSearch.vue
+++ b/ui/src/views/scenes/SavedSearch.vue
@@ -119,7 +119,7 @@ export default {
 
       let p
       if (action === 'create') {
-        p = await ky.post('/api/playlist/', { json: payload }).json()
+        p = await ky.post('/api/playlist', { json: payload }).json()
       } else {
         p = await ky.put(`/api/playlist/${this.currentPlaylistObj.id}`, { json: payload }).json()
       }


### PR DESCRIPTION
Creating a Playlist was broken by a Dependent Package in #1133 
Similar issue to #1147 with a trailing slash in the Api call resulting in a 405 (Method Not Allowed) error