### PR TITLE
SLR Passthrough

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -705,6 +705,15 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0065-scenes-add-chromakey-for-passthrough",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					ChromaKey string `json:"chromakey" xbvrbackup:"chromakey"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -102,6 +102,7 @@ type Scene struct {
 	EditsApplied  bool   `json:"edits_applied" gorm:"default:false" xbvrbackup:"-"`
 	TrailerType   string `json:"trailer_type" xbvrbackup:"trailer_type"`
 	TrailerSource string `gorm:"size:1000" json:"trailer_source" xbvrbackup:"trailer_source"`
+	ChromaKey     string `json:"passthrough" xbvrbackup:"passthrough"`
 	Trailerlist   bool   `json:"trailerlist" gorm:"default:false" xbvrbackup:"trailerlist"`
 	IsSubscribed  bool   `json:"is_subscribed" gorm:"default:false"`
 	IsHidden      bool   `json:"is_hidden" gorm:"default:false" xbvrbackup:"is_hidden"`
@@ -430,6 +431,8 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	}
 	o.SceneURL = ext.HomepageURL
 	o.MemberURL = ext.MembersUrl
+
+	o.ChromaKey = ext.ChromaKey
 
 	// Trailers
 	o.TrailerType = ext.TrailerType

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -36,6 +36,7 @@ type ScrapedScene struct {
 	MembersUrl  string   `json:"members_url"`
 	TrailerType string   `json:"trailer_type"`
 	TrailerSrc  string   `json:"trailer_source"`
+	ChromaKey   string   `json:"chromakey"`
 
 	ActorDetails map[string]ActorDetails `json:"actor_details"`
 }


### PR DESCRIPTION
Passthrough for SLR/DeoVR.

**Existing "passthrough" scenes are not updated automatically.**
1. Does not work on "unmatched" videos.
3. This only works with SLR scraper. Scenes that SLR either supplied native passthrough (Alpha) and where they add passthrough to non-native passthrough (passthrough hack).
3. Downloaded "alpha" vids now automatch.
4. Currently can't manually add your own scenes or update existing within the UI. You would have to edit in the DB.
5. force update (by scene edit or via scraper) is needed to update existing naming or pt info.

This should resolve #1303 