### PR TITLE
fix: filter with both actor and favorite or watchlist attribute

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -807,11 +807,11 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 		case "Codec":
 			where = "exists (select 1 from files where files.scene_id = scenes.id and files.`type` = 'video' and files.video_codec_name = '" + value + "')"
 		case "In Watchlist":
-			where = "watchlist = 1"
+			where = "scenes.watchlist = 1"
 		case "Is Scripted":
 			where = "is_scripted = 1"
 		case "Is Favourite":
-			where = "favourite = 1"
+			where = "scenes.favourite = 1"
 		case "Is Passthrough":
 			where = "chroma_key <> ''"
 		case "Stashdb Linked":


### PR DESCRIPTION
Fix filter when using both an actor in the Cast field and either "Is Favourite" or "In Watchlist" in the Attributes field.

This fixes a regression introduced in https://github.com/xbapps/xbvr/pull/1383/