### PR TITLE
Fix VRHush Trailers

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1468,6 +1468,13 @@ func Migrate() {
 				return tx.Exec(sql).Error
 			},
 		},
+		{
+			ID: "0062-fix-vrhush-trailers",
+			Migrate: func(tx *gorm.DB) error {
+				sql := `update scenes set trailer_source = replace(trailer_source, '"html_element":"web-vr-video-player"', '"html_element":"web-vr-video-player source"') where scene_id like 'vrhush%' and trailer_source like '%"html_element":"web-vr-video-player"%'`
+				return tx.Exec(sql).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -87,7 +87,7 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 
 		// trailer details
 		sc.TrailerType = "scrape_html"
-		params := models.TrailerScrape{SceneUrl: sc.HomepageURL, HtmlElement: "web-vr-video-player", ContentPath: "src", QualityPath: "quality", ContentBaseUrl: "https:"}
+		params := models.TrailerScrape{SceneUrl: sc.HomepageURL, HtmlElement: "web-vr-video-player source", ContentPath: "src", QualityPath: "quality", ContentBaseUrl: "https:"}
 		strParams, _ := json.Marshal(params)
 		sc.TrailerSrc = string(strParams)
 


### PR DESCRIPTION
The fix in the last release correctly fixed VRAllure, however, the fix for VRHush was not quite right.  The selector for Trailers for VRHush was updated to "web-vr-video-player", but should have been "web-vr-video-player source"