### PR TITLE
Update and delete scenes by scraper ID, not site name

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -152,7 +152,7 @@ func (i ConfigResource) WebService() *restful.WebService {
 	ws.Route(ws.PUT("/sites/{site}").To(i.toggleSite).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
-	ws.Route(ws.PUT("/sites/subsrcibed/{site}").To(i.toggleSubscribed).
+	ws.Route(ws.PUT("/sites/subscribed/{site}").To(i.toggleSubscribed).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	ws.Route(ws.POST("/scraper/force-site-update").To(i.forceSiteUpdate).
@@ -469,7 +469,7 @@ func (i ConfigResource) removeStorage(req *restful.Request, resp *restful.Respon
 
 func (i ConfigResource) forceSiteUpdate(req *restful.Request, resp *restful.Response) {
 	var r struct {
-		SiteName string `json:"site_name"`
+		ScraperId string `json:"scraper_id"`
 	}
 
 	if err := req.ReadEntity(&r); err != nil {
@@ -480,12 +480,12 @@ func (i ConfigResource) forceSiteUpdate(req *restful.Request, resp *restful.Resp
 	db, _ := models.GetDB()
 	defer db.Close()
 
-	db.Model(&models.Scene{}).Where("site = ?", r.SiteName).Update("needs_update", true)
+	db.Model(&models.Scene{}).Where("scraper_id = ?", r.ScraperId).Update("needs_update", true)
 }
 
 func (i ConfigResource) deleteScenes(req *restful.Request, resp *restful.Response) {
 	var r struct {
-		SiteName string `json:"site_name"`
+		ScraperId string `json:"scraper_id"`
 	}
 
 	if err := req.ReadEntity(&r); err != nil {
@@ -497,7 +497,7 @@ func (i ConfigResource) deleteScenes(req *restful.Request, resp *restful.Respons
 	defer db.Close()
 
 	var scenes []models.Scene
-	db.Where("site = ?", r.SiteName).Find(&scenes)
+	db.Where("scraper_id = ?", r.ScraperId).Find(&scenes)
 
 	for _, obj := range scenes {
 		files, _ := obj.GetFiles()
@@ -507,7 +507,7 @@ func (i ConfigResource) deleteScenes(req *restful.Request, resp *restful.Respons
 		}
 	}
 
-	db.Where("site = ?", r.SiteName).Delete(&models.Scene{})
+	db.Where("scraper_id = ?", r.ScraperId).Delete(&models.Scene{})
 }
 
 func (i ConfigResource) getState(req *restful.Request, resp *restful.Response) {

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -50,10 +50,10 @@
             <b-dropdown-item aria-role="listitem" @click="taskScrape(props.row.id)">
               {{$t('Run this scraper')}}
             </b-dropdown-item>
-            <b-dropdown-item aria-role="listitem" @click="forceSiteUpdate(props.row.name)">
+            <b-dropdown-item aria-role="listitem" @click="forceSiteUpdate(props.row.name, props.row.id)">
               {{$t('Force update scenes')}}
             </b-dropdown-item>
-            <b-dropdown-item aria-role="listitem" @click="deleteScenes(props.row.name)">
+            <b-dropdown-item aria-role="listitem" @click="deleteScenes(props.row.name, props.row.id)">
               {{$t('Delete scraped scenes')}}
             </b-dropdown-item>
           </b-dropdown>
@@ -96,18 +96,16 @@ export default {
         return u
       }
     },
-    taskScrape (site) {
-      ky.get(`/api/task/scrape?site=${site}`)
+    taskScrape (scraper) {
+      ky.get(`/api/task/scrape?site=${scraper}`)
     },
-    forceSiteUpdate (site) {
-      site = this.sanitizeSiteName(site);
+    forceSiteUpdate (site, scraper) {
       ky.post('/api/options/scraper/force-site-update', {
-        json: { site_name: site }
+        json: { scraper_id: scraper }
       })
       this.$buefy.toast.open(`Scenes from ${site} will be updated on next scrape`)
     },
-    deleteScenes (site) {
-      site = this.sanitizeSiteName(site);      
+    deleteScenes (site, scraper) {
       this.$buefy.dialog.confirm({
         title: this.$t('Delete scraped scenes'),
         message: `You're about to delete scraped scenes for <strong>${site}</strong>. Previously matched files will return to unmatched state.`,
@@ -115,22 +113,16 @@ export default {
         hasIcon: true,
         onConfirm: function () {
           ky.post('/api/options/scraper/delete-scenes', {
-            json: { site_name: site }
+            json: { scraper_id: scraper }
           })
         }
       })
-    },
-    sanitizeSiteName(site) {
-      if (site.includes('(Custom ')) {
-        return site.replace('(Custom ','(') 
-      }      
-      return site.split('(')[0].trim();
     },
     async toggleAllSubscriptions(){
       const table = this.$refs.scraperTable;
       this.isLoading=true
       for (let i=0; i<table.newData.length; i++) {
-        await ky.put(`/api/options/sites/subsrcibed/${table.newData[i].id}`, { json: {} }).json()
+        await ky.put(`/api/options/sites/subscribed/${table.newData[i].id}`, { json: {} }).json()
         this.$store.dispatch('optionsSites/load')
       }
       this.isLoading=false


### PR DESCRIPTION
Some scrapers (e.g. the FuckPassVR ones) share a name, so better use the scraper ID to not e.g. delete more scenes than intended.