### PR TITLE
fix: wishlist button visual state out of sync

### DIFF
--- a/ui/src/components/WishlistButton.vue
+++ b/ui/src/components/WishlistButton.vue
@@ -1,7 +1,7 @@
 <template>
   <a :class="buttonClass"
      v-if="!item.is_available"
-     @click="$store.commit('sceneList/toggleSceneList', {scene_id: item.scene_id, list: 'wishlist'})"
+     @click="toggleState()"
      :title="item.wishlist ? 'Remove from wishlist' : 'Add to wishlist'">
     <b-icon pack="mdi" icon="oil-lamp" size="is-small"/>
   </a>
@@ -17,6 +17,13 @@ export default {
         return 'button is-info is-small'
       }
       return 'button is-info is-outlined is-small'
+    }
+  },
+  methods: {
+    toggleState() {
+      let currentToggle = this.item.wishlist
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'wishlist'})
+      this.item.wishlist = !currentToggle
     }
   }
 }


### PR DESCRIPTION
Applies #1149 to the new wishlist button, essentially.

The button doesn't correctly reflect the new state of the scene after a click.

Fixes #1396.