### PR TITLE
Has Funscript Download

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -365,6 +365,7 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "VRPHub Scraper")
 	outAttributes = append(outAttributes, "VRPorn Scraper")
 	outAttributes = append(outAttributes, "Stashdb Linked")
+	outAttributes = append(outAttributes, "Has Script Download")
 	type Results struct {
 		Result string
 	}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -714,6 +714,19 @@ func Migrate() {
 				return tx.AutoMigrate(Scene{}).Error
 			},
 		},
+		{
+			ID: "0067-scenes-add-has-script-download",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					ScriptPublished time.Time `json:"script_published" xbvrbackup:"script_published"`
+				}
+				err := tx.AutoMigrate(Scene{}).Error
+				if err != nil {
+					return err
+				}
+				return tx.Exec("update scenes set script_published = '0000-00-00' where script_published is null").Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -18,26 +18,27 @@ type Scraper struct {
 }
 
 type ScrapedScene struct {
-	SceneID     string   `json:"_id"`
-	ScraperID   string   `json:"xbvr_site"`
-	SiteID      string   `json:"scene_id"`
-	SceneType   string   `json:"scene_type"`
-	Title       string   `json:"title"`
-	Studio      string   `json:"studio"`
-	Site        string   `json:"site"`
-	Covers      []string `json:"covers"`
-	Gallery     []string `json:"gallery"`
-	Tags        []string `json:"tags"`
-	Cast        []string `json:"cast"`
-	Filenames   []string `json:"filename"`
-	Duration    int      `json:"duration"`
-	Synopsis    string   `json:"synopsis"`
-	Released    string   `json:"released"`
-	HomepageURL string   `json:"homepage_url"`
-	MembersUrl  string   `json:"members_url"`
-	TrailerType string   `json:"trailer_type"`
-	TrailerSrc  string   `json:"trailer_source"`
-	ChromaKey   string   `json:"chromakey"`
+	SceneID           string   `json:"_id"`
+	ScraperID         string   `json:"xbvr_site"`
+	SiteID            string   `json:"scene_id"`
+	SceneType         string   `json:"scene_type"`
+	Title             string   `json:"title"`
+	Studio            string   `json:"studio"`
+	Site              string   `json:"site"`
+	Covers            []string `json:"covers"`
+	Gallery           []string `json:"gallery"`
+	Tags              []string `json:"tags"`
+	Cast              []string `json:"cast"`
+	Filenames         []string `json:"filename"`
+	Duration          int      `json:"duration"`
+	Synopsis          string   `json:"synopsis"`
+	Released          string   `json:"released"`
+	HomepageURL       string   `json:"homepage_url"`
+	MembersUrl        string   `json:"members_url"`
+	TrailerType       string   `json:"trailer_type"`
+	TrailerSrc        string   `json:"trailer_source"`
+	ChromaKey         string   `json:"chromakey"`
+	HasScriptDownload bool     `json:"has_script_Download"`
 
 	ActorDetails map[string]ActorDetails `json:"actor_details"`
 }

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -49,6 +49,7 @@
             <option value="scene_updated_desc">↓ {{ $t("Scene updated date") }}</option>
             <option value="last_opened_desc">↓ {{ $t("Last viewed date") }}</option>
             <option value="last_opened_asc">↑ {{ $t("Last viewed date") }}</option>
+            <option value="script_published_desc">↓ {{ $t("Published Script Added") }}</option>
             <option value="random">↯ {{ $t("Random") }}</option>
           </select>
         </div>


### PR DESCRIPTION
This feature scrapes sites for the availability of a Funscript file for a scene.  This includes studios under the SLR, Badoink and Czech sites.

Usually, Funscripts are published sometime after the scene is published. To handle this, the feature does the following:
- The availability of the of funscripts is recorded from the Scene Lists as well as during a Scene scrape.  This is so you do not have to re-scrape all scenes to pick up scenes that have funscripts added after the scene is published, this can be years later.
- The ability to sort scenes by the Script Publish Date descending to see scenes that have had funscripts recently added

There is also a new Attribute filter "Has Script Download" to indicate a Funscript is available at the Site.  The existing "Is Scripted".

Unfortunately, sites don't show the date the funscript was published, so to be able to provide a sorted list, the date the funscript was found by XBVR is used.  Therefore, after the first site scrape after upgrading xbvr with the new feature, the new script_published column will be set to the current date for all funscripts found.