### PR TITLE
fix: scene list limited to 2 pages

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -566,7 +566,6 @@ type RequestSceneList struct {
 	DlState      optional.String   `json:"dlState"`
 	Limit        optional.Int      `json:"limit"`
 	Offset       optional.Int      `json:"offset"`
-	Counts       optional.Bool     `json:"counts"`
 	IsAvailable  optional.Bool     `json:"isAvailable"`
 	IsAccessible optional.Bool     `json:"isAccessible"`
 	IsWatched    optional.Bool     `json:"isWatched"`
@@ -626,7 +625,8 @@ func QueryScenes(r RequestSceneList, enablePreload bool) ResponseSceneList {
 	preCountTx.Where("is_available = ?", false).Where("is_hidden = ?", false).Count(&out.CountNotDownloaded)
 	preCountTx.Where("is_hidden = ?", true).Count(&out.CountHidden)
 
-	finalTx.Count(&out.Results)
+	// r.Offset must _not_ apply to the count, as the count query always returns a single value
+	finalTx.Offset(0).Count(&out.Results)
 
 	if enablePreload {
 		finalTx = finalTx.


### PR DESCRIPTION
I introduced a bug in #1383 where the scene list would be limited to 2 pages. This fixes it and also removes a field that I added by mistake in that same PR.