### PR TITLE
Provide a migration to keep sexbabes filenames

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1475,6 +1475,22 @@ func Migrate() {
 				return tx.Exec(sql).Error
 			},
 		},
+		{
+			ID: "0064-migrate-sexbabes_filenames",
+			Migrate: func(tx *gorm.DB) error {
+				// new sexbabes scraper does not have filenames, this creates an edit record (if there is not already one)
+				// to reapply the filenames after scraping, so they are not lost
+				sql := `insert into actions (scene_id, action_type, changed_column, new_value) 
+				select s.scene_id, 'edit', 'filenames_arr', filenames_arr
+				from scenes s 
+				left join actions a on a.scene_id = s.scene_id and a.changed_column = 'filenames_arr'
+				where s.scene_id like 'sexbab%' 
+				and a.scene_id is null  
+				and filenames_arr <> 'null'
+				`
+				return tx.Exec(sql).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {


### PR DESCRIPTION
The new sexbabes scraper #1280 does not have filenames and after re-scraping scenes the filename list maybe empty for a scene.  A request was made to keep the old filename list.  No filenames is not really a problem, as files already matched will remain matched, as the file record has a link to the matched scene. 
So this is a bit of a nice to have, although it will be useful if a user changed the Storage Location for their files, as that would require manually re-match files.

The PR will create "edit/filename_arr" Action Records to repopulate the filename list after a re-scraping scenes.