### PR TITLE
Update .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.dockerfile
 tasks:
   - name: Continuous Build
-    command: cd /workspace/xbvr && yarn dev
+    command: yarn global add concurrently && go install github.com/cosmtrek/air@latest && cd /workspace/xbvr && go generate && go get && yarn && yarn dev
 ports:
   - port: 9999
     onOpen: open-preview


### PR DESCRIPTION
Makes Gitpod just work on launch.

It seems like this was brought up in the past but never addressed? #633 - Those same errors that prompted that PR still exist - Gitpod complains about `concurrently` not being installed as soon as it launches the environment. Might there be a better way to do this? Sure. As a matter of fact, there's probably a _much_ better way of doing this. Does this actually work as proposed? **Yes**. Does the Gitpod environment currently work? **_No_**

![image](https://github.com/xbapps/xbvr/assets/81622808/38adc480-7b1f-45ec-adea-f601ed8bdd1d)