### PR TITLE
Fix VirtualReal Site Crashes

### DIFF
--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -74,7 +74,7 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 		}
 
 		// Duration / Release date / Synopsis
-		e.ForEach(`script[type='application/ld+json'][class!='yoast-schema-graph']`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div script[type='application/ld+json']`, func(id int, e *colly.HTMLElement) {
 			var jsonResult map[string]interface{}
 			json.Unmarshal([]byte(e.Text), &jsonResult)
 


### PR DESCRIPTION
Duration, Release Date and Synopsis fields no longer in the script with class "yoast-schema-graph".  Suspect they have split the json into 2 different script tags.  Changed to get the json script under a div, to differentiate from script with class "yoast-schema-graph" under the head tag