### PR TITLE
Display Scene Details using a URL query param

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-test/deep"
@@ -414,15 +415,19 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 }
 
 func (i SceneResource) getScene(req *restful.Request, resp *restful.Response) {
-	sceneId, err := strconv.Atoi(req.PathParameter("scene-id"))
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
 	var scene models.Scene
 	db, _ := models.GetDB()
-	err = scene.GetIfExistByPK(uint(sceneId))
+
+	if strings.Contains(req.PathParameter("scene-id"), "-") {
+		scene.GetIfExist(req.PathParameter("scene-id"))
+	} else {
+		id, err := strconv.Atoi(req.PathParameter("scene-id"))
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		_ = scene.GetIfExistByPK(uint(id))
+	}
 	db.Close()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -588,23 +588,6 @@ func Migrate() {
 				return tx.Exec("DROP TABLE IF EXISTS actions_old2").Error
 			},
 		},
-		{
-			ID: "0061-Create-Scene-View",
-			Migrate: func(tx *gorm.DB) error {
-				sql := ""
-				switch tx.Dialect().GetName() {
-				case "sqlite3":
-					sql = `
-					CREATE VIEW IF NOT EXISTS view_scenes AS
-					select "http://localhost:9999/ui/#/?scene_id="||scene_id as xbvr_url, s.* from scenes s`
-				case "mysql":
-					sql = `
-					CREATE OR REPLACE VIEW view_scenes AS
-					select concat('http://localhost:9999/ui/#/?scene_id=',scene_id) as xbvr_url, s.* from scenes s`
-				}
-				return tx.Model(&models.Action{}).Exec(sql).Error
-			},
-		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -588,6 +588,23 @@ func Migrate() {
 				return tx.Exec("DROP TABLE IF EXISTS actions_old2").Error
 			},
 		},
+		{
+			ID: "0061-Create-Scene-View",
+			Migrate: func(tx *gorm.DB) error {
+				sql := ""
+				switch tx.Dialect().GetName() {
+				case "sqlite3":
+					sql = `
+					CREATE VIEW IF NOT EXISTS view_scenes AS
+					select "http://localhost:9999/ui/#/?scene_id="||scene_id as xbvr_url, s.* from scenes s`
+				case "mysql":
+					sql = `
+					CREATE OR REPLACE VIEW view_scenes AS
+					select concat('http://localhost:9999/ui/#/?scene_id=',scene_id) as xbvr_url, s.* from scenes s`
+				}
+				return tx.Model(&models.Action{}).Exec(sql).Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -41,6 +41,7 @@ const state = {
     not_downloaded: 0,
     hidden: 0
   },
+  show_scene_id: '',
   filterOpts: {
     cast: [],
     sites: [],
@@ -134,6 +135,7 @@ const mutations = {
   },
   stateFromQuery (state, payload) {
     try {
+      state.show_scene_id=payload.scene_id
       const obj = JSON.parse(Buffer.from(payload.q, 'base64').toString('utf-8'))
       for (const [k, v] of Object.entries(obj)) {
         Vue.set(state.filters, k, v)

--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -142,9 +142,11 @@ export default {
       if (this.$store.state.sceneList.show_scene_id != undefined && this.$store.state.sceneList.show_scene_id !='')
       {
         ky.get('/api/scene/'+this.$store.state.sceneList.show_scene_id).json().then(data => {
-        this.$store.commit('overlay/showDetails', { scene: data })
-        this.$store.state.sceneList.show_scene_id = ''
+          if (data.id != 0){
+            this.$store.commit('overlay/showDetails', { scene: data })
+          }          
         })
+        this.$store.state.sceneList.show_scene_id = ''
       }
       
       return this.$store.state.sceneList.show_scene_id

--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -24,6 +24,7 @@
             {{$t("Hidden")}} ({{counts.hidden}})
           </b-radio-button>
         </div>
+        <span v-show="show_scene_id==='never show, just need the computed show_scene_id to trigger '">{{show_scene_id}}</span>
       </div>
       <div class="column">
         <div class="is-pulled-right">
@@ -61,6 +62,7 @@
 
 <script>
 import SceneCard from './SceneCard'
+import ky from 'ky'
 
 export default {
   name: 'List',
@@ -135,6 +137,17 @@ export default {
     },
     counts () {
       return this.$store.state.sceneList.counts
+    },
+    show_scene_id() {
+      if (this.$store.state.sceneList.show_scene_id != undefined && this.$store.state.sceneList.show_scene_id !='')
+      {
+        ky.get('/api/scene/'+this.$store.state.sceneList.show_scene_id).json().then(data => {
+        this.$store.commit('overlay/showDetails', { scene: data })
+        this.$store.state.sceneList.show_scene_id = ''
+        })
+      }
+      
+      return this.$store.state.sceneList.show_scene_id
     }
   },
   methods: {


### PR DESCRIPTION
This feature you to launch the Scene Detail overlay for a scene using a query parameter (scene_id) in the XBVR URL. e.g. http://localhost:9999/ui/#/?scene_id=badoinkvr-326292, you can also use the scene Internal Id.

I have also created a view (view_scenes) in the database that adds a simple URL (using localhost) for the new param. I usually use DBeaver as my normal SQL tool, it recognizes URLs in a query results, so I can query data, find a scene and just click the row in the URL column to bring up the scene of interest or you can just copy/paste the URL.

This is obviously a feature that will be of any use to a small group, developers and advanced users, people who access the database directly or access XBVR external to the app.   I wasn't sure if it was worth submitting, let me know if not and I'll close & delete the PR