### PR TITLE
Log Calls to the Player API Library function

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -506,6 +506,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 }
 
 func (i DeoVRResource) getDeoLibrary(req *restful.Request, resp *restful.Response) {
+	common.Log.Infof("getDeoLibrary called, enabled %v", config.Config.Interfaces.DeoVR.Enabled)
 	if !config.Config.Interfaces.DeoVR.Enabled {
 		return
 	}

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -942,6 +942,7 @@ func matchCuepoint(findCuepoint models.SceneCuepoint, cuepointList []models.Scen
 }
 
 func (i HeresphereResource) getHeresphereLibrary(req *restful.Request, resp *restful.Response) {
+	log.Infof("getHeresphereLibrary called, enabled %v", config.Config.Interfaces.DeoVR.Enabled)
 	if !config.Config.Interfaces.DeoVR.Enabled {
 		return
 	}


### PR DESCRIPTION
This is a very small change which may or may not be worthwhile. It is to assist with Troubleshooting when user report issues with the Heresphere API.  Some users still report issue and turns out they are actually using the DeoVR endpoint not the Heresphere one.

This change to writes a message to the log when a call is made to get the Library list to indicate if getDeoLibrary  or getHeresphereLibrary  is called.