### PR TITLE
feat: Add ability to scrape a single scene

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -106,6 +106,7 @@ type RequestSaveOptionsPreviews struct {
 type GetStateResponse struct {
 	CurrentState config.ObjectState  `json:"currentState"`
 	Config       config.ObjectConfig `json:"config"`
+	Scrapers     []models.Scraper    `json:"scrapers"`
 }
 
 type GetSearchStateResponse struct {
@@ -590,6 +591,7 @@ func (i ConfigResource) getState(req *restful.Request, resp *restful.Response) {
 
 	out.Config = config.Config
 	out.CurrentState = config.State
+	out.Scrapers = models.GetScrapers()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, out)
 }

--- a/pkg/api/tasks.go
+++ b/pkg/api/tasks.go
@@ -128,9 +128,6 @@ func (i TaskResource) scrape(req *restful.Request, resp *restful.Response) {
 	go tasks.Scrape(qSiteID, "", "")
 }
 func (i TaskResource) singleScrape(req *restful.Request, resp *restful.Response) {
-	//body, _ := ioutil.ReadAll(req.Request.Body)
-	//json.Unmarshal(body, &scrapeParams)
-
 	var scrapeParams RequestSingleScrape
 	req.ReadEntity(&scrapeParams)
 	additionalInfo, _ := json.Marshal(scrapeParams.AdditionalInfo)

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -10,10 +10,11 @@ var scrapers []Scraper
 type ScraperFunc func(*sync.WaitGroup, bool, []string, chan<- ScrapedScene, string, string) error
 
 type Scraper struct {
-	ID        string
-	Name      string
-	AvatarURL string
-	Scrape    ScraperFunc
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	AvatarURL string      `json:"avaatarurl"`
+	Domain    string      `json:"domain"`
+	Scrape    ScraperFunc `json:"-"`
 }
 
 type ScrapedScene struct {
@@ -71,11 +72,12 @@ func GetScrapers() []Scraper {
 	return scrapers
 }
 
-func RegisterScraper(id string, name string, avatarURL string, f ScraperFunc) {
+func RegisterScraper(id string, name string, avatarURL string, domain string, f ScraperFunc) {
 	s := Scraper{}
 	s.ID = id
 	s.Name = name
 	s.AvatarURL = avatarURL
+	s.Domain = domain
 	s.Scrape = f
 	scrapers = append(scrapers, s)
 }

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -7,7 +7,7 @@ import (
 
 var scrapers []Scraper
 
-type ScraperFunc func(*sync.WaitGroup, bool, []string, chan<- ScrapedScene) error
+type ScraperFunc func(*sync.WaitGroup, bool, []string, chan<- ScrapedScene, string, string) error
 
 type Scraper struct {
 	ID        string

--- a/pkg/models/model_site.go
+++ b/pkg/models/model_site.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/avast/retry-go/v4"
@@ -52,11 +53,13 @@ func InitSites() {
 
 	scrapers := GetScrapers()
 	for i := range scrapers {
-		var st Site
-		db.Where(&Site{ID: scrapers[i].ID}).FirstOrCreate(&st)
-		st.Name = scrapers[i].Name
-		st.AvatarURL = scrapers[i].AvatarURL
-		st.IsBuiltin = true
-		st.Save()
+		if strings.HasSuffix(scrapers[i].ID, "-single_scene") == false {
+			var st Site
+			db.Where(&Site{ID: scrapers[i].ID}).FirstOrCreate(&st)
+			st.Name = scrapers[i].Name
+			st.AvatarURL = scrapers[i].AvatarURL
+			st.IsBuiltin = true
+			st.Save()
+		}
 	}
 }

--- a/pkg/scrape/baberoticavr.go
+++ b/pkg/scrape/baberoticavr.go
@@ -154,5 +154,5 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 }
 
 func init() {
-	registerScraper("baberoticavr", "BaberoticaVR", "https://baberoticavr.com/wp-content/themes/baberoticavr/images/fav/android-chrome-192x192.png", BaberoticaVR)
+	registerScraper("baberoticavr", "BaberoticaVR", "https://baberoticavr.com/wp-content/themes/baberoticavr/images/fav/android-chrome-192x192.png", "baberoticavr.com", BaberoticaVR)
 }

--- a/pkg/scrape/baberoticavr.go
+++ b/pkg/scrape/baberoticavr.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "baberoticavr"
 	siteID := "BaberoticaVR"

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, URL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -154,7 +154,11 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		}
 	})
 
-	siteCollector.Visit(URL)
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(URL)
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -163,24 +167,24 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	return nil
 }
 
-func BadoinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "badoinkvr", "BadoinkVR", "https://badoinkvr.com/vrpornvideos")
+func BadoinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "badoinkvr", "BadoinkVR", "https://badoinkvr.com/vrpornvideos", singeScrapeAdditionalInfo)
 }
 
-func B18VR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "18vr", "18VR", "https://18vr.com/vrpornvideos")
+func B18VR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "18vr", "18VR", "https://18vr.com/vrpornvideos", singeScrapeAdditionalInfo)
 }
 
-func VRCosplayX(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "vrcosplayx", "VRCosplayX", "https://vrcosplayx.com/cosplaypornvideos")
+func VRCosplayX(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "vrcosplayx", "VRCosplayX", "https://vrcosplayx.com/cosplaypornvideos", singeScrapeAdditionalInfo)
 }
 
-func BabeVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "babevr", "BabeVR", "https://babevr.com/vrpornvideos")
+func BabeVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "babevr", "BabeVR", "https://babevr.com/vrpornvideos", singeScrapeAdditionalInfo)
 }
 
-func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, "kinkvr", "KinkVR", "https://kinkvr.com/bdsm-vr-videos")
+func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "kinkvr", "KinkVR", "https://kinkvr.com/bdsm-vr-videos", singeScrapeAdditionalInfo)
 }
 
 func init() {

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -188,9 +188,9 @@ func KinkVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("badoinkvr", "BadoinkVR", "https://pbs.twimg.com/profile_images/618071358933610497/QaMV81nF_200x200.png", BadoinkVR)
-	registerScraper("18vr", "18VR", "https://pbs.twimg.com/profile_images/989481761783545856/w-iKqgqV_200x200.jpg", B18VR)
-	registerScraper("vrcosplayx", "VRCosplayX", "https://pbs.twimg.com/profile_images/900675974039298049/ofMytpkQ_200x200.jpg", VRCosplayX)
-	registerScraper("babevr", "BabeVR", "https://babevr.com/babevr_icons/apple-touch-icon.png", BabeVR)
-	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/kinkvr_icons/apple-touch-icon.png", KinkVR)
+	registerScraper("badoinkvr", "BadoinkVR", "https://pbs.twimg.com/profile_images/618071358933610497/QaMV81nF_200x200.png", "badoinkvr.com", BadoinkVR)
+	registerScraper("18vr", "18VR", "https://pbs.twimg.com/profile_images/989481761783545856/w-iKqgqV_200x200.jpg", "18vr.com", B18VR)
+	registerScraper("vrcosplayx", "VRCosplayX", "https://pbs.twimg.com/profile_images/900675974039298049/ofMytpkQ_200x200.jpg", "vrcosplayx.com", VRCosplayX)
+	registerScraper("babevr", "BabeVR", "https://babevr.com/babevr_icons/apple-touch-icon.png", "babevr.com", BabeVR)
+	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/kinkvr_icons/apple-touch-icon.png", "kinkvr.com", KinkVR)
 }

--- a/pkg/scrape/caribbeancom.go
+++ b/pkg/scrape/caribbeancom.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func CariVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func CariVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "caribbeancomvr"
 	siteID := "CaribbeanCom VR"
@@ -130,7 +130,11 @@ func CariVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.Visit("https://en.caribbeancom.com/eng/listpages/vr1.htm")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://en.caribbeancom.com/eng/listpages/vr1.htm")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/caribbeancom.go
+++ b/pkg/scrape/caribbeancom.go
@@ -144,5 +144,5 @@ func CariVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("caribbeancomvr", "CaribbeanCom VR", "https://mcdn.vrporn.com/files/20191217194900/baimudan-vr-porn-studio-logo-vrporn.com-virtual-reality-porn.jpg", CariVR)
+	registerScraper("caribbeancomvr", "CaribbeanCom VR", "https://mcdn.vrporn.com/files/20191217194900/baimudan-vr-porn-studio-logo-vrporn.com-virtual-reality-porn.jpg", "en.caribbeancom.com", CariVR)
 }

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, nwID string) error {
+func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, nwID string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -141,7 +141,11 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 		}
 	})
 
-	siteCollector.Visit("https://www.czechvrnetwork.com/vr-porn-videos&sites=" + nwID)
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.czechvrnetwork.com/vr-porn-videos&sites=" + nwID)
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -151,8 +155,8 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 }
 
 func addCZVRScraper(id string, name string, nwid string, avatarURL string) {
-	registerScraper(id, name, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-		return CzechVR(wg, updateSite, knownScenes, out, id, name, nwid)
+	registerScraper(id, name, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return CzechVR(wg, updateSite, knownScenes, out, singleSceneURL, id, name, nwid, singeScrapeAdditionalInfo)
 	})
 }
 

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -30,6 +30,18 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://www.czechvrnetwork.com/", "https://www.czechvrnetwork.com/members/", 1)
 
+		if scraperID == "" {
+			// there maybe no site/studio if user is just scraping a scene url, find what studio it is for
+			e.ForEach(`h1 span.desktop`, func(id int, e *colly.HTMLElement) {
+				sc.Site = strings.TrimSpace(e.Text)
+				switch sc.Site {
+				case "VR Intimacy":
+					sc.ScraperID = "czechvrintimacy"
+				default:
+					sc.ScraperID = strings.ToLower(strings.ReplaceAll(sc.Site, " ", ""))
+				}
+			})
+		}
 		// Title
 		e.ForEach(`div.post div.nazev h1`, func(id int, e *colly.HTMLElement) {
 			fullTitle := strings.TrimSpace(e.Text)
@@ -155,12 +167,16 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 }
 
 func addCZVRScraper(id string, name string, nwid string, avatarURL string) {
-	registerScraper(id, name, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	registerScraper(id, name, avatarURL, "czechvrnetwork.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 		return CzechVR(wg, updateSite, knownScenes, out, singleSceneURL, id, name, nwid, singeScrapeAdditionalInfo)
 	})
 }
 
 func init() {
+	// scraper for scraping single scenes where only the url is provided
+	registerScraper("czechvr-single_scene", "Czech VR - Other Studios", "", "czechvrnetwork.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return CzechVR(wg, updateSite, knownScenes, out, singleSceneURL, "", "", "", "")
+	})
 	addCZVRScraper("czechvr", "Czech VR", "15", "https://www.czechvr.com/images/favicon/android-chrome-256x256.png")
 	addCZVRScraper("czechvrfetish", "Czech VR Fetish", "16", "https://www.czechvrfetish.com/images/favicon/android-chrome-256x256.png")
 	addCZVRScraper("czechvrcasting", "Czech VR Casting", "17", "https://www.czechvrcasting.com/images/favicon/android-chrome-256x256.png")

--- a/pkg/scrape/darkroomvr.go
+++ b/pkg/scrape/darkroomvr.go
@@ -136,5 +136,5 @@ func DarkRoomVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 }
 
 func init() {
-	registerScraper("darkroomvr", "DarkRoomVR", "https://static.darkroomvr.com/img/favicon/apple-touch-180.png", DarkRoomVR)
+	registerScraper("darkroomvr", "DarkRoomVR", "https://static.darkroomvr.com/img/favicon/apple-touch-180.png", "darkroomvr.com", DarkRoomVR)
 }

--- a/pkg/scrape/darkroomvr.go
+++ b/pkg/scrape/darkroomvr.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func DarkRoomVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func DarkRoomVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "darkroomvr"
 	siteID := "DarkRoomVR"
@@ -122,7 +122,11 @@ func DarkRoomVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 		}
 	})
 
-	siteCollector.Visit("https://darkroomvr.com/video/")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://darkroomvr.com/video/")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/fuckpassvr.go
+++ b/pkg/scrape/fuckpassvr.go
@@ -123,14 +123,8 @@ func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 	var lastPage int64 = 1
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		ctx.Put("preview_video_url", extrainfo[0].FieldValue)
+		ctx.Put("preview_video_url", "")
 		slug := strings.Replace(singleSceneURL, "https://www.fuckpassvr.com/video/", "", 1)
 		sceneDetail := "https://www.fuckpassvr.com/api/api/scene/show?slug=" + slug
 		sceneCollector.Request("GET", sceneDetail, nil, ctx, nil)

--- a/pkg/scrape/fuckpassvr.go
+++ b/pkg/scrape/fuckpassvr.go
@@ -175,5 +175,5 @@ func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 }
 
 func init() {
-	registerScraper("fuckpassvr-native", "FuckPassVR", "https://www.fuckpassvr.com/_nuxt/img/logo_bw.1fac7d1.png", FuckPassVR)
+	registerScraper("fuckpassvr-native", "FuckPassVR", "https://www.fuckpassvr.com/_nuxt/img/logo_bw.1fac7d1.png", "fuckpassvr.com", FuckPassVR)
 }

--- a/pkg/scrape/fuckpassvr.go
+++ b/pkg/scrape/fuckpassvr.go
@@ -16,7 +16,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "fuckpassvr-native"
 	siteID := "FuckPassVR"
@@ -32,8 +32,9 @@ func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 			return
 		}
 		res := gjson.ParseBytes(r.Body)
-		previewVideoURL := r.Ctx.Get("preview_video_url")
 		scenedata := res.Get("data.scene")
+		previewVideoURL := r.Ctx.Get("preview_video_url")
+
 		sc := models.ScrapedScene{}
 		sc.ScraperID = scraperID
 		sc.SceneType = "VR"
@@ -121,34 +122,48 @@ func FuckPassVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 	var page int64 = 1
 	var lastPage int64 = 1
 
-	for page <= lastPage {
-		resp, err := client.R().
-			SetQueryParams(map[string]string{
-				"size":   "24",
-				"sortBy": "newest",
-				"page":   strconv.FormatInt(page, 10),
-			}).
-			Get("https://www.fuckpassvr.com/api/api/scene")
+	if singleSceneURL != "" {
+		type extraInfo struct {
+			FieldName  string `json:"fieldName"`
+			FieldValue string `json:"fieldValue"`
+		}
+		var extrainfo []extraInfo
+		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
+		ctx := colly.NewContext()
+		ctx.Put("preview_video_url", extrainfo[0].FieldValue)
+		slug := strings.Replace(singleSceneURL, "https://www.fuckpassvr.com/video/", "", 1)
+		sceneDetail := "https://www.fuckpassvr.com/api/api/scene/show?slug=" + slug
+		sceneCollector.Request("GET", sceneDetail, nil, ctx, nil)
+	} else {
+		for page <= lastPage {
+			resp, err := client.R().
+				SetQueryParams(map[string]string{
+					"size":   "24",
+					"sortBy": "newest",
+					"page":   strconv.FormatInt(page, 10),
+				}).
+				Get("https://www.fuckpassvr.com/api/api/scene")
 
-		if err == nil {
-			res := gjson.ParseBytes(resp.Body())
-			res.Get("data.scenes.data").ForEach(func(_, scenedata gjson.Result) bool {
-				ctx := colly.NewContext()
-				ctx.Put("preview_video_url", scenedata.Get("preview_video_url").String())
+			if err == nil {
+				res := gjson.ParseBytes(resp.Body())
+				res.Get("data.scenes.data").ForEach(func(_, scenedata gjson.Result) bool {
+					ctx := colly.NewContext()
+					ctx.Put("preview_video_url", scenedata.Get("preview_video_url").String())
 
-				sceneURL := "https://www.fuckpassvr.com/video/" + scenedata.Get("slug").String()
-				sceneDetail := "https://www.fuckpassvr.com/api/api/scene/show?slug=" + scenedata.Get("slug").String()
+					sceneURL := "https://www.fuckpassvr.com/video/" + scenedata.Get("slug").String()
+					sceneDetail := "https://www.fuckpassvr.com/api/api/scene/show?slug=" + scenedata.Get("slug").String()
 
-				if !funk.ContainsString(knownScenes, sceneURL) {
-					sceneCollector.Request("GET", sceneDetail, nil, ctx, nil)
-				}
+					if !funk.ContainsString(knownScenes, sceneURL) {
+						sceneCollector.Request("GET", sceneDetail, nil, ctx, nil)
+					}
 
-				return true
-			})
-			lastPage = res.Get("data.scenes.last_page").Int()
-			page = page + 1
-		} else {
-			log.Error(err)
+					return true
+				})
+				lastPage = res.Get("data.scenes.last_page").Int()
+				page = page + 1
+			} else {
+				log.Error(err)
+			}
 		}
 	}
 

--- a/pkg/scrape/groobyvr.go
+++ b/pkg/scrape/groobyvr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "groobyvr"
 	siteID := "GroobyVR"
@@ -119,7 +119,11 @@ func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.Visit("https://www.groobyvr.com/tour/categories/movies/1/latest/")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.groobyvr.com/tour/categories/movies/1/latest/")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/groobyvr.go
+++ b/pkg/scrape/groobyvr.go
@@ -133,5 +133,5 @@ func GroobyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("groobyvr", "GroobyVR", "https://www.groobyvr.com/tour/custom_assets/favicon/apple-touch-icon.png", GroobyVR)
+	registerScraper("groobyvr", "GroobyVR", "https://www.groobyvr.com/tour/custom_assets/favicon/apple-touch-icon.png", "groobyvr.com", GroobyVR)
 }

--- a/pkg/scrape/hologirlsvr.go
+++ b/pkg/scrape/hologirlsvr.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "hologirlsvr"
 	siteID := "HoloGirlsVR"
@@ -111,7 +111,11 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		}
 	})
 
-	siteCollector.Visit("https://www.hologirlsvr.com/Models")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.hologirlsvr.com/Models")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/hologirlsvr.go
+++ b/pkg/scrape/hologirlsvr.go
@@ -125,5 +125,5 @@ func HoloGirlsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func init() {
-	registerScraper("hologirlsvr", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg", HoloGirlsVR)
+	registerScraper("hologirlsvr", "HoloGirlsVR", "https://pbs.twimg.com/profile_images/836310876797837312/Wb3-FTxD_200x200.jpg", "hologirlsvr.com", HoloGirlsVR)
 }

--- a/pkg/scrape/lethalhardcorevr.go
+++ b/pkg/scrape/lethalhardcorevr.go
@@ -1,11 +1,9 @@
 package scrape
 
 import (
-	"encoding/json"
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/mozillazg/go-slugify"
@@ -176,16 +174,8 @@ func LethalHardcoreSite(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 	})
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		parsedDate, _ := time.Parse("2006-01-02", extrainfo[1].FieldValue)
-		formattedDate := parsedDate.Format("01/02/2006")
-		ctx.Put("date", formattedDate)
+		ctx.Put("date", "")
 
 		sceneCollector.Visit(singleSceneURL)
 	} else {

--- a/pkg/scrape/lethalhardcorevr.go
+++ b/pkg/scrape/lethalhardcorevr.go
@@ -208,6 +208,6 @@ func WhorecraftVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 }
 
 func init() {
-	registerScraper("whorecraftvr", "WhorecraftVR", "https://imgs1cdn.adultempire.com/bn/Whorecraft-VR-apple-touch-icon.png", WhorecraftVR)
-	registerScraper("lethalhardcorevr", "LethalHardcoreVR", "https://imgs1cdn.adultempire.com/bn/Lethal-Hardcore-apple-touch-icon.png", LethalHardcoreVR)
+	registerScraper("whorecraftvr", "WhorecraftVR", "https://imgs1cdn.adultempire.com/bn/Whorecraft-VR-apple-touch-icon.png", "lethalhardcorevr.com", WhorecraftVR)
+	registerScraper("lethalhardcorevr", "LethalHardcoreVR", "https://imgs1cdn.adultempire.com/bn/Lethal-Hardcore-apple-touch-icon.png", "lethalhardcorevr.com", LethalHardcoreVR)
 }

--- a/pkg/scrape/littlecaprice.go
+++ b/pkg/scrape/littlecaprice.go
@@ -1,7 +1,6 @@
 package scrape
 
 import (
-	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -111,14 +110,8 @@ func LittleCaprice(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 	})
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		ctx.Put("cover", extrainfo[0].FieldValue)
+		ctx.Put("cover", "")
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {
 		siteCollector.Visit("https://www.littlecaprice-dreams.com/virtual-reality-little-caprice-dreams/")

--- a/pkg/scrape/littlecaprice.go
+++ b/pkg/scrape/littlecaprice.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func LittleCaprice(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func LittleCaprice(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "littlecaprice"
 	siteID := "Little Caprice Dreams"
@@ -109,7 +110,19 @@ func LittleCaprice(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		}
 	})
 
-	siteCollector.Visit("https://www.littlecaprice-dreams.com/virtual-reality-little-caprice-dreams/")
+	if singleSceneURL != "" {
+		type extraInfo struct {
+			FieldName  string `json:"fieldName"`
+			FieldValue string `json:"fieldValue"`
+		}
+		var extrainfo []extraInfo
+		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
+		ctx := colly.NewContext()
+		ctx.Put("cover", extrainfo[0].FieldValue)
+		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
+	} else {
+		siteCollector.Visit("https://www.littlecaprice-dreams.com/virtual-reality-little-caprice-dreams/")
+	}
 
 	// Missing "Me and You" (my-first-time) scene
 	sceneURL := "https://www.littlecaprice-dreams.com/project/vr-180-little-caprice-my-first-time/"

--- a/pkg/scrape/littlecaprice.go
+++ b/pkg/scrape/littlecaprice.go
@@ -142,5 +142,5 @@ func LittleCaprice(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 }
 
 func init() {
-	registerScraper("littlecaprice", "Little Caprice Dreams", "https://littlecaprice-dreams.com/wp-content/uploads/2019/03/cropped-lcd-heart-180x180.png", LittleCaprice)
+	registerScraper("littlecaprice", "Little Caprice Dreams", "https://littlecaprice-dreams.com/wp-content/uploads/2019/03/cropped-lcd-heart-180x180.png", "littlecaprice-dreams.com", LittleCaprice)
 }

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "naughtyamericavr"
 	siteID := "NaughtyAmerica VR"
@@ -176,7 +176,11 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 		}
 	})
 
-	siteCollector.Visit("https://www.naughtyamerica.com/vr-porn")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.naughtyamerica.com/vr-porn")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -190,5 +190,5 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 }
 
 func init() {
-	registerScraper("naughtyamericavr", "NaughtyAmerica VR", "https://mcdn.vrporn.com/files/20170718100937/naughtyamericavr-vr-porn-studio-vrporn.com-virtual-reality.png", NaughtyAmericaVR)
+	registerScraper("naughtyamericavr", "NaughtyAmerica VR", "https://mcdn.vrporn.com/files/20170718100937/naughtyamericavr-vr-porn-studio-vrporn.com-virtual-reality.png", "naughtyamerica.com", NaughtyAmericaVR)
 }

--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string, siteURL string) error {
+func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, company string, siteURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -118,7 +118,11 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.Visit(siteURL)
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(siteURL)
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -136,8 +140,8 @@ func addPOVRScraper(id string, name string, company string, avatarURL string, cu
 	} else {
 		suffixedName += " (POVR)"
 	}
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-		return POVR(wg, updateSite, knownScenes, out, id, siteNameSuffix, company, siteURL)
+	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return POVR(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo)
 	})
 }
 

--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -30,6 +30,22 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 
+		if scraperID == "" {
+			// there maybe no site/studio if user is jusy scraping a scene url
+			e.ForEach(`div.meta a[href^="/studios/"]`, func(id int, e *colly.HTMLElement) {
+				studioId := strings.TrimSuffix(strings.ReplaceAll(e.Attr("href"), "/studios/", ""), "/")
+				sc.Studio = strings.TrimSpace(e.Text)
+				sc.Site = sc.Studio
+				// see if we can find the site record, there may not be
+				db, _ := models.GetDB()
+				defer db.Close()
+				var site models.Site
+				db.Where("name like ?", sc.Studio+"%POVR) or id = ?", sc.Studio, studioId).First(&site)
+				if site.ID != "" {
+					sc.ScraperID = site.ID
+				}
+			})
+		}
 		// Scene ID - get from URL
 		tmp := strings.Split(sc.HomepageURL, "-")
 		sc.SiteID = tmp[len(tmp)-1]
@@ -140,12 +156,15 @@ func addPOVRScraper(id string, name string, company string, avatarURL string, cu
 	} else {
 		suffixedName += " (POVR)"
 	}
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	registerScraper(id, suffixedName, avatarURL, "povr.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 		return POVR(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo)
 	})
 }
 
 func init() {
+	registerScraper("povr-single_scene", "POVR - Other Studios", "", "povr.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return POVR(wg, updateSite, knownScenes, out, singleSceneURL, "", "", "", "", singeScrapeAdditionalInfo)
+	})
 	var scrapers config.ScraperList
 	scrapers.Load()
 	for _, scraper := range scrapers.XbvrScrapers.PovrScrapers {

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -135,6 +135,6 @@ func TSVirtualLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, 
 }
 
 func init() {
-	registerScraper("realitylovers", "RealityLovers", "http://static.rlcontent.com/shared/VR/common/favicons/apple-icon-180x180.png", RealityLovers)
-	registerScraper("tsvirtuallovers", "TSVirtualLovers", "http://static.rlcontent.com/shared/TS/common/favicons/apple-icon-180x180.png", TSVirtualLovers)
+	registerScraper("realitylovers", "RealityLovers", "http://static.rlcontent.com/shared/VR/common/favicons/apple-icon-180x180.png", "realitylovers.com", RealityLovers)
+	registerScraper("tsvirtuallovers", "TSVirtualLovers", "http://static.rlcontent.com/shared/TS/common/favicons/apple-icon-180x180.png", "tsvirtuallovers.com", TSVirtualLovers)
 }

--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"regexp"
 	"strings"
 	"sync"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, domain string) error {
+func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, domain string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -83,28 +84,39 @@ func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string
 	})
 
 	// Request scenes via REST API
-	r, err := resty.New().R().
-		SetHeader("User-Agent", UserAgent).
-		Get("https://engine." + domain + "/content/videos?max=3000&page=0&pornstar=&category=&perspective=&sort=NEWEST")
+	if singleSceneURL == "" {
+		r, err := resty.New().R().
+			SetHeader("User-Agent", UserAgent).
+			Get("https://engine." + domain + "/content/videos?max=3000&page=0&pornstar=&category=&perspective=&sort=NEWEST")
 
-	if err != nil {
-		log.Errorf("Error fetching BaberoticaVR feed: %s", err)
-		logScrapeFinished(scraperID, siteID)
-		return nil
-	}
+		if err != nil {
+			log.Errorf("Error fetching BaberoticaVR feed: %s", err)
+			logScrapeFinished(scraperID, siteID)
+			return nil
+		}
 
-	if err == nil || r.StatusCode() == 200 {
-		result := gjson.Get(r.String(), "contents")
-		result.ForEach(func(key, value gjson.Result) bool {
-			sceneURL := "https://" + domain + "/" + value.Get("videoUri").String()
-			sceneID := value.Get("id").String()
-			if !funk.ContainsString(knownScenes, sceneURL) {
-				ctx := colly.NewContext()
-				ctx.Put("sceneURL", sceneURL)
-				sceneCollector.Request("GET", "https://engine."+domain+"/content/videoDetail?contentId="+sceneID, nil, ctx, nil)
-			}
-			return true
-		})
+		if err == nil || r.StatusCode() == 200 {
+			result := gjson.Get(r.String(), "contents")
+			result.ForEach(func(key, value gjson.Result) bool {
+				sceneURL := "https://" + domain + "/" + value.Get("videoUri").String()
+				sceneID := value.Get("id").String()
+				if !funk.ContainsString(knownScenes, sceneURL) {
+					ctx := colly.NewContext()
+					ctx.Put("sceneURL", sceneURL)
+					sceneCollector.Request("GET", "https://engine."+domain+"/content/videoDetail?contentId="+sceneID, nil, ctx, nil)
+				}
+				return true
+			})
+		}
+	} else {
+		re := regexp.MustCompile(`.com\/vd\/(\d+)\/`)
+		match := re.FindStringSubmatch(singleSceneURL)
+		if len(match) >= 2 {
+			ctx := colly.NewContext()
+			ctx.Put("sceneURL", singleSceneURL)
+			sceneCollector.Request("GET", "https://engine."+domain+"/content/videoDetail?contentId="+match[1], nil, ctx, nil)
+		}
+
 	}
 
 	if updateSite {
@@ -114,12 +126,12 @@ func RealityLoversSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string
 	return nil
 }
 
-func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return RealityLoversSite(wg, updateSite, knownScenes, out, "realitylovers", "RealityLovers", "realitylovers.com")
+func RealityLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return RealityLoversSite(wg, updateSite, knownScenes, out, singleSceneURL, "realitylovers", "RealityLovers", "realitylovers.com", singeScrapeAdditionalInfo)
 }
 
-func TSVirtualLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return RealityLoversSite(wg, updateSite, knownScenes, out, "tsvirtuallovers", "TSVirtualLovers", "tsvirtuallovers.com")
+func TSVirtualLovers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return RealityLoversSite(wg, updateSite, knownScenes, out, singleSceneURL, "tsvirtuallovers", "TSVirtualLovers", "tsvirtuallovers.com", singeScrapeAdditionalInfo)
 }
 
 func init() {

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -215,5 +215,5 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 }
 
 func init() {
-	registerScraper("realjamvr", "RealJam VR", "https://styles.redditmedia.com/t5_3iym1/styles/communityIcon_kqzp15xw0r361.png", RealJamVR)
+	registerScraper("realjamvr", "RealJam VR", "https://styles.redditmedia.com/t5_3iym1/styles/communityIcon_kqzp15xw0r361.png", "realjamvr.com", RealJamVR)
 }

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -17,7 +17,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "realjamvr"
 	siteID := "RealJam VR"
@@ -201,7 +201,11 @@ func RealJamVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out ch
 		}
 	})
 
-	siteCollector.Visit("https://realjamvr.com/scenes")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://realjamvr.com/scenes")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -78,8 +78,8 @@ func getScrapeCacheDir() string {
 	return common.ScrapeCacheDir
 }
 
-func registerScraper(id string, name string, avatarURL string, f models.ScraperFunc) {
-	models.RegisterScraper(id, name, avatarURL, f)
+func registerScraper(id string, name string, avatarURL string, domain string, f models.ScraperFunc) {
+	models.RegisterScraper(id, name, avatarURL, domain, f)
 }
 
 func logScrapeStart(id string, name string) {

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -19,7 +19,7 @@ import (
 var currentYear int
 var lastMonth int
 
-func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "sexbabesvr"
 	siteID := "SexBabesVR"
@@ -128,7 +128,20 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 	currentYear = time.Now().Year()
 	lastMonth = int(time.Now().Month())
 
-	siteCollector.Visit("https://sexbabesvr.com/videos")
+	if singleSceneURL != "" {
+		type extraInfo struct {
+			FieldName  string `json:"fieldName"`
+			FieldValue string `json:"fieldValue"`
+		}
+		var extrainfo []extraInfo
+		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
+		ctx := colly.NewContext()
+		ctx.Put("released", extrainfo[0].FieldValue)
+
+		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
+	} else {
+		siteCollector.Visit("https://sexbabesvr.com/videos")
+	}
 
 	// Sort the videoList as page visits may not return in the same speed and be out of order
 	var sortedVideos []int

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -129,14 +129,8 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 	lastMonth = int(time.Now().Month())
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		ctx.Put("released", extrainfo[0].FieldValue)
+		ctx.Put("released", "")
 
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -175,5 +175,5 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 }
 
 func init() {
-	registerScraper("sexbabesvr", "SexBabesVR", "https://sexbabesvr.com/assets/front/assets/logo.png", SexBabesVR)
+	registerScraper("sexbabesvr", "SexBabesVR", "https://sexbabesvr.com/assets/front/assets/logo.png", "sexbabesvr.com", SexBabesVR)
 }

--- a/pkg/scrape/sinsvr.go
+++ b/pkg/scrape/sinsvr.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "sinsvr"
 	siteID := "SinsVR"
@@ -140,8 +140,12 @@ func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 	})
 
-	siteCollector.Visit("https://xsinsvr.com/studio/sinsvr/videos")
-	siteCollector.Visit("https://xsinsvr.com/studio/billie-star/videos")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://xsinsvr.com/studio/sinsvr/videos")
+		siteCollector.Visit("https://xsinsvr.com/studio/billie-star/videos")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/sinsvr.go
+++ b/pkg/scrape/sinsvr.go
@@ -155,5 +155,5 @@ func SinsVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("sinsvr", "SinsVR", "https://assets.xsinsvr.com/logo.black.svg", SinsVR)
+	registerScraper("sinsvr", "SinsVR", "https://assets.xsinsvr.com/logo.black.svg", "xsinsvr.com", SinsVR)
 }

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -1,7 +1,6 @@
 package scrape
 
 import (
-	"encoding/json"
 	"html"
 	"regexp"
 	"strconv"
@@ -279,18 +278,8 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 	if singleSceneURL != "" {
 		isTransScene := strings.Contains(singleSceneURL, ".com/trans")
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		duration := 0
-		if len(extrainfo) > 1 {
-			duration, _ = strconv.Atoi(extrainfo[0].FieldValue)
-		}
-		ctx.Put("duration", duration)
+		ctx.Put("duration", 0)
 		ctx.Put("isTransScene", isTransScene)
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 

--- a/pkg/scrape/stasyqvr.go
+++ b/pkg/scrape/stasyqvr.go
@@ -152,5 +152,5 @@ func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("stasyqvr", "StasyQVR", "https://stasyqvr.com/s/images/apple-touch-icon.png", StasyQVR)
+	registerScraper("stasyqvr", "StasyQVR", "https://stasyqvr.com/s/images/apple-touch-icon.png", "stasyqvr.com", StasyQVR)
 }

--- a/pkg/scrape/stasyqvr.go
+++ b/pkg/scrape/stasyqvr.go
@@ -1,7 +1,6 @@
 package scrape
 
 import (
-	"encoding/json"
 	"net/url"
 	"strconv"
 	"strings"
@@ -130,15 +129,8 @@ func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 	})
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		duration, _ := strconv.Atoi(extrainfo[0].FieldValue)
-		ctx.Put("duration", duration)
+		ctx.Put("duration", 0)
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {
 		siteCollector.Visit("https://stasyqvr.com/virtualreality/list")

--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "tmwvrnet"
 	siteID := "TmwVRnet"
@@ -45,7 +45,12 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
 			sc.Title = strings.TrimSpace(e.Attr("title"))
 
-			tmpCover := e.Request.AbsoluteURL(e.Request.Ctx.GetAny("cover-id").(string))
+			tmpCover := ""
+			if e.Request.Ctx.GetAny("cover-id").(string) == "" {
+				tmpCover = e.Request.AbsoluteURL(e.Attr("poster"))
+			} else {
+				tmpCover = e.Request.AbsoluteURL(e.Request.Ctx.GetAny("cover-id").(string))
+			}
 			sc.Covers = append(sc.Covers, tmpCover)
 
 			tmp := strings.Split(tmpCover, "/")
@@ -109,7 +114,14 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		}
 	})
 
-	siteCollector.Visit("https://tmwvrnet.com/categories/movies.html")
+	if singleSceneURL != "" {
+		ctx := colly.NewContext()
+		ctx.Put("cover-id", "")
+
+		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
+	} else {
+		siteCollector.Visit("https://tmwvrnet.com/categories/movies.html")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -131,5 +131,5 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("tmwvrnet", "TmwVRnet", "https://tmwvrnet.com/assets/vr/public/tour1/images/favicon/apple-touch-icon.png", TmwVRnet)
+	registerScraper("tmwvrnet", "TmwVRnet", "https://tmwvrnet.com/assets/vr/public/tour1/images/favicon/apple-touch-icon.png", "tmwvrnet.com", TmwVRnet)
 }

--- a/pkg/scrape/tngf.go
+++ b/pkg/scrape/tngf.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/mozillazg/go-slugify"
@@ -160,16 +159,8 @@ func TNGFVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 	})
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		parsedDate, _ := time.Parse("2006-01-02", extrainfo[0].FieldValue)
-		formattedDate := parsedDate.Format("Jan 2, 2006")
-		ctx.Put("date", formattedDate)
+		ctx.Put("date", "")
 
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 

--- a/pkg/scrape/tngf.go
+++ b/pkg/scrape/tngf.go
@@ -185,5 +185,5 @@ func TNGFVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend VR", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", TNGFVR)
+	registerScraper("tonightsgirlfriend", "Tonight's Girlfriend VR", "https://mcdn.vrporn.com/files/20200404124349/TNGF_LOGO_BLK.jpg", "tonightsgirlfriend.com", TNGFVR)
 }

--- a/pkg/scrape/virtualporn.go
+++ b/pkg/scrape/virtualporn.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/nleeper/goment"
@@ -138,17 +137,9 @@ func VirtualPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	})
 
 	if singleSceneURL != "" {
-		type extraInfo struct {
-			FieldName  string `json:"fieldName"`
-			FieldValue string `json:"fieldValue"`
-		}
-		var extrainfo []extraInfo
-		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
-		ctx.Put("dur", extrainfo[0].FieldValue+"mins")
-		parsedDate, _ := time.Parse("2006-01-02", extrainfo[1].FieldValue)
-		formattedDate := parsedDate.Format("Jan 02, 2006")
-		ctx.Put("date", formattedDate)
+		ctx.Put("dur", "")
+		ctx.Put("date", "")
 
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {

--- a/pkg/scrape/virtualporn.go
+++ b/pkg/scrape/virtualporn.go
@@ -163,5 +163,5 @@ func VirtualPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func init() {
-	registerScraper("bvr", "VirtualPorn", "https://images.cn77nd.com/members/bangbros/favicon/apple-icon-60x60.png", VirtualPorn)
+	registerScraper("bvr", "VirtualPorn", "https://images.cn77nd.com/members/bangbros/favicon/apple-icon-60x60.png", "virtualporn.com", VirtualPorn)
 }

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, URL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 	page := 1
@@ -238,7 +238,11 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 		}
 	})
 
-	siteCollector.Visit(fmt.Sprintf("%s?videoPage=%v", URL, page))
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(fmt.Sprintf("%s?videoPage=%v", URL, page))
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -247,20 +251,20 @@ func VirtualRealPornSite(wg *sync.WaitGroup, updateSite bool, knownScenes []stri
 	return nil
 }
 
-func VirtualRealPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealporn", "VirtualRealPorn", "https://virtualrealporn.com/")
+func VirtualRealPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, singleSceneURL, "virtualrealporn", "VirtualRealPorn", "https://virtualrealporn.com/", singeScrapeAdditionalInfo)
 }
-func VirtualRealTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealtrans", "VirtualRealTrans", "https://virtualrealtrans.com/")
+func VirtualRealTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, singleSceneURL, "virtualrealtrans", "VirtualRealTrans", "https://virtualrealtrans.com/", singeScrapeAdditionalInfo)
 }
-func VirtualRealAmateur(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealamateur", "VirtualRealAmateurPorn", "https://virtualrealamateurporn.com/")
+func VirtualRealAmateur(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, singleSceneURL, "virtualrealamateur", "VirtualRealAmateurPorn", "https://virtualrealamateurporn.com/", singeScrapeAdditionalInfo)
 }
-func VirtualRealGay(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealgay", "VirtualRealGay", "https://virtualrealgay.com/")
+func VirtualRealGay(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, singleSceneURL, "virtualrealgay", "VirtualRealGay", "https://virtualrealgay.com/", singeScrapeAdditionalInfo)
 }
-func VirtualRealPassion(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VirtualRealPornSite(wg, updateSite, knownScenes, out, "virtualrealpassion", "VirtualRealPassion", "https://virtualrealpassion.com/")
+func VirtualRealPassion(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VirtualRealPornSite(wg, updateSite, knownScenes, out, singleSceneURL, "virtualrealpassion", "VirtualRealPassion", "https://virtualrealpassion.com/", singeScrapeAdditionalInfo)
 }
 
 func init() {

--- a/pkg/scrape/virtualrealporn.go
+++ b/pkg/scrape/virtualrealporn.go
@@ -268,9 +268,9 @@ func VirtualRealPassion(wg *sync.WaitGroup, updateSite bool, knownScenes []strin
 }
 
 func init() {
-	registerScraper("virtualrealporn", "VirtualRealPorn", "https://pbs.twimg.com/profile_images/921297545195859968/E5-ClWkm_200x200.jpg", VirtualRealPorn)
-	registerScraper("virtualrealtrans", "VirtualRealTrans", "https://pbs.twimg.com/profile_images/921298616970555392/3coTQ6UZ_200x200.jpg", VirtualRealTrans)
-	registerScraper("virtualrealgay", "VirtualRealGay", "https://pbs.twimg.com/profile_images/921298132129992704/jIOE0LxX_200x200.jpg", VirtualRealGay)
-	registerScraper("virtualrealpassion", "VirtualRealPassion", "https://pbs.twimg.com/profile_images/921298874249175041/LjWabMPh_200x200.jpg", VirtualRealPassion)
-	registerScraper("virtualrealamateur", "VirtualRealAmateurPorn", "https://mcdn.vrporn.com/files/20170718094205/virtualrealameteur-vr-porn-studio-vrporn.com-virtual-reality.png", VirtualRealAmateur)
+	registerScraper("virtualrealporn", "VirtualRealPorn", "https://pbs.twimg.com/profile_images/921297545195859968/E5-ClWkm_200x200.jpg", "virtualrealporn.com", VirtualRealPorn)
+	registerScraper("virtualrealtrans", "VirtualRealTrans", "https://pbs.twimg.com/profile_images/921298616970555392/3coTQ6UZ_200x200.jpg", "virtualrealtrans.com", VirtualRealTrans)
+	registerScraper("virtualrealgay", "VirtualRealGay", "https://pbs.twimg.com/profile_images/921298132129992704/jIOE0LxX_200x200.jpg", "virtualrealgay.com", VirtualRealGay)
+	registerScraper("virtualrealpassion", "VirtualRealPassion", "https://pbs.twimg.com/profile_images/921298874249175041/LjWabMPh_200x200.jpg", "virtualrealpassion.com", VirtualRealPassion)
+	registerScraper("virtualrealamateur", "VirtualRealAmateurPorn", "https://mcdn.vrporn.com/files/20170718094205/virtualrealameteur-vr-porn-studio-vrporn.com-virtual-reality.png", "virtualrealamateurporn.com", VirtualRealAmateur)
 }

--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -138,5 +138,5 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 }
 
 func init() {
-	registerScraper("virtualtaboo", "VirtualTaboo", "https://static-src.virtualtaboo.com/img/mobile-logo.png", VirtualTaboo)
+	registerScraper("virtualtaboo", "VirtualTaboo", "https://static-src.virtualtaboo.com/img/mobile-logo.png", "virtualtaboo.com", VirtualTaboo)
 }

--- a/pkg/scrape/virtualtaboo.go
+++ b/pkg/scrape/virtualtaboo.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "virtualtaboo"
 	siteID := "VirtualTaboo"
@@ -124,7 +124,11 @@ func VirtualTaboo(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 		}
 	})
 
-	siteCollector.Visit("https://virtualtaboo.com/videos")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://virtualtaboo.com/videos")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "vr3000"
 	siteID := "VR3000"
@@ -120,7 +120,11 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 	})
 
-	siteCollector.Visit("https://www.vr3000.com")
+	if singleSceneURL != "" {
+		siteCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.vr3000.com")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vr3000.go
+++ b/pkg/scrape/vr3000.go
@@ -134,5 +134,5 @@ func VR3000(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("vr3000", "VR3000", "https://pbs.twimg.com/profile_images/753992720348217344/-q03m_OT_200x200.jpg", VR3000)
+	registerScraper("vr3000", "VR3000", "https://pbs.twimg.com/profile_images/753992720348217344/-q03m_OT_200x200.jpg", "vr3000.com", VR3000)
 }

--- a/pkg/scrape/vrallure.go
+++ b/pkg/scrape/vrallure.go
@@ -18,7 +18,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "vrallure"
 	siteID := "VRAllure"
@@ -151,7 +151,11 @@ func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		}
 	})
 
-	siteCollector.Visit("https://vrallure.com/scenes")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://vrallure.com/scenes")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vrallure.go
+++ b/pkg/scrape/vrallure.go
@@ -165,5 +165,5 @@ func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("vrallure", "VRAllure", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vra/favicon/apple-touch-icon-180x180.png", VRAllure)
+	registerScraper("vrallure", "VRAllure", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vra/favicon/apple-touch-icon-180x180.png", "vrallure.com", VRAllure)
 }

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -157,7 +157,11 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.Visit(URL + "videos/?sort=latest")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(URL + "videos/?sort=latest")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -166,20 +170,20 @@ func VRBangersSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, ou
 	return nil
 }
 
-func VRBangers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrbangers", "VRBangers", "https://vrbangers.com/")
+func VRBangers(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, singleSceneURL, "vrbangers", "VRBangers", "https://vrbangers.com/")
 }
-func VRBTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrbtrans", "VRBTrans", "https://vrbtrans.com/")
+func VRBTrans(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, singleSceneURL, "vrbtrans", "VRBTrans", "https://vrbtrans.com/")
 }
-func VRBGay(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrbgay", "VRBGay", "https://vrbgay.com/")
+func VRBGay(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, singleSceneURL, "vrbgay", "VRBGay", "https://vrbgay.com/")
 }
-func VRConk(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "vrconk", "VRCONK", "https://vrconk.com/")
+func VRConk(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, singleSceneURL, "vrconk", "VRCONK", "https://vrconk.com/")
 }
-func BlowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return VRBangersSite(wg, updateSite, knownScenes, out, "blowvr", "BlowVR", "https://blowvr.com/")
+func BlowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return VRBangersSite(wg, updateSite, knownScenes, out, singleSceneURL, "blowvr", "BlowVR", "https://blowvr.com/")
 }
 
 func init() {

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -187,9 +187,9 @@ func BlowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("vrbangers", "VRBangers", "https://vrbangers.com/favicon/apple-touch-icon-144x144.png", VRBangers)
-	registerScraper("vrbtrans", "VRBTrans", "https://vrbtrans.com/favicon/apple-touch-icon-144x144.png", VRBTrans)
-	registerScraper("vrbgay", "VRBGay", "https://vrbgay.com/favicon/apple-touch-icon-144x144.png", VRBGay)
-	registerScraper("vrconk", "VRCONK", "https://vrconk.com/favicon/apple-touch-icon-144x144.png", VRConk)
-	registerScraper("blowvr", "BlowVR", "https://blowvr.com/favicon/apple-touch-icon-144x144.png", BlowVR)
+	registerScraper("vrbangers", "VRBangers", "https://vrbangers.com/favicon/apple-touch-icon-144x144.png", "vrbangers.com", VRBangers)
+	registerScraper("vrbtrans", "VRBTrans", "https://vrbtrans.com/favicon/apple-touch-icon-144x144.png", "vrbtrans.com", VRBTrans)
+	registerScraper("vrbgay", "VRBGay", "https://vrbgay.com/favicon/apple-touch-icon-144x144.png", "vrbgay.com", VRBGay)
+	registerScraper("vrconk", "VRCONK", "https://vrconk.com/favicon/apple-touch-icon-144x144.png", "vrconk.com", VRConk)
+	registerScraper("blowvr", "BlowVR", "https://blowvr.com/favicon/apple-touch-icon-144x144.png", "blowvr.com", BlowVR)
 }

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "vrhush"
 	siteID := "VRHush"
@@ -144,7 +144,11 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 	})
 
-	siteCollector.Visit("https://vrhush.com/scenes")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://vrhush.com/scenes")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -158,5 +158,5 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("vrhush", "VRHush", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vrh/favicon/apple-touch-icon-180x180.png", VRHush)
+	registerScraper("vrhush", "VRHush", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vrh/favicon/apple-touch-icon-180x180.png", "vrhush.com", VRHush)
 }

--- a/pkg/scrape/vrlatina.go
+++ b/pkg/scrape/vrlatina.go
@@ -136,5 +136,5 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 }
 
 func init() {
-	registerScraper("vrlatina", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg", VRLatina)
+	registerScraper("vrlatina", "VRLatina", "https://pbs.twimg.com/profile_images/979329978750898176/074YPl3H_200x200.jpg", "vrlatina.com", VRLatina)
 }

--- a/pkg/scrape/vrlatina.go
+++ b/pkg/scrape/vrlatina.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	scraperID := "vrlatina"
 	siteID := "VRLatina"
@@ -122,7 +122,11 @@ func VRLatina(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		}
 	})
 
-	siteCollector.Visit("https://vrlatina.com/most-recent/")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://vrlatina.com/most-recent/")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -42,6 +42,27 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.Studio = company
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		if scraperID == "" {
+			// there maybe no site/studio if user is jusy scraping a scene url
+			e.ForEach(`li.entry-category a`, func(id int, e *colly.HTMLElement) {
+				studioId := strings.TrimSuffix(strings.ReplaceAll(e.Attr("href"), "https://vrphub.com/category/", ""), "/")
+				sc.Studio = strings.TrimSpace(e.Text)
+				sc.Site = sc.Studio
+				// see if we can find the site record, there may not be
+				db, _ := models.GetDB()
+				defer db.Close()
+				var site models.Site
+				db.Where("name like ?", sc.Studio+"%VRPHub) or id = ?", sc.Studio, studioId).First(&site)
+				if site.ID != "" {
+					sc.ScraperID = site.ID
+				}
+			})
+			// if doing a single scrape we need a cover as well
+			e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
+				sc.Covers = append(sc.Covers, e.Attr("poster"))
+			})
+
+		}
 
 		isPost := false
 		e.ForEach(`link[rel="shortlink"]`, func(id int, e *colly.HTMLElement) {
@@ -173,7 +194,10 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 	})
 
 	if singleSceneURL != "" {
-		sceneCollector.Visit(singleSceneURL)
+		sc := models.ScrapedScene{}
+		ctx := colly.NewContext()
+		ctx.Put("scene", &sc)
+		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {
 		siteCollector.Visit(siteURL)
 	}
@@ -233,12 +257,15 @@ func addVRPHubScraper(id string, name string, company string, avatarURL string, 
 		avatarURL = "https://cdn.vrphub.com/wp-content/uploads/2016/08/vrphubnew.png"
 	}
 
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	registerScraper(id, suffixedName, avatarURL, "vrphub.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 		return VRPHub(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo, callback)
 	})
 }
 
 func init() {
+	registerScraper("vrphub-single_scene", "VRPHub - Other Studios", "", "vrphub.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return VRPHub(wg, updateSite, knownScenes, out, singleSceneURL, "", "", "", "", singeScrapeAdditionalInfo, noop)
+	})
 	var scrapers config.ScraperList
 	scrapers.Load()
 	for _, scraper := range scrapers.XbvrScrapers.VrphubScrapers {

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -29,7 +29,7 @@ func getVideoName(fileUrl string) (string, error) {
 	return filename, nil
 }
 
-func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string, siteURL string, callback func(e *colly.HTMLElement, sc *models.ScrapedScene)) error {
+func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, company string, siteURL string, singeScrapeAdditionalInfo string, callback func(e *colly.HTMLElement, sc *models.ScrapedScene)) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -172,7 +172,11 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 	})
 
-	siteCollector.Visit(siteURL)
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(siteURL)
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -229,8 +233,8 @@ func addVRPHubScraper(id string, name string, company string, avatarURL string, 
 		avatarURL = "https://cdn.vrphub.com/wp-content/uploads/2016/08/vrphubnew.png"
 	}
 
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-		return VRPHub(wg, updateSite, knownScenes, out, id, siteNameSuffix, company, siteURL, callback)
+	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return VRPHub(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo, callback)
 	})
 }
 

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -39,6 +39,22 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
 
+		if scraperID == "" {
+			// there maybe no site/studio if user is jusy scraping a scene url
+			e.ForEach(`div.studio a[id="studio-logo"]`, func(id int, e *colly.HTMLElement) {
+				studioId := strings.TrimSuffix(strings.ReplaceAll(e.Attr("href"), "https://vrporn.com/studio/", ""), "/")
+				sc.Studio = strings.TrimSpace(e.Text)
+				sc.Site = sc.Studio
+				// see if we can find the site record, there may not be
+				db, _ := models.GetDB()
+				defer db.Close()
+				var site models.Site
+				db.Where("name like ?", sc.Studio+"%VRPorn) or id = ?", sc.Studio, studioId).First(&site)
+				if site.ID != "" {
+					sc.ScraperID = site.ID
+				}
+			})
+		}
 		// Scene ID - get from page HTML
 		id := sceneIDRegEx.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`article.post`, "class")))[1]
 		sc.SiteID = id
@@ -168,12 +184,16 @@ func addVRPornScraper(id string, name string, company string, avatarURL string, 
 	} else {
 		suffixedName += " (VRPorn)"
 	}
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	registerScraper(id, suffixedName, avatarURL, "vrporn.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 		return VRPorn(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo)
 	})
 }
 
 func init() {
+	registerScraper("vrporn-single_scene", "VRPorn - Other Studios", "", "vrporn.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return VRPorn(wg, updateSite, knownScenes, out, singleSceneURL, "", "", "", "", singeScrapeAdditionalInfo)
+	})
+
 	var scrapers config.ScraperList
 	scrapers.Load()
 	for _, scraper := range scrapers.XbvrScrapers.VrpornScrapers {

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -14,7 +14,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, company string, siteURL string) error {
+func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, company string, siteURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -146,7 +146,11 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		}
 	})
 
-	siteCollector.Visit(siteURL + "/?sort=newest")
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(siteURL + "/?sort=newest")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -164,8 +168,8 @@ func addVRPornScraper(id string, name string, company string, avatarURL string, 
 	} else {
 		suffixedName += " (VRPorn)"
 	}
-	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-		return VRPorn(wg, updateSite, knownScenes, out, id, siteNameSuffix, company, siteURL)
+	registerScraper(id, suffixedName, avatarURL, func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+		return VRPorn(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo)
 	})
 }
 

--- a/pkg/scrape/vrsexygirlz.go
+++ b/pkg/scrape/vrsexygirlz.go
@@ -12,7 +12,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func VRSexygirlz(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
+func VRSexygirlz(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 
 	scraperID := "vrsexygirlz"
@@ -103,7 +103,12 @@ func VRSexygirlz(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			sceneCollector.Visit(sceneURL)
 		}
 	})
-	siteCollector.Visit("https://www.vrsexygirlz.com")
+
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://www.vrsexygirlz.com")
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)

--- a/pkg/scrape/vrsexygirlz.go
+++ b/pkg/scrape/vrsexygirlz.go
@@ -118,5 +118,5 @@ func VRSexygirlz(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 }
 
 func init() {
-	registerScraper("vrsexygirlz", "VRSexyGirlz", "https://www.vrsexygirlz.com/wp-content/uploads/2017/03/FV.png", VRSexygirlz)
+	registerScraper("vrsexygirlz", "VRSexyGirlz", "https://www.vrsexygirlz.com/wp-content/uploads/2017/03/FV.png", "vrsexygirlz.com", VRSexygirlz)
 }

--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -45,8 +45,10 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 
 		// Date
 		scenedate := e.Request.Ctx.GetAny("scene-date").(string)
-		tmpDate, _ := goment.New(scenedate, "MMMM DD, YYYY")
-		sc.Released = tmpDate.Format("YYYY-MM-DD")
+		if scenedate != "" {
+			tmpDate, _ := goment.New(scenedate, "MMMM DD, YYYY")
+			sc.Released = tmpDate.Format("YYYY-MM-DD")
+		}
 
 		// Duration
 		tmpDuration := durationRegEx.FindStringSubmatch(e.ChildText(`div#t2019-stime`))[1]
@@ -118,9 +120,13 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		json.Unmarshal([]byte(singeScrapeAdditionalInfo), &extrainfo)
 		ctx := colly.NewContext()
 		ctx.Put("scene-id", extrainfo[0].FieldValue)
-		parsedDate, _ := time.Parse("2006-01-02", extrainfo[1].FieldValue)
-		formattedDate := parsedDate.Format("January 02, 2006")
-		ctx.Put("scene-date", formattedDate)
+		if len(extrainfo) > 1 {
+			parsedDate, _ := time.Parse("2006-01-02", extrainfo[1].FieldValue)
+			formattedDate := parsedDate.Format("January 02, 2006")
+			ctx.Put("scene-date", formattedDate)
+		} else {
+			ctx.Put("scene-date", "")
+		}
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {
 		siteCollector.Visit("https://wetvr.com/")

--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -134,5 +134,5 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 }
 
 func init() {
-	registerScraper("wetvr", "WetVR", "https://wetvr.com/assets/images/sites/wetvr/logo-4a2f06a4c9.png", WetVR)
+	registerScraper("wetvr", "WetVR", "https://wetvr.com/assets/images/sites/wetvr/logo-4a2f06a4c9.png", "wetvr.com", WetVR)
 }

--- a/pkg/scrape/zexywankitnow.go
+++ b/pkg/scrape/zexywankitnow.go
@@ -197,6 +197,6 @@ func ZexyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 }
 
 func init() {
-	registerScraper("wankitnowvr", "WankitNowVR", "https://mcdn.vrporn.com/files/20190103150250/wankitnow-profile.jpg", WankitNowVR)
-	registerScraper("zexyvr", "ZexyVR", "https://mcdn.vrporn.com/files/20210617065837/zexyvr-profile-400x400.jpg", ZexyVR)
+	registerScraper("wankitnowvr", "WankitNowVR", "https://mcdn.vrporn.com/files/20190103150250/wankitnow-profile.jpg", "wankitnowvr.com", WankitNowVR)
+	registerScraper("zexyvr", "ZexyVR", "https://mcdn.vrporn.com/files/20210617065837/zexyvr-profile-400x400.jpg", "wankitnowvr.com", ZexyVR)
 }

--- a/pkg/scrape/zexywankitnow.go
+++ b/pkg/scrape/zexywankitnow.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, scraperID string, siteID string, URL string) error {
+func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, URL string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
@@ -175,7 +175,11 @@ func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, 
 		}
 	})
 
-	siteCollector.Visit(URL)
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit(URL)
+	}
 
 	if updateSite {
 		updateSiteLastUpdate(scraperID)
@@ -184,12 +188,12 @@ func TwoWebMediaSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, 
 	return nil
 }
 
-func WankitNowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return TwoWebMediaSite(wg, updateSite, knownScenes, out, "wankitnowvr", "WankitNowVR", "https://wankitnowvr.com/videos/")
+func WankitNowVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return TwoWebMediaSite(wg, updateSite, knownScenes, out, singleSceneURL, "wankitnowvr", "WankitNowVR", "https://wankitnowvr.com/videos/")
 }
 
-func ZexyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene) error {
-	return TwoWebMediaSite(wg, updateSite, knownScenes, out, "zexyvr", "ZexyVR", "https://zexyvr.com/videos/")
+func ZexyVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
+	return TwoWebMediaSite(wg, updateSite, knownScenes, out, singleSceneURL, "zexyvr", "ZexyVR", "https://zexyvr.com/videos/")
 }
 
 func init() {

--- a/pkg/server/cron.go
+++ b/pkg/server/cron.go
@@ -72,7 +72,7 @@ func SetupCron() {
 
 func scrapeCron() {
 	if !session.HasActiveSession() {
-		tasks.Scrape("_enabled")
+		tasks.Scrape("_enabled", "", "")
 	}
 	log.Println(fmt.Sprintf("Next Rescrape Task at %v", cronInstance.Entry(rescrapTask).Next))
 }

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -97,7 +97,7 @@ func CleanTags() {
 	CountTags()
 }
 
-func runScrapers(knownScenes []string, toScrape string, updateSite bool, collectedScenes chan<- models.ScrapedScene) error {
+func runScrapers(knownScenes []string, toScrape string, updateSite bool, collectedScenes chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string) error {
 	defer scrape.DeleteScrapeCache()
 
 	scrapers := models.GetScrapers()
@@ -120,7 +120,7 @@ func runScrapers(knownScenes []string, toScrape string, updateSite bool, collect
 			for _, scraper := range scrapers {
 				if site.ID == scraper.ID {
 					wg.Add(1)
-					go scraper.Scrape(&wg, updateSite, knownScenes, collectedScenes)
+					go scraper.Scrape(&wg, updateSite, knownScenes, collectedScenes, singleSceneURL, singeScrapeAdditionalInfo)
 				}
 			}
 		}
@@ -232,7 +232,7 @@ func ReapplyEdits() {
 	db.Model(&models.Scene{}).UpdateColumn("edits_applied", true)
 }
 
-func Scrape(toScrape string) {
+func Scrape(toScrape string, singleSceneURL string, singeScrapeAdditionalInfo string) {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
 		defer models.RemoveLock("scrape")
@@ -261,7 +261,7 @@ func Scrape(toScrape string) {
 		go sceneDBWriter(&wg, &sceneCount, collectedScenes)
 
 		// Start scraping
-		if e := runScrapers(knownScenes, toScrape, true, collectedScenes); e != nil {
+		if e := runScrapers(knownScenes, toScrape, true, collectedScenes, singleSceneURL, singeScrapeAdditionalInfo); e != nil {
 			tlog.Info(e)
 		} else {
 			// Notify DB Writer threads that there are no more scenes
@@ -416,7 +416,7 @@ func ExportBundle() {
 		var scrapedScenes []models.ScrapedScene
 		go sceneSliceAppender(&scrapedScenes, collectedScenes)
 
-		runScrapers(knownScenes, "_enabled", false, collectedScenes)
+		runScrapers(knownScenes, "_enabled", false, collectedScenes, "", "")
 
 		out := ContentBundle{
 			Timestamp:     time.Now().UTC(),

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -200,5 +200,6 @@
   "No matching sites":"No matching sites",
   "No matching attributes":"No matching attributes",
   "Only required when troubleshooting search issues, this will enable a Tab in the Scene Details to display what search fields exist and their values for a scene":"Only required when troubleshooting search issues, this will enable a Tab in the Scene Details to display what search fields exist and their values for a scene",
+  "Scene Id Required": "Scene Id Required",
   "Go": "Go"
 }

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -134,6 +134,7 @@
   "Enter Studio Name": "Enter Studio Name",
   "Optional: defaults to Name": "Optional: defaults to Name",
   "Optional": "Optional",
+  "Scrape Single Scene": "Scrape Single Scene",
   "Actors": "Actors",
   "Added Date": "Added Date",
   "Birthdate": "Birthdate",

--- a/ui/src/store/optionsVendor.js
+++ b/ui/src/store/optionsVendor.js
@@ -2,8 +2,9 @@ import ky from 'ky'
 
 const state = {
   tpdb: {
-    apiToken: ''
-  }
+    apiToken: '',
+  },
+  scrapers: [],
 }
 
 const mutations = {}
@@ -14,6 +15,7 @@ const actions = {
       .json()
       .then(data => {
         state.tpdb.apiToken = data.config.vendor.tpdb.apiToken
+        state.scrapers = data.scrapers        
       })
   },
 }

--- a/ui/src/views/options/sections/OptionsSceneCreate.vue
+++ b/ui/src/views/options/sections/OptionsSceneCreate.vue
@@ -44,6 +44,43 @@
         </b-field>
       </div>
     </div>
+    
+    <h3 class="title">{{$t('Scrape a scene')}}</h3>
+    <div class="card">
+      <div class="card-content content">
+        <b-field label="Scene URL" label-position="on-border">
+          <b-input v-model="scrapeUrl" placeholder="" type="url"></b-input>
+        </b-field>
+        <b-tooltip :label="$t('Warning: Ensure you are entering a link to a scene. Links to something like a Category or Studio list may result in a corrupt scene you cannot delete. Use with caution')" :delay="50" multilined type="is-danger">
+          <b-button class="button is-primary" v-on:click="scrapeSingleScene()">{{$t('Scrape')}}</b-button>
+        </b-tooltip>
+      </div>
+    </div>    
+
+    <b-modal :active.sync="isSingleScrapeModalActive"
+             has-modal-card
+             trap-focus
+             aria-role="dialog"
+             aria-modal>
+      <div class="modal-card" style="width: auto">
+        <header class="modal-card-head">
+          <p class="modal-card-title">{{$t('Scene Id Required')}}</p>
+        </header>
+        <section class="modal-card-body">          
+          <b-field label="Scene Id">
+            <b-input 
+              v-model='singleScrapeId'              
+              placeholder="eg wetvr-12345"              
+              >
+            </b-input>            
+          </b-field>
+        </section>
+        <footer class="modal-card-foot">
+          <button class="button is-primary" :disabled="this.singleScrapeId == ''" @click="scrapeSingleScene()">Continue</button>
+        </footer>
+      </div>
+    </b-modal>
+    
   </div>
 </template>
 
@@ -58,7 +95,11 @@ export default {
       javrQuery: '',
       tpdbSceneUrl: '',
       customSceneTitle: '',
-      customSceneID: ''
+      customSceneID: '',
+      scrapeUrl: '',
+      isSingleScrapeModalActive: false,
+      singleScrapeId: '',
+      additionalinfo: [],
     }
   },
   mounted () {
@@ -82,6 +123,53 @@ export default {
     scrapeTPDB () {
       ky.post('/api/task/scrape-tpdb', {
         json: { apiToken: this.tpdbApiToken, sceneUrl: this.tpdbSceneUrl }
+      })
+    },
+    scrapeSingleScene () {
+      this.additionalinfo = []
+      if (this.scrapeUrl.toLowerCase().includes("wetvr.com")) {
+        // we need a scene id for wetvr
+        if (this.singleScrapeId=="") {
+          this.isSingleScrapeModalActive = true
+          return
+        } else {
+          this.isSingleScrapeModalActive = false
+          this.additionalinfo = [{scene_id: this.singleScrapeId}]
+        }
+      }      
+
+      let site = ""
+      this.$store.state.optionsVendor.scrapers.forEach((element) => {
+        if (this.scrapeUrl.toLowerCase().includes(element.domain)) {
+          site = element.id
+        }
+      });
+      if (this.scrapeUrl.toLowerCase().includes("sexlikereal.com")) {
+        site = "slr-single_scene"
+      }
+      if (this.scrapeUrl.toLowerCase().includes("czechvrnetwork.com")) {
+        site = "czechvr-single_scene"
+      }
+      if (this.scrapeUrl.toLowerCase().includes("povr.com")) {
+        site = "povr-single_scene"
+      }
+      if (this.scrapeUrl.toLowerCase().includes("vrporn.com")) {
+        site = "vrporn-single_scene"
+      }
+      if (this.scrapeUrl.toLowerCase().includes("vrphub.com")) {
+        site = "vrphub-single_scene"
+      }
+      if (site == "") {
+        this.$buefy.toast.open({message: `No scrapers exist for this domain`, type: 'is-danger', duration: 5000})      
+        return
+      }
+      this.$buefy.toast.open({message: `Scene scraping in progress, please wait for the Scene Detail popup`, type: 'is-warning', duration: 5000})      
+      ky.post(`/api/task/singlescrape`, {timeout: false, json: { site: site, sceneurl: this.scrapeUrl, additionalinfo: this.additionalinfo}})
+      .json()
+      .then(data => { 
+        if (data.status == 'OK') {          
+          this.$store.commit('overlay/editDetails', { scene: data.scene })
+        }
       })
     },
   },

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -148,8 +148,7 @@ export default {
       ky.get(`/api/task/scrape?site=${scraper}`)
     },
     taskScrapeScene (scraper) {
-      this.currentScraper=scraper
-      console.log("taskScrapeScene",this.sceneUrl)
+      this.currentScraper=scraper      
       this.additionalInfo = [{fieldName: "scene_url", fieldPrompt: "Scene Url", placeholder: "Enter the url for a VR Scene", fieldValue: '', required: true, type: 'url'}]      
       this.scraperwarning = "Take care to only use scene urls for the " + scraper + " Scraper"
       this.scraperwarning2 = ""
@@ -171,10 +170,7 @@ export default {
       this.isSingleScrapeModalActive = true      
     },
     taskScrapeSceneInfoEntered () {      
-      console.log("taskScrapeSceneinfoentered",this.sceneUrl, this.additionalInfoIdx, this.additionalInfo, this.currentScraper)      
       const inputElement = this.$refs.additionInfoInput
-      console.log("input ele", inputElement)
-      console.log(inputElement.isValid)
       if (!inputElement.isValid) {
         // get the field again
         this.isSingleScrapeModalActive = true
@@ -218,8 +214,7 @@ export default {
       if (this.additionalInfoIdx + 1 < this.additionalInfo.length) {          
         this.additionalInfoIdx = this.additionalInfoIdx +1
         this.isSingleScrapeModalActive = true      
-      } else {
-        console.log("sending",{json: { site: this.currentScraper, sceneurl: this.additionalInfo[0].fieldValue, additionalinfo: this.additionalInfo.slice(1) }})
+      } else {        
         ky.post(`/api/task/singlescrape`, {json: { site: this.currentScraper, sceneurl: this.additionalInfo[0].fieldValue, additionalinfo: this.additionalInfo.slice(1)}})
       }
     },

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -177,36 +177,36 @@ export default {
         return
       }
 
-      this.isSingleScrapeModalActive = false
+      this.isSingleScrapeModalActive = false      
+      var fieldCheckMsg = ""
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('fuckpassvr.com')) {
+        var fieldCheckMsg="Note: Video Previews are not available when scraping single scenes from FuckpassVR"
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('lethalhardcorevr.com')) {
+        var fieldCheckMsg=`Please check the Site if the scene was for WhorecraftVR. Please check the Release Date`
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('littlecaprice-dreams.com')) {
+        var fieldCheckMsg=`Please specify a URL for the cover image`
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('sexbabesvr.com')) {
+        var fieldCheckMsg="Please check the Release Date"
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('stasyqvr.com')) {
+        var fieldCheckMsg=`Please specify a Duration if required`
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('tonightsgirlfriend.com')) {
+        var fieldCheckMsg="Please check the Release Date"
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('virtualporn.com')) {
+        var fieldCheckMsg=`Please check the Release Date and specify a Duration if required`
+      }
+      if (this.additionalInfo[0].fieldValue.toLowerCase().includes('wetvr.com')) {        
+        var fieldCheckMsg="Please check the Release Date"
+      }
+
       if (this.additionalInfoIdx == 0) {
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('fuckpassvr.com')) {
-          this.additionalInfo.push({fieldName: "preview_video_url", fieldPrompt: "Preview Video Url", placeholder: "Optional", fieldValue: '', required: false, type: 'url'})
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('lethalhardcorevr.com')) {
-          this.additionalInfo.push({fieldName: "date", fieldPrompt: "Release Date", placeholder: "", fieldValue: '', required: true, type: 'date' })
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('littlecaprice-dreams.com')) {
-          this.additionalInfo.push({fieldName: "cover", fieldPrompt: "Cover Url", placeholder: "Optional", fieldValue: '', required: false, type: 'url'})
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('sexbabesvr.com')) {
-          this.additionalInfo.push({fieldName: "date", fieldPrompt: "Release Date", placeholder: "", fieldValue: '', required: true, type: 'date' })
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('sexlikereal.com')) {
-          this.additionalInfo.push({fieldName: "duration", fieldPrompt: "Duration", placeholder: "duration in minutes (optional)", fieldValue: '', required: false, type: 'number'})
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('stasyqvr.com')) {
-          this.additionalInfo.push({fieldName: "duration", fieldPrompt: "Duration", placeholder: "duration in minutes (optional)", fieldValue: '', required: false, type: 'number'})
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('tonightsgirlfriend.com')) {
-          this.additionalInfo.push({fieldName: "date", fieldPrompt: "Release Date", placeholder: "", fieldValue: '', required: true, type: 'date' })
-        }
-        if (this.additionalInfo[0].fieldValue.toLowerCase().includes('virtualporn.com')) {
-          this.additionalInfo.push({fieldName: "dur", fieldPrompt: "Duration", placeholder: "duration in minutes (optional)", fieldValue: '', required: false, type: 'number'})
-          this.additionalInfo.push({fieldName: "date", fieldPrompt: "Release Date", placeholder: "", fieldValue: '', required: true, type: 'date' })
-        }
         if (this.additionalInfo[0].fieldValue.toLowerCase().includes('wetvr.com')) {
-          this.additionalInfo.push({fieldName: "scene_id", fieldPrompt: "Scene Id", placeholder: "eg 69037", fieldValue: '', required: true, type: 'number'})
-          this.additionalInfo.push({fieldName: "scene-date", fieldPrompt: "Release Date", placeholder: "", fieldValue: '', required: true, type: 'date' })
+          this.additionalInfo.push({fieldName: "scene_id", fieldPrompt: "Scene Id", placeholder: "eg 69037 (excl site prefix)", fieldValue: '', required: true, type: 'number'})
         }
       }
       
@@ -214,8 +214,22 @@ export default {
       if (this.additionalInfoIdx + 1 < this.additionalInfo.length) {          
         this.additionalInfoIdx = this.additionalInfoIdx +1
         this.isSingleScrapeModalActive = true      
-      } else {        
-        ky.post(`/api/task/singlescrape`, {json: { site: this.currentScraper, sceneurl: this.additionalInfo[0].fieldValue, additionalinfo: this.additionalInfo.slice(1)}})
+      } else {
+        if (fieldCheckMsg != "") {
+          this.$buefy.toast.open({message: `Scene scraping in progress, please wait for the Scene Detail popup`, type: 'is-warning', duration: 5000})
+        } else {
+          this.$buefy.toast.open({message: `Scene scraping in progress`, type: 'is-warning', duration: 5000})
+        }
+        ky.post(`/api/task/singlescrape`, {timeout: false, json: { site: this.currentScraper, sceneurl: this.additionalInfo[0].fieldValue, additionalinfo: this.additionalInfo.slice(1)}})
+        .json()
+        .then(data => { 
+          if (data.status == 'OK') {          
+            this.$store.commit('overlay/editDetails', { scene: data.scene })
+            if (fieldCheckMsg != "") {
+              this.$buefy.toast.open({message: fieldCheckMsg, type: 'is-warning', duration: 10000})
+            }
+          }
+        })
       }
     },
     forceSiteUpdate (site, scraper) {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -435,6 +435,9 @@ export default {
     },
     // Properties for gallery
     images () {
+      if (this.item.images=="null") {
+        return "[]"
+      }      
       return JSON.parse(this.item.images).filter(im => im && im.url)
     },
     // Tab: cuepoints
@@ -650,10 +653,17 @@ export default {
           this.$store.commit('overlay/showDetails', { scene: data })
       })
     },
-    getImageURL (u, size) {
-      if (u.startsWith('http') || u.startsWith('https')) {
-        return '/img/' + size + '/' + u.replace('://', ':/')
-      } else {
+    getImageURL (u, size) {      
+      if (u==undefined) {
+        return u
+      }
+      try {
+        if (u.startsWith('http') || u.startsWith('https')) {
+          return '/img/' + size + '/' + u.replace('://', ':/')
+        } else {
+          return u
+        }
+      } catch {
         return u
       }
     },

--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -44,6 +44,10 @@
                          @blur="blur('release_date_text')"/>
                 </div>
               </b-field>
+
+              <b-field :label="$t('Duration')">
+                <b-input type="number" v-model="scene.duration" @blur="blur('duration')"/>
+              </b-field>
             </b-field>
 
             <b-field :label="$t('Cast')">
@@ -132,9 +136,15 @@ export default {
       images = JSON.parse(scene.images)
     } catch {
       images = []
+    }    
+    try {
+      scene.covers = images.filter(i => i.type === 'cover').map(i => i.url)
+      scene.gallery = images.filter(i => i.type === 'gallery').map(i => i.url)
     }
-    scene.covers = images.filter(i => i.type === 'cover').map(i => i.url)
-    scene.gallery = images.filter(i => i.type === 'gallery').map(i => i.url)
+    catch {
+      scene.covers = []
+      scene.gallery = []
+    }    
     try {
       scene.files = JSON.parse(scene.filenames_arr)
     } catch {


### PR DESCRIPTION
This change allows the user to scrape a single scene using the URL to the scene page from Options/Scrapers, selecting the 3 dots on the scraper to use, has a new option Scrape Single Scene, the user then specifies the URL for the scene.
Uses:

- You can scrape scenes that exist on a site but are missing from the Scene List page used by the scraper.  Sinsvr has had a couple of scenes like this and VirtualPorn recently had all scene from page 5 onwards inaccessible to the scraper
- You don't want to scrape all scenes from a studio, but may see a small subset you still want
- A scene may not be available from a site normally used by your scraper but is available at another site, eg you could use SLR to scrape scenes from JackandJillVR, but it doesn't have the scene "3Some With Nessa", however, the scene is available from VRPorn, by creating an extra Custom Site from JackandJill on the VRPorn site, you could then scrape the single scene "3Some With Nessa" from VRPorn

For some sites the scraper may get some details from the Scene List page as they are not available on the Scene Page.  In these cases the user will be prompted to enter additional details.

Notes

- A scraper does not have to be Enabled to scrape a single scene
- You can specify a url for an existing scene and it will refresh it, similar to the current option to Refresh a scene
- Single scenes cannot be scraped from Baberoticvr as the scraper does not scrape scene pages.
