### PR TITLE
Fix VRClubz url

### DIFF
--- a/pkg/config/scrapers.json
+++ b/pkg/config/scrapers.json
@@ -502,7 +502,7 @@
           "avatar_url": "https://mcdn.vrporn.com/files/20170718063811/realteensvr-vr-porn-studio-vrporn.com-virtual-reality.png"
         },
         {
-          "url": "https://vrporn.com/studio/studios/vrclubz",
+          "url": "https://vrporn.com/studio/vrclubz",
           "name": "VRClubz",
           "company": "VixenVR",
           "avatar_url": "https://mcdn.vrporn.com/files/20200421094123/vrclubz_logo_NEW-400x400_webwhite.png"


### PR DESCRIPTION
The url for VRClubz returns a 404 page. Updated to the correct url.