### PR TITLE
fix javdatabase cast scraping, again

### DIFF
--- a/pkg/scrape/javdatabase.go
+++ b/pkg/scrape/javdatabase.go
@@ -27,12 +27,11 @@ func ScrapeJavDB(out *[]models.ScrapedScene, queryString string) {
 		html.ForEach("h2.subhead", func(id int, h2 *colly.HTMLElement) {
 			if strings.HasSuffix(h2.Text, "Actress/Idols") {
 				h2.DOM.Parent().Find("div.card-body a.cut-text").Each(func(i int, anchor *goquery.Selection) {
-						href, exists := anchor.Attr("href")
-						if exists && strings.Contains(href, "javdatabase.com/idols/") && anchor.Text() != "" {
-							sc.Cast = append(sc.Cast, strings.TrimSpace(anchor.Text()))
-						}
-					})
-				}
+					href, exists := anchor.Attr("href")
+					if exists && strings.Contains(href, "javdatabase.com/idols/") && anchor.Text() != "" {
+						sc.Cast = append(sc.Cast, strings.TrimSpace(anchor.Text()))
+					}
+				})
 			}
 		})
 

--- a/pkg/scrape/javdatabase.go
+++ b/pkg/scrape/javdatabase.go
@@ -26,10 +26,7 @@ func ScrapeJavDB(out *[]models.ScrapedScene, queryString string) {
 		// Cast
 		html.ForEach("h2.subhead", func(id int, h2 *colly.HTMLElement) {
 			if strings.HasSuffix(h2.Text, "Actress/Idols") {
-				dom := h2.DOM
-				parent := dom.Parent()
-				if parent != nil {
-					parent.Find("a").Each(func(i int, anchor *goquery.Selection) {
+				h2.DOM.Parent().Find("div.card-body a.cut-text").Each(func(i int, anchor *goquery.Selection) {
 						href, exists := anchor.Attr("href")
 						if exists && strings.Contains(href, "javdatabase.com/idols/") && anchor.Text() != "" {
 							sc.Cast = append(sc.Cast, strings.TrimSpace(anchor.Text()))


### PR DESCRIPTION
prevents creation of erroneous e.g. `<img src="https://wwwjavdatabasecom/idolimages/thumb/aoi-kururugiwebp"width="160" height="200" alt="Aoi kururugi">` cast entries