### PR TITLE
Patch javbus duration

### DIFF
--- a/pkg/scrape/javbus.go
+++ b/pkg/scrape/javbus.go
@@ -2,8 +2,8 @@ package scrape
 
 import (
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/xbapps/xbvr/pkg/models"
@@ -58,7 +58,7 @@ func ScrapeJavBus(out *[]models.ScrapedScene, queryString string) {
 				durationRegex := regexp.MustCompile("(\\d+)")
 				match := durationRegex.FindStringSubmatch(durationStr)
 				if match != nil && len(match) > 1 {
-					sc.Duration, _ =  strconv.Atoi(match[1])
+					sc.Duration, _ = strconv.Atoi(match[1])
 				}
 			}
 		})

--- a/pkg/scrape/javbus.go
+++ b/pkg/scrape/javbus.go
@@ -50,6 +50,15 @@ func ScrapeJavBus(out *[]models.ScrapedScene, queryString string) {
 				if match != nil && len(match) > 1 {
 					sc.Released = match[1]
 				}
+
+			} else if label == `Length:` {
+				// Duration
+				durationStr := p.Text
+				durationRegex := regexp.MustCompile("(\\d+)")
+				match := durationRegex.FindStringSubmatch(durationStr)
+				if match != nil {
+					sc.Duration = match[1]
+				}
 			}
 		})
 

--- a/pkg/scrape/javbus.go
+++ b/pkg/scrape/javbus.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"regexp"
 	"strings"
+	"strconv"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/xbapps/xbvr/pkg/models"
@@ -56,8 +57,8 @@ func ScrapeJavBus(out *[]models.ScrapedScene, queryString string) {
 				durationStr := p.Text
 				durationRegex := regexp.MustCompile("(\\d+)")
 				match := durationRegex.FindStringSubmatch(durationStr)
-				if match != nil {
-					sc.Duration = match[1]
+				if match != nil && len(match) > 1 {
+					sc.Duration, _ =  strconv.Atoi(match[1])
 				}
 			}
 		})


### PR DESCRIPTION
Similarly to #1270 add duration to javbus JAVR scraper
`scraper: add duration to javbus JAVR scraper`

<details><summary>Seems to work OK in testing</summary>
<p>

![image](https://github.com/xbapps/xbvr/assets/81622808/4684a617-3f5a-42f6-84cb-055eed974504)
![image](https://github.com/xbapps/xbvr/assets/81622808/ef618e90-bff3-4d29-bd4e-094cbe167d85)

</p>
</details> 

Gitpod didn't complain about gofmt errors either.