### PR TITLE
Fix VirtualTaboo description

### DIFF
--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -68,7 +68,7 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 		})
 
 		// Synopsis
-		e.ForEach(`div.video-detail div.description`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div.video-detail .description`, func(id int, e *colly.HTMLElement) {
 			sc.Synopsis = strings.TrimSpace(e.Text)
 		})
 


### PR DESCRIPTION
The description for VirtualTaboo changed from a div to a p tag.  Changed so the scraper does not care which, will just search for class="description" within a div with a class video-detail 