### PR TITLE
Change Age Slider lower bound to 18

### DIFF
--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -344,7 +344,7 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 		tx = tx.Where("actors.name > ?", r.JumpTo.OrElse(""))
 	}
 
-	if r.MinAge.OrElse(0) > 0 || r.MaxAge.OrElse(100) < 100 {
+	if r.MinAge.OrElse(0) > 18 || r.MaxAge.OrElse(100) < 100 {
 		startRange := time.Now().AddDate(r.MinAge.OrElse(0)*-1, 0, 0)
 		endRange := time.Now().AddDate(r.MaxAge.OrElse(0)*-1, 0, 0)
 		tx = tx.Where("actors.birth_date <= ? and actors.birth_date >= ?", startRange, endRange)

--- a/ui/src/views/actors/Filters.vue
+++ b/ui/src/views/actors/Filters.vue
@@ -108,7 +108,7 @@
       <table width="100%">
         <tr>
           <td class="slider-title"><strong><small>{{ $t("Age") }}:</small></strong></td>
-          <td ><b-slider :min="0" :max="100" :step="1" :tooltip="true" v-model="ages" lazy class="slider"></b-slider></td>
+          <td ><b-slider :min="18" :max="100" :step="1" :tooltip="true" v-model="ages" lazy class="slider"></b-slider></td>
         </tr>
         <tr>
           <td class="slider-title"><strong><small>{{ $t("Height") }}:</small></strong></td>


### PR DESCRIPTION
This is a minor change (requested in the interests of good taste) to set the lower bounds of the Age filter slider to 18.
It will not really affect queries given no-one should be under 18 and not adjusting the sliders still shows everyone (including unknown birth dates)