### PR TITLE
Update "Possible Aka" Saved Search

### DIFF
--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -127,6 +127,7 @@ func (i ActorResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "Has Piercing")
 	outAttributes = append(outAttributes, "Aka Group")
 	outAttributes = append(outAttributes, "Possible Aka")
+	outAttributes = append(outAttributes, "In An Aka Group")
 	outAttributes = append(outAttributes, "Multiple Stashdb Links")
 	outAttributes = append(outAttributes, "Has Image")
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1765,6 +1765,44 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0070-update_possible_aka_saved_search",
+			Migrate: func(tx *gorm.DB) error {
+				// update existing Possible Aka Actor Playlist
+				var playlist models.Playlist
+				tx.Model(&models.Playlist{}).Where("playlist_type = ? and name = ?", "actor", "Possible Aka").First(&playlist)
+				if playlist.ID != 0 {
+					list := models.RequestActorList{
+						DlState:        optional.NewString("Any"),
+						Lists:          []optional.String{},
+						Cast:           []optional.String{},
+						Sites:          []optional.String{},
+						Tags:           []optional.String{},
+						Attributes:     []optional.String{},
+						JumpTo:         optional.NewString(""),
+						MinAge:         optional.NewInt(0),
+						MaxAge:         optional.NewInt(100),
+						MinHeight:      optional.NewInt(120),
+						MaxHeight:      optional.NewInt(220),
+						MinCount:       optional.NewInt(0),
+						MaxCount:       optional.NewInt(150),
+						MinAvail:       optional.NewInt(0),
+						MaxAvail:       optional.NewInt(150),
+						MinRating:      optional.NewFloat64(0),
+						MaxRating:      optional.NewFloat64(5),
+						MinSceneRating: optional.NewFloat64(0),
+						MaxSceneRating: optional.NewFloat64(5),
+						Sort:           optional.NewString("birthday_desc"),
+					}
+					list.Attributes = append(list.Attributes, optional.NewString("&Possible Aka"), optional.NewString("!In An Aka Group"), optional.NewString("!Aka Group"))
+					b, _ := json.Marshal(list)
+
+					playlist.SearchParams = string(b)
+					playlist.Save()
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -258,6 +258,12 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 			} else {
 				where = "name not like 'aka:%'"
 			}
+		case "In An Aka Group":
+			if truefalse {
+				where = "(select count(*) from actor_akas " + " where actor_akas.actor_id = actors.id) > 0"
+			} else {
+				where = "(select count(*) from actor_akas " + " where actor_akas.actor_id = actors.id) = 0"
+			}
 		case "Has Image":
 			if truefalse {
 				where = "image_url is not null and image_url <> ''"


### PR DESCRIPTION
The existing "Possible Aka" Saved Search shows Actors who may be the same as another Actor.  This shows Actors regardless of whether they are in an Aka Group already or not.  A more useful search would be to only list Actors who aren't already in a group.

I have added a new Attribute Filter for Actors "In An Aka Group" to show Actors who are in a Group or toggle the switch to show those who are not.

Using the new Attribute, I have updated the Saved Search for "Possible Aka" to only show Actors that maybe matched to another Actor, but are not already in an Aka Group.  The updated search will include the Attributes, Must be a "Possible Aka", Must Not be "In An Aka Group" and Must Not be an "Aka Group"