### PR TITLE
Show scene counts in Actors cards

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -43,17 +43,18 @@ type VersionCheckResponse struct {
 }
 
 type RequestSaveOptionsWeb struct {
-	TagSort           string `json:"tagSort"`
-	SceneWatchlist    bool   `json:"sceneWatchlist"`
-	SceneFavourite    bool   `json:"sceneFavourite"`
-	SceneWatched      bool   `json:"sceneWatched"`
-	SceneEdit         bool   `json:"sceneEdit"`
-	SceneDuration     bool   `json:"sceneDuration"`
-	SceneCuepoint     bool   `json:"sceneCuepoint"`
-	ShowHspFile       bool   `json:"showHspFile"`
-	ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
-	SceneTrailerlist  bool   `json:"sceneTrailerlist"`
-	UpdateCheck       bool   `json:"updateCheck"`
+	TagSort                string `json:"tagSort"`
+	SceneWatchlist         bool   `json:"sceneWatchlist"`
+	SceneFavourite         bool   `json:"sceneFavourite"`
+	SceneWatched           bool   `json:"sceneWatched"`
+	SceneEdit              bool   `json:"sceneEdit"`
+	SceneDuration          bool   `json:"sceneDuration"`
+	SceneCuepoint          bool   `json:"sceneCuepoint"`
+	ShowHspFile            bool   `json:"showHspFile"`
+	ShowSubtitlesFile      bool   `json:"showSubtitlesFile"`
+	SceneTrailerlist       bool   `json:"sceneTrailerlist"`
+	ShowSceneCountForActor bool   `json:"showSceneCountForActor"`
+	UpdateCheck            bool   `json:"updateCheck"`
 }
 
 type RequestSaveOptionsAdvanced struct {
@@ -356,6 +357,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.ShowHspFile = r.ShowHspFile
 	config.Config.Web.ShowSubtitlesFile = r.ShowSubtitlesFile
 	config.Config.Web.SceneTrailerlist = r.SceneTrailerlist
+	config.Config.Web.ShowSceneCountForActor = r.ShowSceneCountForActor
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.SaveConfig()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,17 +28,18 @@ type ObjectConfig struct {
 		Password string `default:"" json:"password"`
 	} `json:"security"`
 	Web struct {
-		TagSort           string `default:"by-tag-count" json:"tagSort"`
-		SceneWatchlist    bool   `default:"true" json:"sceneWatchlist"`
-		SceneFavourite    bool   `default:"true" json:"sceneFavourite"`
-		SceneWatched      bool   `default:"false" json:"sceneWatched"`
-		SceneEdit         bool   `default:"false" json:"sceneEdit"`
-		SceneDuration     bool   `default:"false" json:"sceneDuration"`
-		SceneCuepoint     bool   `default:"true" json:"sceneCuepoint"`
-		ShowHspFile       bool   `default:"true" json:"showHspFile"`
-		ShowSubtitlesFile bool   `default:"true" json:"showSubtitlesFile"`
-		SceneTrailerlist  bool   `default:"true" json:"sceneTrailerlist"`
-		UpdateCheck       bool   `default:"true" json:"updateCheck"`
+		TagSort                string `default:"by-tag-count" json:"tagSort"`
+		SceneWatchlist         bool   `default:"true" json:"sceneWatchlist"`
+		SceneFavourite         bool   `default:"true" json:"sceneFavourite"`
+		SceneWatched           bool   `default:"false" json:"sceneWatched"`
+		SceneEdit              bool   `default:"false" json:"sceneEdit"`
+		SceneDuration          bool   `default:"false" json:"sceneDuration"`
+		SceneCuepoint          bool   `default:"true" json:"sceneCuepoint"`
+		ShowHspFile            bool   `default:"true" json:"showHspFile"`
+		ShowSubtitlesFile      bool   `default:"true" json:"showSubtitlesFile"`
+		SceneTrailerlist       bool   `default:"true" json:"sceneTrailerlist"`
+		ShowSceneCountForActor bool   `default:"false" json:"showSceneCountForActor"`
+		UpdateCheck            bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Advanced struct {
 		ShowInternalSceneId   bool   `default:"false" json:"showInternalSceneId"`

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -12,17 +12,18 @@ type ObjectState struct {
 		BoundIP []string `json:"bound_ip"`
 	} `json:"server"`
 	Web struct {
-		TagSort           string `json:"tagSort"`
-		SceneWatchlist    bool   `json:"sceneWatchlist"`
-		SceneFavourite    bool   `json:"sceneFavourite"`
-		SceneWatched      bool   `json:"sceneWatched"`
-		SceneEdit         bool   `json:"sceneEdit"`
-		SceneDuration     bool   `json:"sceneDuration"`
-		SceneCuepoint     bool   `json:"sceneCuepoint"`
-		ShowHspFile       bool   `json:"showHspFile"`
-		ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
-		SceneTrailerlist  bool   `json:"sceneTrailerlist"`
-		UpdateCheck       bool   `json:"updateCheck"`
+		TagSort                string `json:"tagSort"`
+		SceneWatchlist         bool   `json:"sceneWatchlist"`
+		SceneFavourite         bool   `json:"sceneFavourite"`
+		SceneWatched           bool   `json:"sceneWatched"`
+		SceneEdit              bool   `json:"sceneEdit"`
+		SceneDuration          bool   `json:"sceneDuration"`
+		SceneCuepoint          bool   `json:"sceneCuepoint"`
+		ShowHspFile            bool   `json:"showHspFile"`
+		ShowSubtitlesFile      bool   `json:"showSubtitlesFile"`
+		SceneTrailerlist       bool   `json:"sceneTrailerlist"`
+		ShowSceneCountForActor bool   `json:"showSceneCountForActor"`
+		UpdateCheck            bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {
 		Running  bool     `json:"running"`

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -163,6 +163,8 @@
   "Press o/left arrow to page back, p/right arrow to page forward":"Press o/left arrow to page back, p/right arrow to page forward",
   "Average rating of scenes":"Average rating of scenes",
   "Your rating":"Your rating",
+  "Number of scenes":"Number of scenes",
+  "Number of available scenes":"Number of available scenes",
   "Gallery":"Gallery",
   "Details":"Details",
   "Delete Aka Group":"Delete Aka Group",

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -13,6 +13,7 @@ const state = {
     showHspFile: true,
     showSubtitlesFile: true,
     sceneTrailerlist: true,
+    showSceneCountForActor: false,
     updateCheck: true
   }
 }
@@ -35,6 +36,7 @@ const actions = {
         state.web.showHspFile = data.config.web.showHspFile
         state.web.showSubtitlesFile = data.config.web.showSubtitlesFile
         state.web.sceneTrailerlist = data.config.web.sceneTrailerlist
+        state.web.showSceneCountForActor = data.config.web.showSceneCountForActor
         state.web.updateCheck = data.config.web.updateCheck
         state.loading = false
       })
@@ -54,6 +56,7 @@ const actions = {
         state.web.showHspFile = data.showHspFile
         state.web.showSubtitlesFile = data.showSubtitlesFile        
         state.web.sceneTrailerlist = data.sceneTrailerlist
+        state.web.showSceneCountForActor = data.showSceneCountForActor
         state.web.updateCheck = data.updateCheck
         state.loading = false
       })

--- a/ui/src/views/actors/ActorCard.vue
+++ b/ui/src/views/actors/ActorCard.vue
@@ -22,15 +22,27 @@
       <actor-watchlist-button :actor="actor" v-if="this.$store.state.optionsWeb.web.sceneWatchlist"/>
       <actor-edit-button :actor="actor"/>&nbsp;
       <b-tooltip :label="$t('Your rating')" :delay="500">
-      <b-tag type="is-warning" v-if="actor.star_rating != 0 " size="is-small" style="height:30px;">
+      <b-tag type="is-warning" v-if="actor.star_rating != 0 && !this.$store.state.optionsWeb.web.showSceneCountForActor" size="is-small" style="height:30px;">
         <b-icon pack="mdi" icon="star" size="is-small"/>
         {{actor.star_rating}}
       </b-tag>
       </b-tooltip>
       <b-tooltip :label="$t('Average rating of scenes')" :delay="500">
-      <b-tag type="is-primary" v-if="actor.scene_rating_average != 0 " style="height:30px;">
+      <b-tag type="is-primary" v-if="actor.scene_rating_average != 0 && !this.$store.state.optionsWeb.web.showSceneCountForActor" style="height:30px;">
         <b-icon pack="mdi" icon="star" size="is-small"/>
         {{Math.round(actor.scene_rating_average * 4) / 4}}
+      </b-tag>
+      </b-tooltip>
+      <b-tooltip :label="$t('Number of scenes')" :delay="500">
+      <b-tag type="is-warning" v-if="this.$store.state.optionsWeb.web.showSceneCountForActor" size="is-small" style="height:30px;">
+        <b-icon pack="mdi" icon="movie-open" size="is-small"/>
+        {{actor.scenes.length}}
+      </b-tag>
+      </b-tooltip>
+      <b-tooltip :label="$t('Number of available scenes')" :delay="500">
+      <b-tag type="is-primary" v-if="this.$store.state.optionsWeb.web.showSceneCountForActor" size="is-small" style="height:30px;">
+        <b-icon pack="mdi" icon="movie-open" size="is-small"/>
+        {{actor.avail_count}}
       </b-tag>
       </b-tooltip>
 

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -65,6 +65,11 @@
                 show subtitles File button
               </b-switch>
             </b-field>
+            <b-field>
+              <b-switch v-model="sceneCountForActor" type="is-dark">
+                show scene counts rather than ratings in Actors cards
+              </b-switch>
+            </b-field>
 
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
@@ -180,6 +185,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.showSubtitlesFile = value
+      }
+    },
+    sceneCountForActor: {
+      get () {
+        return this.$store.state.optionsWeb.web.showSceneCountForActor
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showSceneCountForActor = value
       }
     },
     isLoading: function () {


### PR DESCRIPTION
As discussed on Discord, this adds the option in the Web UI settings to display the number of scenes and available number of scenes on the Actors cards instead of the scene ratings average and the actor rating.