### PR TITLE
Add Duration Search

### DIFF
--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -175,13 +175,17 @@ export default {
         if (this.queryString == undefined) {
           this.queryString = prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'          
         } else {
-        this.queryString = this.queryString.trim() + ' ' + prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'        
+          this.queryString = this.queryString.trim() + ' ' + prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'        
         }
         this.getAsyncData(this.queryString)
         this.$refs.autocompleteInput.focus()
     },
     searchDurationPrefix(prefix) {
-      this.queryString = this.queryString.trim() + ' ' + prefix + '>=0'        
+      if (this.queryString == undefined) {
+        this.queryString = prefix + '>=0'
+      } else {
+        this.queryString = this.queryString.trim() + ' ' + prefix + '>=0'
+      }
       this.getAsyncData(this.queryString)
       this.$refs.autocompleteInput.focus()
     }

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -14,6 +14,7 @@
           <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
           <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
           <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+          <b-button @click='searchDurationPrefix("duration:")' class="tag is-info is-small is-light">duration:</b-button>
           <b-tooltip :label="$t('Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros')" :delay="500" position="is-top">
             <b-button @click='searchDatePrefix("released:")' class="tag is-info is-small is-light">released:</b-button>
             <b-button @click='searchDatePrefix("added:")' class="tag is-info is-small is-light">added:</b-button>
@@ -178,6 +179,11 @@ export default {
         }
         this.getAsyncData(this.queryString)
         this.$refs.autocompleteInput.focus()
+    },
+    searchDurationPrefix(prefix) {
+      this.queryString = this.queryString.trim() + ' ' + prefix + '>=0'        
+      this.getAsyncData(this.queryString)
+      this.$refs.autocompleteInput.focus()
     }
   }
 }

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -34,6 +34,7 @@
                 <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
                 <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
                 <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+                <b-button @click='searchDurationPrefix("duration:")' class="tag is-info is-small is-light">duration:</b-button>
                 <b-tooltip :label="$t('Defaults date range to the last week. Note:must match yyyy-mm-dd, include leading zeros')" :delay="500" position="is-top">
                   <b-button @click='searchDatePrefix("released:")' class="tag is-info is-small is-light">released:</b-button>
                   <b-button @click='searchDatePrefix("added:")' class="tag is-info is-small is-light">added:</b-button>
@@ -281,6 +282,14 @@ export default {
         let today = new Date().toISOString().slice(0, 10)
         let weekago = new Date(Date.now() - 604800000).toISOString().slice(0, 10)        
           this.queryString = this.queryString.trim() + ' ' + prefix + '>="' + weekago + '" ' +  prefix + '<="' + today + '"'        
+        this.loadData()
+    },
+    searchDurationPrefix(prefix) {        
+        if (this.file.duration==0) {
+          this.queryString = this.queryString.trim() + ' ' + prefix + '>=0 '
+        } else {
+          this.queryString = this.queryString.trim() + ' ' + prefix + '>=' + (Math.floor(this.file.duration / 60)-1) + ' ' +  prefix + '<=' + (Math.floor(this.file.duration / 60)+1) + ''        
+        }
         this.loadData()
     },
     prettyBytes


### PR DESCRIPTION
Added the ability to also search on the Scene Duration.

From the file matching, it will default the search range from 1 less to 1 more than the files duration.

Less useful for the Quick Find as there is no duration to default a range from.  I have defaulted to >=0 so at the users will have an idea of the search syntax to use and can edit it from there.

Sorry I didn't include this in the previous commit, but only thought of it after seeing the duration visible in a number of places to help matching in a recent commit