### PR TITLE
Fixes Db Locks and Missing SLR Ai Scripts (rebased #1381)

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -554,6 +554,16 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 			Name: file.Filename,
 			URL:  fmt.Sprintf("%v://%v/api/dms/file/%v", getProto(req), req.Request.Host, file.ID),
 		})
+
+		if scene.HumanScript {
+			addFeatureTag("Hand Crafted Funscript")
+		}
+		if scene.AiScript {
+			addFeatureTag("AI Generated Funscript")
+		}
+		if scene.MultiAxisScript {
+			addFeatureTag("Multi-xis Funscript")
+		}
 	}
 
 	var heresphereSubtitlesFiles []HeresphereSubtitles

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -561,9 +561,6 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		if scene.AiScript {
 			addFeatureTag("AI Generated Funscript")
 		}
-		if scene.MultiAxisScript {
-			addFeatureTag("Multi-xis Funscript")
-		}
 	}
 
 	var heresphereSubtitlesFiles []HeresphereSubtitles

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -68,6 +68,9 @@ type RequestSaveOptionsAdvanced struct {
 	UseImperialEntry      bool   `json:"useImperialEntry"`
 }
 
+type RequestSaveOptionsFunscripts struct {
+	ScrapeFunscripts bool `json:"scrapeFunscripts":`
+}
 type RequestSaveOptionsDLNA struct {
 	Enabled      bool     `json:"enabled"`
 	ServiceName  string   `json:"name"`
@@ -236,6 +239,10 @@ func (i ConfigResource) WebService() *restful.WebService {
 	ws.Route(ws.PUT("/interface/advanced").To(i.saveOptionsAdvanced).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
+	// "Web Advanced UI options" section endpoints
+	ws.Route(ws.PUT("/funscripts").To(i.saveOptionsFunscripts).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
 	// "Cache" section endpoints
 	ws.Route(ws.DELETE("/cache/reset/{cache}").To(i.resetCache).
 		Param(ws.PathParameter("cache", "Cache to reset - possible choices are `images`, `previews`, and `searchIndex`").DataType("string")).
@@ -392,6 +399,19 @@ func (i ConfigResource) saveOptionsAdvanced(req *restful.Request, resp *restful.
 	config.Config.Advanced.StashApiKey = r.StashApiKey
 	config.Config.Advanced.ScrapeActorAfterScene = r.ScrapeActorAfterScene
 	config.Config.Advanced.UseImperialEntry = r.UseImperialEntry
+	config.SaveConfig()
+
+	resp.WriteHeaderAndEntity(http.StatusOK, r)
+}
+func (i ConfigResource) saveOptionsFunscripts(req *restful.Request, resp *restful.Response) {
+	var r RequestSaveOptionsFunscripts
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	config.Config.Funscripts.ScrapeFunscripts = r.ScrapeFunscripts
 	config.SaveConfig()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, r)

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -366,6 +366,9 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "VRPorn Scraper")
 	outAttributes = append(outAttributes, "Stashdb Linked")
 	outAttributes = append(outAttributes, "Has Script Download")
+	outAttributes = append(outAttributes, "Has AI Generated Script")
+	outAttributes = append(outAttributes, "Has Multi Axis Script")
+	outAttributes = append(outAttributes, "Has Human Generated Script")
 	type Results struct {
 		Result string
 	}

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -367,7 +367,6 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "Stashdb Linked")
 	outAttributes = append(outAttributes, "Has Script Download")
 	outAttributes = append(outAttributes, "Has AI Generated Script")
-	outAttributes = append(outAttributes, "Has Multi Axis Script")
 	outAttributes = append(outAttributes, "Has Human Generated Script")
 	type Results struct {
 		Result string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,9 @@ type ObjectConfig struct {
 		UseImperialEntry      bool   `default:"false" json:"useImperialEntry"`
 		ProgressTimeInterval  int    `default:"15" json:"progressTimeInterval"`
 	} `json:"advanced"`
+	Funscripts struct {
+		ScrapeFunscripts bool `default:"false" json:"scrapeFunscripts"`
+	} `json:"funscripts"`
 	Vendor struct {
 		TPDB struct {
 			ApiToken string `default:"" json:"apiToken"`

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -729,6 +729,17 @@ func Migrate() {
 			},
 		},
 		{
+			ID: "0067-scenes-add-ai-multi-human-script-types",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					AiScript        bool `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
+					MultiAxisScript bool `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
+					HumanScript     bool `json:"human_script" gorm:"default:false" xbvrbackup:"human_script"`
+				}
+				return tx.AutoMigrate(Scene{}).Error
+			},
+		},
+		{
 			ID: "0068-scene-wishlist",
 			Migrate: func(tx *gorm.DB) error {
 				type Scene struct {

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -732,9 +732,8 @@ func Migrate() {
 			ID: "0067-scenes-add-ai-multi-human-script-types",
 			Migrate: func(tx *gorm.DB) error {
 				type Scene struct {
-					AiScript        bool `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
-					MultiAxisScript bool `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
-					HumanScript     bool `json:"human_script" gorm:"default:false" xbvrbackup:"human_script"`
+					AiScript    bool `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
+					HumanScript bool `json:"human_script" gorm:"default:false" xbvrbackup:"human_script"`
 				}
 				return tx.AutoMigrate(Scene{}).Error
 			},

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -111,6 +111,9 @@ type Scene struct {
 	LegacySceneID string `json:"legacy_scene_id" xbvrbackup:"legacy_scene_id"`
 
 	ScriptPublished time.Time `json:"script_published" xbvrbackup:"script_published"`
+	AiScript        bool      `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
+	MultiAxisScript bool      `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
+	HumanScript     bool      `json:"human_script" gorm:"default:false" xbvrbackup:"human_script"`
 
 	Description string  `gorm:"-" json:"description" xbvrbackup:"-"`
 	Score       float64 `gorm:"-" json:"_score" xbvrbackup:"-"`
@@ -451,6 +454,9 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	if ext.HasScriptDownload && o.ScriptPublished.IsZero() {
 		o.ScriptPublished = time.Now()
 	}
+	o.AiScript = ext.AiScript
+	o.MultiAxisScript = ext.MultiAxisScript
+	o.HumanScript = ext.HumanScript
 
 	// Trailers
 	o.TrailerType = ext.TrailerType
@@ -808,6 +814,10 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 			where = `scenes.scene_id like "vrporn-%"`
 		case "Has Script Download":
 			where = "scenes.script_published > '0001-01-01 00:00:00+00:00'"
+		case "Has AI Generated Script":
+			where = "scenes.ai_script = 1"
+		case "Has Human Generated Script":
+			where = "scenes.human_script = 1"
 		}
 
 		if negate {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -550,6 +550,21 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	return nil
 }
 
+func SceneUpdateScriptData(db *gorm.DB, ext ScrapedScene) {
+	var o Scene
+	o.GetIfExistByPK(ext.InternalSceneId)
+
+	if o.ID != 0 {
+		if o.ScriptPublished.IsZero() || o.HumanScript != ext.HumanScript || o.AiScript != ext.AiScript || o.MultiAxisScript != ext.MultiAxisScript {
+			o.ScriptPublished = time.Now()
+			o.HumanScript = ext.HumanScript
+			o.AiScript = ext.AiScript
+			o.MultiAxisScript = ext.MultiAxisScript
+			o.Save()
+		}
+	}
+}
+
 type RequestSceneList struct {
 	DlState      optional.String   `json:"dlState"`
 	Limit        optional.Int      `json:"limit"`

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -112,7 +112,6 @@ type Scene struct {
 
 	ScriptPublished time.Time `json:"script_published" xbvrbackup:"script_published"`
 	AiScript        bool      `json:"ai_script" gorm:"default:false" xbvrbackup:"ai_script"`
-	MultiAxisScript bool      `json:"multi_axis_script" gorm:"default:false" xbvrbackup:"multi_axis_script"`
 	HumanScript     bool      `json:"human_script" gorm:"default:false" xbvrbackup:"human_script"`
 
 	Description string  `gorm:"-" json:"description" xbvrbackup:"-"`
@@ -455,7 +454,6 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 		o.ScriptPublished = time.Now()
 	}
 	o.AiScript = ext.AiScript
-	o.MultiAxisScript = ext.MultiAxisScript
 	o.HumanScript = ext.HumanScript
 
 	// Trailers
@@ -555,11 +553,10 @@ func SceneUpdateScriptData(db *gorm.DB, ext ScrapedScene) {
 	o.GetIfExistByPK(ext.InternalSceneId)
 
 	if o.ID != 0 {
-		if o.ScriptPublished.IsZero() || o.HumanScript != ext.HumanScript || o.AiScript != ext.AiScript || o.MultiAxisScript != ext.MultiAxisScript {
+		if o.ScriptPublished.IsZero() || o.HumanScript != ext.HumanScript || o.AiScript != ext.AiScript {
 			o.ScriptPublished = time.Now()
 			o.HumanScript = ext.HumanScript
 			o.AiScript = ext.AiScript
-			o.MultiAxisScript = ext.MultiAxisScript
 			o.Save()
 		}
 	}

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -40,7 +40,6 @@ type ScrapedScene struct {
 	ChromaKey         string   `json:"chromakey"`
 	HasScriptDownload bool     `json:"has_script_Download"`
 	AiScript          bool     `json:"ai_script"`
-	MultiAxisScript   bool     `json:"multi_axis_script"`
 	HumanScript       bool     `json:"human_script"`
 
 	OnlyUpdateScriptData bool `default:"false" json:"only_update_script_data"`

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -43,6 +43,9 @@ type ScrapedScene struct {
 	MultiAxisScript   bool     `json:"multi_axis_script"`
 	HumanScript       bool     `json:"human_script"`
 
+	OnlyUpdateScriptData bool `default:"false" json:"only_update_script_data"`
+	InternalSceneId      uint `json:"internal_id"`
+
 	ActorDetails map[string]ActorDetails `json:"actor_details"`
 }
 

--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -39,6 +39,9 @@ type ScrapedScene struct {
 	TrailerSrc        string   `json:"trailer_source"`
 	ChromaKey         string   `json:"chromakey"`
 	HasScriptDownload bool     `json:"has_script_Download"`
+	AiScript          bool     `json:"ai_script"`
+	MultiAxisScript   bool     `json:"multi_axis_script"`
+	HumanScript       bool     `json:"human_script"`
 
 	ActorDetails map[string]ActorDetails `json:"actor_details"`
 }

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -220,7 +220,6 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 					sc.OnlyUpdateScriptData = true
 					sc.HumanScript = false
 					sc.AiScript = false
-					sc.MultiAxisScript = false
 					out <- sc
 				}
 			})

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -207,7 +207,12 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		})
 
 		e.ForEach(`a[href^="/category/funscript"]`, func(id int, e *colly.HTMLElement) {
-			db.Model(&models.Scene{}).Where("scene_url = ? and script_published = '0000-00-00'", sceneURL).Update("script_published", time.Now())
+			var existingScene models.Scene
+			existingScene.GetIfExistURL(sceneURL)
+			if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
+				existingScene.ScriptPublished = time.Now()
+				existingScene.Save()
+			}
 		})
 	})
 

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -173,7 +173,6 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 					sc.OnlyUpdateScriptData = true
 					sc.HumanScript = false
 					sc.AiScript = false
-					sc.MultiAxisScript = false
 					out <- sc
 				}
 			})

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -161,7 +161,12 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 			}
 		})
 		e.ForEach(`div.interactive`, func(id int, e *colly.HTMLElement) {
-			db.Model(&models.Scene{}).Where("scene_url = ? and script_published = '0000-00-00'", sceneURL).Update("script_published", time.Now())
+			var existingScene models.Scene
+			existingScene.GetIfExistURL(sceneURL)
+			if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
+				existingScene.ScriptPublished = time.Now()
+				existingScene.Save()
+			}
 		})
 	})
 

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -5,12 +5,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/mozillazg/go-slugify"
 	"github.com/nleeper/goment"
 	"github.com/thoas/go-funk"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -98,9 +98,11 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 			}
 		})
 
-		e.ForEach(`div.interactive`, func(id int, e *colly.HTMLElement) {
-			sc.HasScriptDownload = true
-		})
+		if config.Config.Funscripts.ScrapeFunscripts {
+			e.ForEach(`div.interactive`, func(id int, e *colly.HTMLElement) {
+				sc.HasScriptDownload = true
+			})
+		}
 
 		// trailer details
 		sc.TrailerType = "heresphere"
@@ -151,24 +153,32 @@ func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.OnHTML(`div.postTag`, func(e *colly.HTMLElement) {
-		sceneURL := ""
-		e.ForEach(`div.foto a`, func(id int, e *colly.HTMLElement) {
-			sceneURL = e.Request.AbsoluteURL(e.Attr("href"))
-			// If scene exist in database, there's no need to scrape
-			if !funk.ContainsString(knownScenes, sceneURL) {
-				sceneCollector.Visit(sceneURL)
-			}
+	if config.Config.Funscripts.ScrapeFunscripts {
+		siteCollector.OnHTML(`div.postTag`, func(e *colly.HTMLElement) {
+			sceneURL := ""
+			e.ForEach(`div.foto a`, func(id int, e *colly.HTMLElement) {
+				sceneURL = e.Request.AbsoluteURL(e.Attr("href"))
+				// If scene exist in database, there's no need to scrape
+				if !funk.ContainsString(knownScenes, sceneURL) {
+					sceneCollector.Visit(sceneURL)
+				}
+			})
+			e.ForEach(`div.interactive`, func(id int, e *colly.HTMLElement) {
+				var existingScene models.Scene
+				existingScene.GetIfExistURL(sceneURL)
+				if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
+					var sc models.ScrapedScene
+					sc.InternalSceneId = existingScene.ID
+					sc.HasScriptDownload = true
+					sc.OnlyUpdateScriptData = true
+					sc.HumanScript = false
+					sc.AiScript = false
+					sc.MultiAxisScript = false
+					out <- sc
+				}
+			})
 		})
-		e.ForEach(`div.interactive`, func(id int, e *colly.HTMLElement) {
-			var existingScene models.Scene
-			existingScene.GetIfExistURL(sceneURL)
-			if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
-				existingScene.ScriptPublished = time.Now()
-				existingScene.Save()
-			}
-		})
-	})
+	}
 
 	if singleSceneURL != "" {
 		sceneCollector.Visit(singleSceneURL)

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -248,7 +248,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			})
 		})
 		sc.HasScriptDownload = false
-		e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
+		e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-vr'], ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-ai-vr'], ul.c-meta--scene-specs a[href='/tags/multi-axis-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
 			sc.HasScriptDownload = true
 		})
 		out <- sc
@@ -266,8 +266,13 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		isTransScene := strings.Contains(sceneURL, "/trans")
 
 		if isStraightScene || isTransScene {
-			e.ForEach(`div.c-grid-badge--fleshlight-badge`, func(id int, e_a *colly.HTMLElement) {
-				db.Model(&models.Scene{}).Where("scene_url = ? and script_published = '0000-00-00'", sceneURL).Update("script_published", time.Now())
+			e.ForEach(`div.c-grid-badge--fleshlight, div.c-grid-badge--script-ai, div.c-grid-badge--fleshlight-badge-multi`, func(id int, e_a *colly.HTMLElement) {
+				var existingScene models.Scene
+				existingScene.GetIfExistURL(sceneURL)
+				if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
+					existingScene.ScriptPublished = time.Now()
+					existingScene.Save()
+				}
 			})
 
 			// If scene exist in database, there's no need to scrape

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -249,7 +249,6 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		if config.Config.Funscripts.ScrapeFunscripts {
 			sc.HasScriptDownload = false
 			sc.AiScript = false
-			sc.MultiAxisScript = false
 			sc.HumanScript = false
 			e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
 				sc.HasScriptDownload = true
@@ -258,10 +257,6 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			e.ForEach(`ul.c-meta--scene-specs a[href='/tags/sex-toy-scripts-ai-vr']`, func(id int, e_a *colly.HTMLElement) {
 				sc.HasScriptDownload = true
 				sc.AiScript = true
-			})
-			e.ForEach(`ul.c-meta--scene-specs a[href='/tags/multi-axis-scripts-vr']`, func(id int, e_a *colly.HTMLElement) {
-				sc.HasScriptDownload = true
-				sc.MultiAxisScript = true
 			})
 		}
 
@@ -291,7 +286,6 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 					human := false
 					ai := false
-					multiAxis := false
 					e.ForEach(`div.c-grid-badge--fleshlight`, func(id int, e_a *colly.HTMLElement) {
 						fleshlightBadge = true
 					})
@@ -312,19 +306,14 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 						human = true
 						// ai = true
 					}
-					if multiBadge && fleshlightBadge {
-						// dont apply this rule yet until more examples are available to confirm rule validity
-						//multiAxis = true
-					}
 
-					if existingScene.HumanScript != human || existingScene.AiScript != ai || existingScene.MultiAxisScript != multiAxis {
+					if existingScene.HumanScript != human || existingScene.AiScript != ai {
 						var sc models.ScrapedScene
 						sc.InternalSceneId = existingScene.ID
 						sc.HasScriptDownload = true
 						sc.OnlyUpdateScriptData = true
 						sc.HumanScript = human
 						sc.AiScript = ai
-						sc.MultiAxisScript = multiAxis
 						out <- sc
 					}
 				}

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -282,7 +282,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 			var existingScene models.Scene
 			existingScene.GetIfExistURL(sceneURL)
-			if existingScene.ID != 0 && existingScene.ScriptPublished.IsZero() {
+			if existingScene.ID != 0 {
 				fleshlightBadge := false
 				aiBadge := false
 				multiBadge := false

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -156,7 +156,13 @@ func sceneDBWriter(wg *sync.WaitGroup, i *uint64, scenes <-chan models.ScrapedSc
 		if os.Getenv("DEBUG") != "" {
 			log.Printf("Saving %v", scene.SceneID)
 		}
-		models.SceneCreateUpdateFromExternal(db, scene)
+		if scene.OnlyUpdateScriptData {
+			if config.Config.Funscripts.ScrapeFunscripts {
+				models.SceneUpdateScriptData(db, scene)
+			}
+		} else {
+			models.SceneCreateUpdateFromExternal(db, scene)
+		}
 		atomic.AddUint64(i, 1)
 		if os.Getenv("DEBUG") != "" {
 			log.Printf("Saved %v", scene.SceneID)

--- a/ui/src/store/optionsFunscripts.js
+++ b/ui/src/store/optionsFunscripts.js
@@ -2,7 +2,10 @@ import ky from 'ky'
 
 const state = {
   countTotal: 0,
-  countUpdated: 0
+  countUpdated: 0,  
+  optionsFunscripts: {
+    scrapeFunscripts: false,
+  }
 }
 
 const mutations = {}
@@ -14,6 +17,19 @@ const actions = {
       .then(data => {
         state.countTotal = data.total
         state.countUpdated = data.updated
+      })
+    ky.get('/api/options/state')
+      .json()
+      .then(data => {
+        state.optionsFunscripts.scrapeFunscripts = data.config.funscripts.scrapeFunscripts
+      })
+
+  },
+  async save ({ state }) {    
+    ky.put('/api/options/funscripts', { json: { ...state.optionsFunscripts } })
+      .json()
+      .then(data => {
+        state.optionsFunscripts.scrapeFunscripts = data.scrapeFunscripts
       })
   },
 }

--- a/ui/src/views/options/sections/Funscripts.vue
+++ b/ui/src/views/options/sections/Funscripts.vue
@@ -44,6 +44,15 @@
           }})</b-button
         >
       </p>
+      <hr />
+      <b-field>
+        <b-switch v-model="scrapeFunscripts" type="is-default">
+          <strong>Scrape for Available Funscripts</strong>
+        </b-switch>
+      </b-field>
+      <b-field>
+        <b-button type="is-primary" @click="save">Save</b-button>
+      </b-field>
     </div>
   </div>
 </template>
@@ -67,6 +76,9 @@ export default {
       link.href = "/api/task/funscript/export-new";
       link.click();
     },
+    save () {
+      this.$store.dispatch('optionsFunscripts/save')
+    },
   },
   computed: {
     countTotal: function () {
@@ -74,6 +86,14 @@ export default {
     },
     countUpdated: function () {
       return this.$store.state.optionsFunscripts.countUpdated;
+    },
+    scrapeFunscripts: {
+      get () {
+        return this.$store.state.optionsFunscripts.optionsFunscripts.scrapeFunscripts
+      },
+      set (value) {
+        this.$store.state.optionsFunscripts.optionsFunscripts.scrapeFunscripts = value
+      },
     },
   },
 };


### PR DESCRIPTION
This fixes issues with possible Database locks and scenes with AI Generated scripts not been flagged as having scripts.

The updates are now performed by the channel used to update the scenes with new scrapes

Scraping to find Available Funscripts is now Optional. Set in "Options/Funscripts/Scrape for Available Funscripts". To be safe this is off by default, if a user turns it on and has trouble, they know where to disable it.


This is a rebase of #1381, I needed to rebase the PR to address conflicts with other PRs and it could no longer be Push back.