### PR TITLE
Fix issue with Ambiguous column name

### DIFF
--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -180,10 +180,10 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 
 	for _, i := range r.Lists {
 		if i.OrElse("") == "watchlist" {
-			tx = tx.Where("watchlist = ?", true)
+			tx = tx.Where("actors.watchlist = ?", true)
 		}
 		if i.OrElse("") == "favourite" {
-			tx = tx.Where("favourite = ?", true)
+			tx = tx.Where("actors.favourite = ?", true)
 		}
 	}
 
@@ -230,9 +230,9 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 		switch fieldName {
 		case "In Watchlist":
 			if truefalse {
-				where = "watchlist = 1"
+				where = "actors.watchlist = 1"
 			} else {
-				where = "watchlist = 0"
+				where = "actors.watchlist = 0"
 			}
 		case "Is Scripted":
 			if truefalse {
@@ -242,15 +242,15 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 			}
 		case "Is Favourite":
 			if truefalse {
-				where = "favourite = 1"
+				where = "actors.favourite = 1"
 			} else {
-				where = "favourite = 0"
+				where = "actors.favourite = 0"
 			}
 		case "Has Rating":
 			if truefalse {
-				where = "star_rating > 0"
+				where = "actors.star_rating > 0"
 			} else {
-				where = "star_rating = 0"
+				where = "actors.star_rating = 0"
 			}
 		case "Aka Group":
 			if truefalse {
@@ -286,9 +286,9 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 			}
 		case "Rating 0", "Rating .5", "Rating 1", "Rating 1.5", "Rating 2", "Rating 2.5", "Rating 3", "Rating 3.5", "Rating 4", "Rating 4.5", "Rating 5":
 			if truefalse {
-				where = "star_rating = " + fieldName[7:]
+				where = "actors.star_rating = " + fieldName[7:]
 			} else {
-				where = "star_rating <> " + fieldName[7:]
+				where = "actors.star_rating <> " + fieldName[7:]
 			}
 		case "Has Tattoo":
 			if truefalse {
@@ -423,12 +423,12 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 		tx = tx.Order("name desc")
 	case "rating_desc":
 		tx = tx.
-			Where("star_rating > ?", 0).
-			Order("star_rating desc")
+			Where("actors.star_rating > ?", 0).
+			Order("actors.star_rating desc")
 	case "rating_asc":
 		tx = tx.
-			Where("star_rating > ?", 0).
-			Order("star_rating asc")
+			Where("actors.star_rating > ?", 0).
+			Order("actors.star_rating asc")
 	case "scene_rating_desc":
 		tx = tx.
 			Order("(select AVG(s.star_rating) from scene_cast sc join scenes s on s.id=sc.scene_id where sc.actor_id =actors.id and s.star_rating > 0 ) desc, (select count(*) from scene_cast sc join scenes s on s.id=sc.scene_id where sc.actor_id =actors.id and s.star_rating > 0 ) desc, (select count(*) from scene_cast sc join scenes s on s.id=sc.scene_id where sc.actor_id =actors.id) desc")

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -602,10 +602,10 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 
 	for _, i := range r.Lists {
 		if i.OrElse("") == "watchlist" {
-			tx = tx.Where("watchlist = ?", true)
+			tx = tx.Where("scenes.watchlist = ?", true)
 		}
 		if i.OrElse("") == "favourite" {
-			tx = tx.Where("favourite = ?", true)
+			tx = tx.Where("scenes.favourite = ?", true)
 		}
 		if i.OrElse("") == "scripted" {
 			tx = tx.Where("is_scripted = ?", true)
@@ -686,9 +686,9 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 			}
 		case "Has Rating":
 			if truefalse {
-				where = "star_rating > 0"
+				where = "scenes.star_rating > 0"
 			} else {
-				where = "star_rating = 0"
+				where = "scenes.star_rating = 0"
 			}
 		case "Has Cuepoints":
 			if truefalse {
@@ -722,9 +722,9 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 			}
 		case "Rating 0", "Rating .5", "Rating 1", "Rating 1.5", "Rating 2", "Rating 2.5", "Rating 3", "Rating 3.5", "Rating 4", "Rating 4.5", "Rating 5":
 			if truefalse {
-				where = "star_rating = " + fieldName[7:]
+				where = "scenes.star_rating = " + fieldName[7:]
 			} else {
-				where = "star_rating <> " + fieldName[7:]
+				where = "scenes.star_rating <> " + fieldName[7:]
 			}
 		case "Cast 6+":
 			if truefalse {
@@ -863,9 +863,9 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 			}
 		case "In Watchlist":
 			if truefalse {
-				where = "watchlist = 1"
+				where = "scenes.watchlist = 1"
 			} else {
-				where = "watchlist = 0"
+				where = "scenes.watchlist = 0"
 			}
 		case "Is Scripted":
 			if truefalse {
@@ -875,9 +875,9 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 			}
 		case "Is Favourite":
 			if truefalse {
-				where = "favourite = 1"
+				where = "scenes.favourite = 1"
 			} else {
-				where = "favourite = 0"
+				where = "scenes.favourite = 0"
 			}
 		case "Stashdb Linked":
 			if truefalse {
@@ -1099,12 +1099,12 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 		tx = tx.Order("total_watch_time asc")
 	case "rating_desc":
 		tx = tx.
-			Where("star_rating > ?", 0).
-			Order("star_rating desc")
+			Where("scenes.star_rating > ?", 0).
+			Order("scenes.star_rating desc")
 	case "rating_asc":
 		tx = tx.
-			Where("star_rating > ?", 0).
-			Order("star_rating asc")
+			Where("scenes.star_rating > ?", 0).
+			Order("scenes.star_rating asc")
 	case "last_opened_desc":
 		tx = tx.
 			Where("last_opened > ?", "0001-01-01 00:00:00+00:00").


### PR DESCRIPTION
The introduction of Actors broke some existing filter queries, this is due to the same column name now existing in the actors table as in the scenes table.  Some filter combinations now fail due to ambiguous column names.

e.g. filter scenes by Favorites and an Actor would return no results