### PR TITLE
Add search prefix buttons and the ability to search by Date Released or Added

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1401,6 +1401,20 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			// rebuild search indexes with new fields
+			ID: "00359-rebuild-new-indexes",
+			Migrate: func(d *gorm.DB) error {
+				os.RemoveAll(common.IndexDirV2)
+				os.MkdirAll(common.IndexDirV2, os.ModePerm)
+				// rebuild asynchronously, no need to hold up startup, blocking the UI
+				go func() {
+					tasks.SearchIndex()
+					tasks.CalculateCacheSizes()
+				}()
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -14,6 +14,10 @@
           <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
           <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
           <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+          <b-tooltip :label="$t('Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros')" :delay="500" position="is-top">
+            <b-button @click='searchDatePrefix("released:")' class="tag is-info is-small is-light">released:</b-button>
+            <b-button @click='searchDatePrefix("added:")' class="tag is-info is-small is-light">added:</b-button>
+          </b-tooltip>
         </b-taglist>
       </b-tooltip>
     </b-field>
@@ -27,6 +31,7 @@
         v-model="queryString"
         @typing="getAsyncData"
         @select="option => showSceneDetails(option)"
+        :open-on-focus="true"
         custom-class="is-large"
         max-height="450">
 
@@ -122,7 +127,6 @@ export default {
         }
       }).json()
 
-
       if (requestIndex >= this.dataNumResponses) {
         this.dataNumResponses = requestIndex + 1
         if (this.dataNumResponses === this.dataNumRequests) {
@@ -148,6 +152,7 @@ export default {
         this.$router.push({ name: 'scenes' })
       }
       this.$store.commit('overlay/hideQuickFind')
+      this.data = []
       this.$store.commit('overlay/showDetails', { scene })
     },
     searchPrefix(prefix) {      
@@ -162,6 +167,17 @@ export default {
         this.getAsyncData(this.queryString)
         this.$refs.autocompleteInput.focus()
       }
+    },
+    searchDatePrefix(prefix) {      
+        let today = new Date().toISOString().slice(0, 10)
+        let weekago = new Date(Date.now() - 604800000).toISOString().slice(0, 10)
+        if (this.queryString == undefined) {
+          this.queryString = prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'          
+        } else {
+        this.queryString = this.queryString.trim() + ' ' + prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'        
+        }
+        this.getAsyncData(this.queryString)
+        this.$refs.autocompleteInput.focus()
     }
   }
 }

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -6,6 +6,17 @@
            aria-role="dialog"
            aria-modal
            can-cancel>
+    <b-field grouped>
+      <b-tooltip :label="$t('Optional: select one or more words to target searching to a specific field')" :delay="500" position="is-right">
+        <b-taglist>
+          <b-tag class="tag is-info is-small">{{$t('Search Fields')}}</b-tag>
+          <b-button @click='searchPrefix("title:")' class="tag is-info is-small is-light">title:</b-button>
+          <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
+          <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
+          <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+        </b-taglist>
+      </b-tooltip>
+    </b-field>
     <b-field style="width:600px">
       <b-autocomplete
         ref="autocompleteInput"
@@ -13,6 +24,7 @@
         placeholder="Find scene..."
         field="query"
         :loading="isFetching"
+        v-model="queryString"
         @typing="getAsyncData"
         @select="option => showSceneDetails(option)"
         custom-class="is-large"
@@ -84,7 +96,8 @@ export default {
       dataNumRequests: 0,
       dataNumResponses: 0,
       selected: null,
-      isFetching: false
+      isFetching: false,
+      queryString: ""
     }
   },
   methods: {
@@ -136,6 +149,19 @@ export default {
       }
       this.$store.commit('overlay/hideQuickFind')
       this.$store.commit('overlay/showDetails', { scene })
+    },
+    searchPrefix(prefix) {      
+      let textbox = this.$refs.autocompleteInput.$refs.input.$refs.input
+      if (textbox.selectionStart != textbox.selectionEnd) {
+        let selected = textbox.value.substring(textbox.selectionStart, textbox.selectionEnd)
+        selected=selected.replace(/_/g," ").replace(/-/g," ").trim()
+        if (selected.indexOf(' ') >= 0) {
+          selected='"' + selected + '"'
+        }
+        this.queryString = textbox.value.substring(0,textbox.selectionStart) + " " + prefix + selected + " " + textbox.value.substr(textbox.selectionEnd)
+        this.getAsyncData(this.queryString)
+        this.$refs.autocompleteInput.focus()
+      }
     }
   }
 }

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -114,5 +114,7 @@
   "Hidden": "Hidden",
   "Only include offical studios": "Only include offical studios",
   "You should exclude Studios from your Custom list (scrapers.json) if sharing data with others": "You should exclude Studios from your Custom list (scrapers.json) if sharing data with others",
+  "Optional: select one or more words to target searching to a specific field": "Optional: select one or more words to target searching to a specific field",
+  "Search Fields": "Search Fields",
   "Go": "Go"
 }

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -116,5 +116,6 @@
   "You should exclude Studios from your Custom list (scrapers.json) if sharing data with others": "You should exclude Studios from your Custom list (scrapers.json) if sharing data with others",
   "Optional: select one or more words to target searching to a specific field": "Optional: select one or more words to target searching to a specific field",
   "Search Fields": "Search Fields",
+  "Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros": "Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros",
   "Go": "Go"
 }

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -23,11 +23,24 @@
             {{ prettyBytes(file.size) }}, {{ file.video_width }}x{{ file.video_height }},
             {{ format(parseISO(file.created_time), "yyyy-MM-dd") }}
           </small>
-          <b-field :label="$t('Search')">
+
+          <b-field grouped>
+            <b-tooltip :label="$t('Optional: select one or more words to target searching to a specific field')" :delay="500" position="is-right">
+              <b-taglist>                  
+                <b-tag class="tag is-info is-small">{{$t('Search Fields')}}</b-tag>
+                <b-button @click='searchPrefix("title:")' class="tag is-info is-small is-light">title:</b-button>
+                <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
+                <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
+                <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+              </b-taglist>
+            </b-tooltip>
+          </b-field>
+          <b-field :label="$t('Search')" label-position="on-border">
             <div class="control">
-              <input class="input" type="text" v-model='queryString' v-debounce:200ms="loadData" autofocus>
+              <input class="input" type="text" v-model='queryString' v-debounce:200ms="loadData" autofocus ref="searchInput">
             </div>
           </b-field>
+          
           <b-table :data="data" ref="table" paginated :current-page.sync="currentPage" per-page="5">
             <b-table-column field="cover_url" :label="$t('Image')" width="120" v-slot="props">
               <vue-load-image>
@@ -239,6 +252,20 @@ export default {
       } else {
         this.currentPage = this.currentPage - 1
       }
+    },
+    searchPrefix(prefix) {
+      let textbox = this.$refs.searchInput
+      if (textbox.selectionStart != textbox.selectionEnd) {
+        let selected = textbox.value.substring(textbox.selectionStart, textbox.selectionEnd)
+        selected=selected.replace(/_/g," ").replace(/-/g," ").trim()
+        if (selected.indexOf(' ') >= 0)
+        {
+          selected='"' + selected + '"'
+        }        
+        this.queryString = textbox.value.substring(0,textbox.selectionStart) + " " + prefix + selected + " " + textbox.value.substr(textbox.selectionEnd)
+        this.loadData()
+      }
+      
     },
     prettyBytes
   }

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -26,13 +26,17 @@
 
           <b-field grouped>
             <b-tooltip :label="$t('Optional: select one or more words to target searching to a specific field')" :delay="500" position="is-right">
-              <b-taglist>                  
+              <b-taglist>
                 <b-tag class="tag is-info is-small">{{$t('Search Fields')}}</b-tag>
                 <b-button @click='searchPrefix("title:")' class="tag is-info is-small is-light">title:</b-button>
                 <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
                 <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
                 <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
-              </b-taglist>
+                <b-tooltip :label="$t('Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros')" :delay="500" position="is-top">
+                  <b-button @click='searchDatePrefix("released:")' class="tag is-info is-small is-light">released:</b-button>
+                  <b-button @click='searchDatePrefix("added:")' class="tag is-info is-small is-light">added:</b-button>
+                </b-tooltip>
+              </b-taglist>          
             </b-tooltip>
           </b-field>
           <b-field :label="$t('Search')" label-position="on-border">
@@ -266,6 +270,12 @@ export default {
         this.loadData()
       }
       
+    },
+    searchDatePrefix(prefix) {      
+        let today = new Date().toISOString().slice(0, 10)
+        let weekago = new Date(Date.now() - 604800000).toISOString().slice(0, 10)        
+          this.queryString = this.queryString.trim() + ' ' + prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'        
+        this.loadData()
     },
     prettyBytes
   }


### PR DESCRIPTION
This change is in response to requests to make Search Prefixes used to target searching to specific fields, more obvious and ideally easier to use.

The search prefixes introduced in #760 can have a big effect on search results, especially with common words that are ignored by the default search, but a lot of users are not aware they are available.

