### PR TITLE
Display scene duration

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -45,6 +45,7 @@ type RequestSaveOptionsWeb struct {
 	SceneFavourite    bool   `json:"sceneFavourite"`
 	SceneWatched      bool   `json:"sceneWatched"`
 	SceneEdit         bool   `json:"sceneEdit"`
+	SceneDuration     bool   `json:"sceneDuration"`
 	SceneCuepoint     bool   `json:"sceneCuepoint"`
 	ShowHspFile       bool   `json:"showHspFile"`
 	ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
@@ -306,6 +307,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.SceneFavourite = r.SceneFavourite
 	config.Config.Web.SceneWatched = r.SceneWatched
 	config.Config.Web.SceneEdit = r.SceneEdit
+	config.Config.Web.SceneDuration = r.SceneDuration
 	config.Config.Web.SceneCuepoint = r.SceneCuepoint
 	config.Config.Web.ShowHspFile = r.ShowHspFile
 	config.Config.Web.ShowSubtitlesFile = r.ShowSubtitlesFile

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,6 +33,7 @@ type ObjectConfig struct {
 		SceneFavourite    bool   `default:"true" json:"sceneFavourite"`
 		SceneWatched      bool   `default:"false" json:"sceneWatched"`
 		SceneEdit         bool   `default:"false" json:"sceneEdit"`
+		SceneDuration     bool   `default:"false" json:"sceneDuration"`
 		SceneCuepoint     bool   `default:"true" json:"sceneCuepoint"`
 		ShowHspFile       bool   `default:"true" json:"showHspFile"`
 		ShowSubtitlesFile bool   `default:"true" json:"showSubtitlesFile"`

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -17,6 +17,7 @@ type ObjectState struct {
 		SceneFavourite    bool   `json:"sceneFavourite"`
 		SceneWatched      bool   `json:"sceneWatched"`
 		SceneEdit         bool   `json:"sceneEdit"`
+		SceneDuration     bool   `json:"sceneDuration"`
 		SceneCuepoint     bool   `json:"sceneCuepoint"`
 		ShowHspFile       bool   `json:"showHspFile"`
 		ShowSubtitlesFile bool   `json:"showSubtitlesFile"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -8,6 +8,7 @@ const state = {
     sceneFavourite: true,
     sceneWatched: false,
     sceneEdit: false,
+    sceneDuration: false,
     sceneCuepoint: true,
     showHspFile: true,
     showSubtitlesFile: true,
@@ -29,6 +30,7 @@ const actions = {
         state.web.sceneFavourite = data.config.web.sceneFavourite
         state.web.sceneWatched = data.config.web.sceneWatched
         state.web.sceneEdit = data.config.web.sceneEdit
+        state.web.sceneDuration = data.config.web.sceneDuration
         state.web.sceneCuepoint = data.config.web.sceneCuepoint
         state.web.showHspFile = data.config.web.showHspFile
         state.web.showSubtitlesFile = data.config.web.showSubtitlesFile
@@ -47,6 +49,7 @@ const actions = {
         state.web.sceneFavourite = data.sceneFavourite
         state.web.sceneWatched = data.sceneWatched
         state.web.sceneEdit = data.sceneEdit
+        state.web.sceneDuration = data.sceneDuration
         state.web.sceneCuepoint = data.sceneCuepoint
         state.web.showHspFile = data.showHspFile
         state.web.showSubtitlesFile = data.showSubtitlesFile        

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -20,7 +20,9 @@
           <small>
             <span class="pathDetails">{{ file.path }}</span>
             <br/>
-            {{ prettyBytes(file.size) }}, {{ file.video_width }}x{{ file.video_height }},
+            {{ prettyBytes(file.size) }},
+            <span v-if="file.type == 'video'">{{ file.video_width }}x{{ file.video_height }}, </span>
+            <span v-if="file.duration > 0">{{ Math.floor(file.duration / 60) }} min,</span>
             {{ format(parseISO(file.created_time), "yyyy-MM-dd") }}
           </small>
           <b-field :label="$t('Search')">
@@ -43,6 +45,10 @@
                   <b-icon pack="mdi" icon="eye-off-outline" size="is-small" style="margin-right:0.1em"/>                
                 </b-tag>&nbsp;
               </b-tooltip>
+              <b-tag type="is-info is-light" v-if="props.row.duration">
+                <b-icon pack="mdi" icon="clock" size="is-small" style="margin-right:0.1em"/>
+                {{props.row.duration}}
+              </b-tag>&nbsp;
               <b-tag type="is-info is-light" v-if="videoFilesCount(props.row)">
                 <b-icon pack="mdi" icon="file" size="is-small" style="margin-right:0.1em"/>
                 {{videoFilesCount(props.row)}}

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -46,8 +46,13 @@
               </b-switch>
             </b-field>
             <b-field>
+              <b-switch v-model="sceneDuration" type="is-dark">
+                show Duration button
+              </b-switch>
+            </b-field>
+            <b-field>
               <b-switch v-model="sceneCuepoint" type="is-dark">
-                show Cuepoints  button
+                show Cuepoints button
               </b-switch>
             </b-field>
             <b-field>
@@ -143,6 +148,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.updateCheck = value
+      }
+    },
+    sceneDuration: {
+      get () {
+        return this.$store.state.optionsWeb.web.sceneDuration
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.sceneDuration = value
       }
     },
     sceneCuepoint: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -74,18 +74,27 @@
                 <h3>
                   <span v-if="item.title">{{ item.title }}</span>
                   <span v-else class="missing">(no title)</span>
-                  <small class="is-pulled-right">{{ format(parseISO(item.release_date), "yyyy-MM-dd") }}</small>
+                  <small class="is-pulled-right">
+                    {{ format(parseISO(item.release_date), "yyyy-MM-dd") }}
+                  </small>
                 </h3>
-                <small>
-                  <a :href="item.scene_url" target="_blank" rel="noreferrer">{{ item.site }}</a>                  
-                  <br  v-if="item.members_url != ''"/>
-                  <a v-if="item.members_url != ''" :href="item.members_url" target="_blank" rel="noreferrer"><b-icon pack="mdi" icon="link-lock" custom-size="mdi-18px"/>Members Link</a>
-                </small>
-                <div class="columns mt-0">
+                <div class="columns">
+                  <div class="column pb-0">
+                    <small>
+                      <a :href="item.scene_url" target="_blank" rel="noreferrer">{{ item.site }}</a>                  
+                      <br v-if="item.members_url != ''"/>
+                      <a v-if="item.members_url != ''" :href="item.members_url" target="_blank" rel="noreferrer"><b-icon pack="mdi" icon="link-lock" custom-size="mdi-18px"/>Members Link</a>
+                    </small>
+                  </div>
+                  <div class="column pb-0">
+                    <small v-if="item.duration" class="is-pulled-right">{{ item.duration }} minutes</small>
+                  </div>
+                </div>
+                <div class="columns is-vcentered">
                   <div class="column pt-0">
                     <b-field>
                       <star-rating :key="item.id" v-model="item.star_rating" :rating="item.star_rating" @rating-selected="setRating"
-                                   :increment="0.5" :star-size="20"/>
+                                   :increment="0.5" :star-size="20" :show-rating="false" />
                       <b-tooltip :label="$t('Reset Rating')" position="is-right" :delay="250">
                         <b-icon pack="mdi" icon="autorenew" size="is-small" @click.native="setRating(0)" style="padding-left: 1em;padding-top: .5em;"/>
                       </b-tooltip>
@@ -860,6 +869,10 @@ export default {
 }
 
 .block-opts {
+}
+
+.vue-star-rating {
+    line-height: 0;
 }
 
 .scene-id {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -28,7 +28,7 @@
               <b-icon pack="mdi" icon="subtitles" size="is-small"/>
               <span v-if="subtitlesFilesCount > 1">{{subtitlesFilesCount}}</span>
             </b-tag>
-            <b-tag type="is-info" v-if="item.cuepoints.length>0 && this.$store.state.optionsWeb.web.sceneCuepoint">
+            <b-tag type="is-info" v-if="item.cuepoints.length > 0 && this.$store.state.optionsWeb.web.sceneCuepoint">
               <b-icon pack="mdi" icon="skip-next-outline" size="is-small"/>
               <span v-if="item.cuepoints.length > 1">{{item.cuepoints.length}}</span>
             </b-tag>
@@ -36,7 +36,7 @@
               <b-icon pack="mdi" icon="star" size="is-small"/>
               {{item.star_rating}}
             </b-tag>
-            <b-tag type="is-info" v-if="item.duration > 0">
+            <b-tag type="is-info" v-if="item.duration > 0 && this.$store.state.optionsWeb.web.sceneDuration">
               <b-icon pack="mdi" icon="clock" size="is-small"/>
               {{item.duration}}m
             </b-tag>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -36,6 +36,10 @@
               <b-icon pack="mdi" icon="star" size="is-small"/>
               {{item.star_rating}}
             </b-tag>
+            <b-tag type="is-info" v-if="item.duration > 0">
+              <b-icon pack="mdi" icon="clock" size="is-small"/>
+              {{item.duration}}m
+            </b-tag>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This adds scene duration to the scene details view and optionally to the scene cards, controlled with a toggle in the settings. It also adds file duration to the matching view, along with scene duration to the results.