### PR TITLE
Improve loading time of HereSphere and DeoVR lists

### DIFF
--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -13,11 +13,12 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"github.com/markphelps/optional"
 	"github.com/tidwall/gjson"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/session"
-	"golang.org/x/crypto/bcrypt"
 )
 
 type DeoLibrary struct {
@@ -285,8 +286,8 @@ func (i DeoVRResource) getDeoFile(req *restful.Request, resp *restful.Response) 
 	var file models.File
 	db.Where(&models.File{ID: uint(fileId)}).First(&file)
 
-	var height = file.VideoHeight
-	var width = file.VideoWidth
+	height := file.VideoHeight
+	width := file.VideoWidth
 	var sources []DeoSceneEncoding
 	sources = append(sources, DeoSceneEncoding{
 		Name: fmt.Sprintf("File 1/1 - %v", humanize.Bytes(uint64(file.Size))),
@@ -389,9 +390,9 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 	var sceneMultiProjection bool = true
 
 	for i, file := range videoFiles {
-		var height = file.VideoHeight
-		var width = file.VideoWidth
-		var source = DeoSceneEncoding{
+		height := file.VideoHeight
+		width := file.VideoWidth
+		source := DeoSceneEncoding{
 			Name: fmt.Sprintf("File %v/%v %vp - %v", i+1, len(videoFiles), file.VideoHeight, humanize.Bytes(uint64(file.Size))),
 			VideoSources: []DeoSceneVideoSource{
 				{
@@ -499,7 +500,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 	title := scene.Title
 	thumbnailURL := session.DeoRequestHost + "/img/700x/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 
-	//Passthrough
+	// Passthrough
 	var ckdata map[string]interface{}
 	//	nochromaKey := `{"enabled":false,"hasAlpha":false,"h":0,"opacity":0,"s":0,"threshold":0,"v":0}`
 	chromaKey := gjson.Parse(scene.ChromaKey)
@@ -512,7 +513,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		if !result.Exists() || ckdata["hasAlpha"] == "" {
 			//			if ckdata["."].(map[string]interface{})["hasAlpha"] = "false" || ckdata["."].(map[string]interface{})["hasAlpha"] = "" {
 
-			//setting hasAlpha to false
+			// setting hasAlpha to false
 			ckdata["hasAlpha"] = "false"
 		}
 		// Convert back to JSON string
@@ -625,6 +626,7 @@ func (i DeoVRResource) getDeoLibrary(req *restful.Request, resp *restful.Respons
 			r.IsAccessible = optional.NewBool(true)
 			r.IsAvailable = optional.NewBool(true)
 			r.Limit = optional.NewInt(10000)
+			r.Counts = optional.NewBool(false)
 
 			q := models.QueryScenes(r, false)
 			sceneLists = append(sceneLists, DeoListScenes{

--- a/pkg/api/dms.go
+++ b/pkg/api/dms.go
@@ -11,6 +11,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/jinzhu/gorm"
+
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/session"
@@ -36,18 +37,22 @@ func (i DMSResource) WebService() *restful.WebService {
 
 	ws.Route(ws.GET("/file/{file-id}").To(i.getFile).
 		Param(ws.PathParameter("file-id", "File ID").DataType("int")).
+		ContentEncodingEnabled(false).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	ws.Route(ws.GET("/file/{file-id}/{var:*}").To(i.getFile).
 		Param(ws.PathParameter("file-id", "File ID").DataType("int")).
+		ContentEncodingEnabled(false).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	ws.Route(ws.GET("/heatmap/{file-id}").To(i.getHeatmap).
 		Param(ws.PathParameter("file-id", "File ID").DataType("int")).
+		ContentEncodingEnabled(false).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	ws.Route(ws.GET("/preview/{scene-id}").To(i.getPreview).
 		Param(ws.PathParameter("scene-id", "Scene ID")).
+		ContentEncodingEnabled(false).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	return ws

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -970,6 +970,7 @@ func (i HeresphereResource) getHeresphereLibrary(req *restful.Request, resp *res
 			r.IsAccessible = optional.NewBool(true)
 			r.IsAvailable = optional.NewBool(true)
 			r.Limit = optional.NewInt(20000)
+			r.Counts = optional.NewBool(false)
 
 			q := models.QueryScenes(r, false)
 

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -969,15 +969,11 @@ func (i HeresphereResource) getHeresphereLibrary(req *restful.Request, resp *res
 		if err := json.Unmarshal([]byte(savedPlaylists[i].SearchParams), &r); err == nil {
 			r.IsAccessible = optional.NewBool(true)
 			r.IsAvailable = optional.NewBool(true)
-			r.Limit = optional.NewInt(20000)
-			r.Counts = optional.NewBool(false)
 
-			q := models.QueryScenes(r, false)
+			list := models.QuerySceneIDs(r)
 
-			list := make([]string, len(q.Scenes))
-			for i := range q.Scenes {
-				url := fmt.Sprintf("%v://%v/heresphere/%v", getProto(req), req.Request.Host, q.Scenes[i].ID)
-				list[i] = url
+			for i := range list {
+				list[i] = fmt.Sprintf("%v://%v/heresphere/%v", getProto(req), req.Request.Host, list[i])
 			}
 
 			sceneLists = append(sceneLists, HeresphereListScenes{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,8 @@ import (
 	"github.com/koding/websocketproxy"
 	"github.com/peterbourgon/diskv"
 	"github.com/rs/cors"
+	"willnorris.com/go/imageproxy"
+
 	"github.com/xbapps/xbvr/pkg/api"
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/config"
@@ -28,7 +30,6 @@ import (
 	"github.com/xbapps/xbvr/pkg/session"
 	"github.com/xbapps/xbvr/pkg/tasks"
 	"github.com/xbapps/xbvr/ui"
-	"willnorris.com/go/imageproxy"
 )
 
 var (
@@ -63,6 +64,8 @@ func StartServer(version, commit, branch, date string) {
 
 	models.InitSites()
 
+	restful.DefaultContainer.EnableContentEncoding(true)
+
 	// API endpoints
 	ws := new(restful.WebService)
 	ws.Route(ws.GET("/").To(func(req *restful.Request, resp *restful.Response) {
@@ -88,7 +91,7 @@ func StartServer(version, commit, branch, date string) {
 		WebServices: restful.RegisteredWebServices(),
 		APIPath:     "/api.json",
 		PostBuildSwaggerObjectHandler: func(swo *spec.Swagger) {
-			var e = spec.VendorExtensible{}
+			e := spec.VendorExtensible{}
 			e.AddExtension("x-logo", map[string]interface{}{
 				"url": "/ui/icons/xbvr-512.png",
 			})


### PR DESCRIPTION
This drastically reduces the time it takes to generate the JSON sent on `/heresphere` and `/deovr`. On my setup, `/heresphere` went from 13-14 seconds down to 1-2 seconds and `/deovr` from ~14 seconds to 2-3 seconds.

These gains come from 2 main improvements:
* this removes all the count queries when going through those APIs, since those values are only used in the web UI;
* this only fetches the required columns to generated the JSON, rather than the whole scene.

I also enabled content encoding (aka compression of the HTTP response). It has no noticeable impact on processing time, but should make a difference in transfer time since those JSON documents compress really well.

Some attribute filters should also be a little faster to apply, this is negligible in comparison to the other improvements. As a bit of a side effect, this also fixes some attribute filters that could not be negated.