### PR TITLE
Fix scene card spacing in Scene Tab in Actor Details overlay

### DIFF
--- a/ui/src/views/actors/ActorDetails.vue
+++ b/ui/src/views/actors/ActorDetails.vue
@@ -152,7 +152,7 @@
                     </b-message>
                 </b-tab-item>
                 <b-tab-item :label="`Scenes (${actor.scenes.length})`">
-                  <div v-show="activeTab == 1" class="columns is-multiline scroll">
+                  <div v-show="activeTab == 1" :class="['columns', 'is-multiline', actor.scenes.length > 6 ? 'scroll' : '']">
                     <div :class="['column', 'is-multiline', 'is-one-third']"
                       v-for="(scene, idx) in actor.scenes" :key="idx" class="image-wrapper">
                       <SceneCard :item="scene" :reRead=true />


### PR DESCRIPTION
This change provides a minor cosmetic fix to the Scenes Tab in the Actors Details.

The scenes use a "scroll" style, to place a scroll window around the list of scenes, this is so the user can scroll down the scenes, but leave the Actors Images visible on the left.

However, when there was only 2 rows of scenes, this can pull the second row to the bottom of the window, leaving a gap between the scene rows.  How obvious this is, depends on the screen resolution, it was more noticeable when using 1080.

The scroll style is now only applied when there is more than 6 scenes (more than 2 rows)