### PR TITLE
Option to Delete Actors

### DIFF
--- a/ui/src/views/actors/EditActor.vue
+++ b/ui/src/views/actors/EditActor.vue
@@ -110,7 +110,8 @@
 
       <footer class="modal-card-foot">
         <b-field>
-          <b-button type="is-primary" @click="save">{{ $t('Save Details') }}</b-button>          
+          <b-button type="is-primary" @click="save">{{ $t('Save Details') }}</b-button>
+          <b-button v-if="actor.scenes.length == 0 && !actor.name.startsWith('aka:')" type="is-danger" outlined @click="deleteactor">{{ $t('Delete Actor') }}</b-button>
         </b-field>
       </footer>
     </div>
@@ -291,6 +292,22 @@ export default {
       this.extrefsChangesMade = false
       this.$store.state.actorList.isLoading = false
       this.close()
+    },
+    deleteactor () {
+      this.$buefy.dialog.confirm({
+        title: 'Delete actor',
+        message: `Do you really want to delete <strong>${this.actor.name}</strong>`,
+        type: 'is-info is-wide',
+        hasIcon: true,
+        id: 'heh',
+        onConfirm: () => {
+          ky.delete(`/api/actor/delete/${this.actor.id}`).json().then(data => {
+            this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset - this.$store.state.actorList.limit })
+            this.$store.commit('overlay/hideActorEditDetails')
+            this.$store.commit('overlay/hideActorDetails')
+          })
+        }
+      })
     },
     blur (field) {
       if (this.changesMade) return // Changes have already been made. No point to check any further   


### PR DESCRIPTION
This change allows users to delete an Actor that has no scenes.  Users can go to Actor Details, Edit and a button will appear for "Delete Actor" if they have no scenes, and the actor record is not for an Aka group.

If the Actor is for an Aka Group, i.e., the name is prefixed with aka:, they should be deleted using the existing methods to remove an Aka group

If users want to find Actors that can be deleted they can use the existing Scenes Filter on the Actor list and set the Slider to be from 0 to 0