### PR TITLE
Update heresphere.go

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -221,7 +221,7 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 				Height:     height,
 				Width:      width,
 				Size:       file.Size,
-				URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v/%v", getProto(req), req.Request.Host, file.ID, file.Filename, dnt),
+				URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v", getProto(req), req.Request.Host, file.ID, dnt),
 			},
 		},
 	})
@@ -335,7 +335,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 					Height:     height,
 					Width:      width,
 					Size:       file.Size,
-					URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v/%v", getProto(req), req.Request.Host, file.ID, scene.GetFunscriptTitle(), dnt),
+					URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v", getProto(req), req.Request.Host, file.ID, dnt),
 				},
 			},
 		}


### PR DESCRIPTION
Rather than try and sanitize the URL with the full title in it to fix #1220 - I went for a different approach: _drop the title from the URL in the HereSphere JSON entirely_ - and hopefully never have to deal with issues stemming from unescaped **anything** in scene titles ever again.

I don't have any funscripts to test but that's the only other part of the code I touched. `ws` seemingly responds to anything, including the "short" e.g. `http://127.0.0.1:9999/api/dms/file/1234` that this now puts in the HereSphere JSON for `media` -> `url`.

Not sure which change actually fixes this. Not sure if the `file.Filename` that you'd expect to see in the JSON based on Line 224 was never used and the media URLs always had `scene.GetFunscriptTitle()` in them, or if just replacing that with `file.Filename` on Line 338 alone would work, or if `file.Filename` itself was to blame and was just dumping the entire title in there instead of the actual filename. But I'd have to build it again to check, and this already worked just fine as is anyways with seemingly no downsides...`file.ID` is already unique, and `ws` will serve it up without anything appended to it just fine.

Somebody who knows more about how the heresphere API works - ideally whoever wrote heresphere.go - might want to take a look. @toshski @crwxaj 