### PR TITLE
Change NewValue Column to Text

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -573,19 +573,19 @@ func Migrate() {
 				var err error
 				switch tx.Dialect().GetName() {
 				case "sqlite3":
-					err = tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old").Error
+					err = tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old2").Error
 				case "mysql":
-					err = tx.Model(&models.Action{}).Exec("RENAME TABLE actions TO actions_old").Error
+					err = tx.Model(&models.Action{}).Exec("RENAME TABLE actions TO actions_old2").Error
 				}
 				if err != nil {
 					return err
 				}
 				tx.AutoMigrate(&models.Action{})
-				err = tx.Model(&models.Action{}).Exec("INSERT INTO actions SELECT * FROM actions_old").Error
+				err = tx.Model(&models.Action{}).Exec("INSERT INTO actions SELECT * FROM actions_old2").Error
 				if err != nil {
 					return err
 				}
-				return tx.Exec("DROP TABLE IF EXISTS actions_old").Error
+				return tx.Exec("DROP TABLE IF EXISTS actions_old2").Error
 			},
 		},
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -567,6 +567,27 @@ func Migrate() {
 				return tx.AutoMigrate(&models.TagGroup{}).Error
 			},
 		},
+		{
+			ID: "0058-Change-NewValue-Column-To-Text",
+			Migrate: func(tx *gorm.DB) error {
+				var err error
+				switch tx.Dialect().GetName() {
+				case "sqlite3":
+					err = tx.Model(&models.Action{}).Exec("ALTER TABLE actions RENAME TO actions_old").Error
+				case "mysql":
+					err = tx.Model(&models.Action{}).Exec("RENAME TABLE actions TO actions_old").Error
+				}
+				if err != nil {
+					return err
+				}
+				tx.AutoMigrate(&models.Action{})
+				err = tx.Model(&models.Action{}).Exec("INSERT INTO actions SELECT * FROM actions_old").Error
+				if err != nil {
+					return err
+				}
+				return tx.Exec("DROP TABLE IF EXISTS actions_old").Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_action.go
+++ b/pkg/models/model_action.go
@@ -8,7 +8,7 @@ type Action struct {
 	SceneID       string `json:"scene_id" xbvrbackup:"scene_id"`
 	ActionType    string `json:"action_type" xbvrbackup:"action_type"`
 	ChangedColumn string `json:"changed_column" xbvrbackup:"changed_column"`
-	NewValue      string `json:"new_value" gorm:"size:4095" xbvrbackup:"new_value"`
+	NewValue      string `json:"new_value" sql:"type:text;" xbvrbackup:"new_value"`
 }
 
 func (a *Action) GetIfExist(id uint) error {


### PR DESCRIPTION
Fixes #899

This changes the new_value column on the actions table from varchar(4095) to Text

I also have very occasionally had issues with updates failing due to the new_value column been too small.  This was only every on non-standard studios that I added to my own build, however, since users can add studios to their own custom list, this may become more of a problem.