### PR TITLE
Handle AI & Multi Axis SLR funscripts

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -366,6 +366,8 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "VRPorn Scraper")
 	outAttributes = append(outAttributes, "Stashdb Linked")
 	outAttributes = append(outAttributes, "Has Script Download")
+	outAttributes = append(outAttributes, "Has AI Script")
+	outAttributes = append(outAttributes, "Has Multi Axis Script")
 	type Results struct {
 		Result string
 	}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -727,6 +727,16 @@ func Migrate() {
 				return tx.Exec("update scenes set script_published = '0000-00-00' where script_published is null").Error
 			},
 		},
+		{
+			ID: "0067-scenes-add-ai-multi-script-types",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					AiScript        bool `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
+					MultiAxisScript bool `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -110,6 +110,8 @@ type Scene struct {
 	LegacySceneID string `json:"legacy_scene_id" xbvrbackup:"legacy_scene_id"`
 
 	ScriptPublished time.Time `json:"script_published" xbvrbackup:"script_published"`
+	AiScript        bool      `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
+	MultiAxisScript bool      `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
 
 	Description string  `gorm:"-" json:"description" xbvrbackup:"-"`
 	Score       float64 `gorm:"-" json:"_score" xbvrbackup:"-"`
@@ -449,6 +451,8 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	if ext.HasScriptDownload && o.ScriptPublished.IsZero() {
 		o.ScriptPublished = time.Now()
 	}
+	o.AiScript = ext.AiScript
+	o.MultiAxisScript = ext.MultiAxisScript
 
 	// Trailers
 	o.TrailerType = ext.TrailerType
@@ -939,6 +943,18 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 				where = "scenes.script_published > '0001-01-01 00:00:00+00:00'"
 			} else {
 				where = "scenes.script_published < '0001-01-02 00:00:00+00:00'"
+			}
+		case "Has AI Script":
+			if truefalse {
+				where = "scenes.ai_script = 1"
+			} else {
+				where = "scenes.ai_script = 0"
+			}
+		case "Has Multi Axis Script":
+			if truefalse {
+				where = "scenes.multi_axis_script = 1"
+			} else {
+				where = "scenes.multi_axis_script = 0"
 			}
 		}
 

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -39,6 +39,8 @@ type ScrapedScene struct {
 	TrailerSrc        string   `json:"trailer_source"`
 	ChromaKey         string   `json:"chromakey"`
 	HasScriptDownload bool     `json:"has_script_Download"`
+	AiScript          bool     `json:"ai_script"`
+	MultiAxisScript   bool     `json:"multi_axis_script"`
 
 	ActorDetails map[string]ActorDetails `json:"actor_details"`
 }

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -248,8 +248,18 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			})
 		})
 		sc.HasScriptDownload = false
+		sc.AiScript = false
+		sc.MultiAxisScript = false
 		e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
 			sc.HasScriptDownload = true
+		})
+		e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-ai-vr']`, func(id int, e_a *colly.HTMLElement) {
+			sc.HasScriptDownload = true
+			sc.AiScript = true
+		})
+		e.ForEach(`ul.c-meta--scene-specs a[href='/tags/multi-axis-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
+			sc.HasScriptDownload = true
+			sc.MultiAxisScript = true
 		})
 		out <- sc
 	})
@@ -266,8 +276,16 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		isTransScene := strings.Contains(sceneURL, "/trans")
 
 		if isStraightScene || isTransScene {
-			e.ForEach(`div.c-grid-badge--fleshlight-badge`, func(id int, e_a *colly.HTMLElement) {
+			var scene models.Scene
+			scene.GetIfExistURL(sceneURL)
+			e.ForEach(`div.c-grid-badge--fleshlight`, func(id int, e_a *colly.HTMLElement) {
 				db.Model(&models.Scene{}).Where("scene_url = ? and script_published = '0000-00-00'", sceneURL).Update("script_published", time.Now())
+			})
+			e.ForEach(`div.c-grid-badge--script-ai`, func(id int, e_a *colly.HTMLElement) {
+				db.Model(&models.Scene{}).Where("scene_url = ? and (script_published = '0000-00-00' or ai_script = 0)", sceneURL).Updates(models.Scene{ScriptPublished: time.Now(), AiScript: true})
+			})
+			e.ForEach(`div.c-grid-badge--fleshlight-badge-multi`, func(id int, e_a *colly.HTMLElement) {
+				db.Model(&models.Scene{}).Where("scene_url = ? and (script_published = '0000-00-00' or multi_axis_script = 0)", sceneURL).Updates(models.Scene{ScriptPublished: time.Now(), MultiAxisScript: true})
 			})
 
 			// If scene exist in database, there's no need to scrape


### PR DESCRIPTION
Fixes Issue an with SLR AI generated Funscripts no longer flagged as "Has Script Download".

Adds 2 new columns to the scene table to distinguishes between AI generated scripts, Multi Axis scripts from normal scripts on the SLR Site.
Add new Scene Attribute filters "Has AI Script" and "Has Multi Axis Script".