### PR TITLE
Search troubleshooting assistance

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -59,6 +59,7 @@ type RequestSaveOptionsWeb struct {
 type RequestSaveOptionsAdvanced struct {
 	ShowInternalSceneId   bool   `json:"showInternalSceneId"`
 	ShowHSPApiLink        bool   `json:"showHSPApiLink"`
+	ShowSceneSearchField  bool   `json:"showSceneSearchField"`
 	StashApiKey           string `json:"stashApiKey"`
 	ScrapeActorAfterScene bool   `json:"scrapeActorAfterScene"`
 	UseImperialEntry      bool   `json:"useImperialEntry"`
@@ -379,6 +380,7 @@ func (i ConfigResource) saveOptionsAdvanced(req *restful.Request, resp *restful.
 
 	config.Config.Advanced.ShowInternalSceneId = r.ShowInternalSceneId
 	config.Config.Advanced.ShowHSPApiLink = r.ShowHSPApiLink
+	config.Config.Advanced.ShowSceneSearchField = r.ShowSceneSearchField
 	config.Config.Advanced.StashApiKey = r.StashApiKey
 	config.Config.Advanced.ScrapeActorAfterScene = r.ScrapeActorAfterScene
 	config.Config.Advanced.UseImperialEntry = r.UseImperialEntry

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type ObjectConfig struct {
 	Advanced struct {
 		ShowInternalSceneId   bool   `default:"false" json:"showInternalSceneId"`
 		ShowHSPApiLink        bool   `default:"false" json:"showHSPApiLink"`
+		ShowSceneSearchField  bool   `default:"false" json:"showSceneSearchField"`
 		StashApiKey           string `default:"" json:"stashApiKey"`
 		ScrapeActorAfterScene bool   `default:"true" json:"scrapeActorAfterScene"`
 		UseImperialEntry      bool   `default:"false" json:"useImperialEntry"`

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -198,5 +198,6 @@
   "No Matching Cast":"No Matching Cast",
   "No matching sites":"No matching sites",
   "No matching attributes":"No matching attributes",
+  "Only required when troubleshooting search issues, this will enable a Tab in the Scene Details to display what search fields exist and their values for a scene":"Only required when troubleshooting search issues, this will enable a Tab in the Scene Details to display what search fields exist and their values for a scene",
   "Go": "Go"
 }

--- a/ui/src/store/optionsAdvanced.js
+++ b/ui/src/store/optionsAdvanced.js
@@ -5,6 +5,7 @@ const state = {
   advanced: {
     showInternalSceneId: false,
     showHSPApiLink: false,
+    showSceneSearchField: false,
     stashApiKey: '',
     scrapeActorAfterScene: 'true',
     useImperialEntry: 'false',
@@ -21,6 +22,7 @@ const actions = {
       .then(data => {
         state.advanced.showInternalSceneId = data.config.advanced.showInternalSceneId
         state.advanced.showHSPApiLink = data.config.advanced.showHSPApiLink
+        state.advanced.showSceneSearchField = data.config.advanced.showSceneSearchField
         state.advanced.stashApiKey = data.config.advanced.stashApiKey
         state.advanced.scrapeActorAfterScene = data.config.advanced.scrapeActorAfterScene
         state.advanced.useImperialEntry = data.config.advanced.useImperialEntry
@@ -34,6 +36,7 @@ const actions = {
       .then(data => {
         state.advanced.showInternalSceneId = data.showInternalSceneId
         state.advanced.showHSPApiLink = data.showHSPApiLink
+        state.advanced.showSceneSearchField = data.showSceneSearchField
         state.advanced.stashApiKey = data.stashApiKey
         state.advanced.scrapeActorAfterScene = data.scrapeActorAfterScene
         state.advanced.useImperialEntry = data.useImperialEntry

--- a/ui/src/views/options/sections/InterfaceAdvanced.vue
+++ b/ui/src/views/options/sections/InterfaceAdvanced.vue
@@ -25,6 +25,13 @@
               </b-switch>
             </b-field>
             <b-field>
+              <b-tooltip :label="$t('Only required when troubleshooting search issues, this will enable a Tab in the Scene Details to display what search fields exist and their values for a scene')" :delay="500" type="is-warning">
+              <b-switch v-model="showSceneSearchField" type="is-default">
+                show Scene Search Fields
+              </b-switch>
+              </b-tooltip>
+            </b-field>
+            <b-field>
               <b-button type="is-primary" @click="save">Save</b-button>
             </b-field>
           </section>
@@ -152,11 +159,19 @@ export default {
       }
     },
     showHSPApiLink: {
-      get () {
+      get () {        
         return this.$store.state.optionsAdvanced.advanced.showHSPApiLink
       },
       set (value) {
         this.$store.state.optionsAdvanced.advanced.showHSPApiLink = value
+      },
+    },
+    showSceneSearchField: {
+      get () {
+        return this.$store.state.optionsAdvanced.advanced.showSceneSearchField
+      },
+      set (value) {
+        this.$store.state.optionsAdvanced.advanced.showSceneSearchField = value
       },
     },
     stashApiKey: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -331,6 +331,15 @@
                     </b-message>
                   </div>
                 </b-tab-item>
+                <b-tab-item v-if="this.$store.state.optionsAdvanced.advanced.showSceneSearchField" label="Search fields">
+                  <div class="block-tab-content block">
+                    <div class="content is-small">
+                      <div class="block" v-for="(field, idx) in searchfields" :key="idx">
+                        <strong>{{ field.FieldName }} - </strong> {{ field.FieldValue }}                        
+                      </div>
+                    </div>
+                  </div>
+                </b-tab-item>
 
               </b-tabs>
             </div>
@@ -399,6 +408,7 @@ export default {
       endTime: null,
       sortMultiple: true,
       castimages: [],
+      searchfields: [],
     }
   },
   computed: {
@@ -406,9 +416,7 @@ export default {
       const item = this.$store.state.overlay.details.scene
       if (this.$store.state.optionsWeb.web.tagSort === 'alphabetically') {
         item.tags.sort((a, b) => a.name < b.name ? -1 : 1)
-      }
-
-      console.log(item.cast)
+      }      
       let imgs = item.cast.map((actor) => {
         let img = actor.image_url
         if (img == "" ){
@@ -510,7 +518,8 @@ export default {
       this.cuepointPositionTags = data.positions
       this.cuepointActTags.unshift("")
       this.cuepointPositionTags.unshift("")      
-      })  
+      }) 
+    this.getSearchFields() 
 },
   methods: {
     setupPlayer () {
@@ -743,6 +752,7 @@ export default {
         this.carouselSlide = 0
         this.updatePlayer(undefined, '180')
       }
+      this.getSearchFields()
     },
     prevScene () {
       const data = this.$store.getters['sceneList/prevScene'](this.item)
@@ -752,6 +762,7 @@ export default {
         this.carouselSlide = 0
         this.updatePlayer(undefined, '180')
       }
+      this.getSearchFields()
     },
     playerStepBack (interval) {
       const wasPlaying = !this.player.paused()
@@ -868,6 +879,18 @@ export default {
     },
     hideTooltip(idx) {
       this.castimages[idx].visible = false;      
+    },
+    getSearchFields() {
+      // load search fields
+      if (this.$store.state.optionsAdvanced.advanced.showSceneSearchField) {
+        ky.get('/api/scene/searchfields', {
+          searchParams: {
+            q: this.item.id
+          },
+          }).json().then(data => { 
+            this.searchfields = data
+          })
+      }
     },
     format,
     parseISO,


### PR DESCRIPTION
This mod is to help when people are having trouble with search.
Commit d6d272acfce1915b796d519d627de3dc4b5fcdd1 

- Displays a count of scenes in the search index to Options/Cache/Search Index
- Adds a Rescan button to trigger an Index update Options/Cache/Search Index.  The existing Reset button only clears the Indexes, it doesn't start a scan

Commit 827566850b3a1fba04e8cd08ed9ffff823e90737
- Adds an option to enable an extra Tab in the Scene Details overlay, to display what fields exist in the Index and their values for the scene. Enable in Options/Advanced/Scene Details 