### PR TITLE
Fix filenames for SLR CustomSites

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1373,6 +1373,28 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// Fixes the filenames of scenes for Custom SLR Sites, which have a (SLR) prefix enbedded in the filename
+			ID: "0057-fix-slr-filenames-for-custom-studios",
+			Migrate: func(tx *gorm.DB) error {
+				common.Log.Infof("Migration updating filenames for Custom SLR Sites")
+				var scenes []models.Scene
+				err := tx.Where("site like ?", "% (SLR)").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+
+				for _, scene := range scenes {
+					scene.FilenamesArr = strings.ReplaceAll(scene.FilenamesArr, "SLR_"+scene.Site, "SLR_"+strings.TrimSuffix(scene.Site, " (SLR)"))
+					err = tx.Save(&scene).Error
+					if err != nil {
+						return err
+					}
+				}
+				common.Log.Infof("Migration update for Custom SLR Site filenames completed")
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -158,7 +158,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				// Only shown for logged in users so need to generate them
 				// Format: SLR_siteID_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
 				resolutions := []string{"_6400p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
-				baseName := "SLR_" + siteID + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
+				baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
 				switch videotype {
 				case "360°": // Sadly can't determine if TB or MONO so have to add both
 					for i := range resolutions {


### PR DESCRIPTION
Fixes an issue for the filenames for scenes from SLR Custom Studios.  The filenames include " (SLR)" in the filenames which should not be there. 
e.g.
SLR_Dreamcam (SLR)_Sybil A LIVE - The Highlights_6400p_31775_VRCA220.mp4
should be
SLR_Dreamcam_Sybil A LIVE - The Highlights_6400p_31775_VRCA220.mp4
