### PR TITLE
Actor pagination fixes

### DIFF
--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -88,6 +88,7 @@ type ResponseActorList struct {
 	CountDownloaded    int     `json:"count_downloaded"`
 	CountNotDownloaded int     `json:"count_not_downloaded"`
 	CountHidden        int     `json:"count_hidden"`
+	Offset             int     `json:"offset"`
 }
 
 type ActorLink struct {
@@ -340,10 +341,6 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 		tx = tx.Where("actors.name NOT IN (?)", excludedCast)
 	}
 
-	if r.JumpTo.OrElse("") != "" {
-		tx = tx.Where("actors.name > ?", r.JumpTo.OrElse(""))
-	}
-
 	if r.MinAge.OrElse(0) > 18 || r.MaxAge.OrElse(100) < 100 {
 		startRange := time.Now().AddDate(r.MinAge.OrElse(0)*-1, 0, 0)
 		endRange := time.Now().AddDate(r.MaxAge.OrElse(0)*-1, 0, 0)
@@ -469,6 +466,21 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 	tx = tx.Preload("Scenes", func(db *gorm.DB) *gorm.DB {
 		return db.Order("release_date DESC").Where("is_hidden = 0")
 	})
+
+	if r.JumpTo.OrElse("") != "" {
+		// if we want to jump to actors starting with a specific letter, then we need to work out the offset to them
+		cnt := 0
+		txList := tx.Select(`distinct actors.name`)
+		txList.Find(&out.Actors)
+		for idx, actor := range out.Actors {
+			if strings.ToLower(actor.Name) >= strings.ToLower(r.JumpTo.OrElse("")) {
+				break
+			}
+			cnt = idx
+		}
+		offset = (cnt / limit) * limit
+	}
+	out.Offset = offset
 
 	tx = tx.Select(`distinct actors.*, 
 	(select AVG(s.star_rating) scene_avg from scene_cast sc join scenes s on s.id=sc.scene_id where sc.actor_id =actors.id and s.star_rating > 0 ) as scene_rating_average	

--- a/ui/src/store/actorList.js
+++ b/ui/src/store/actorList.js
@@ -161,13 +161,14 @@ const actions = {
       .json()
 
     state.isLoading = false
+    state.filters.jumpTo = ""  // clear the jumpto value now that we have the data
 
     if (iOffset === 0) {
       commit('setActors', [])
     }
 
     commit('setActors', state.actors=data.actors)
-    state.offset = iOffset + state.limit
+    state.offset = data.offset + state.limit
     state.total = data.results    
   }
 }

--- a/ui/src/views/actors/List.vue
+++ b/ui/src/views/actors/List.vue
@@ -256,6 +256,9 @@ export default {
       if (this.$store.state.overlay.actordetails.show){
         return 
       }
+      if (this.$store.state.overlay.details.show){
+        return 
+      }
       if (this.current * this.limit >= this.total) {
         this.current = 1
       } else {
@@ -265,6 +268,9 @@ export default {
     },
     prevpage () {      
       if (this.$store.state.overlay.actordetails.show){
+        return 
+      }
+      if (this.$store.state.overlay.details.show){
         return 
       }
       if (this.current > 1) {


### PR DESCRIPTION
There is an issue if a user goes into the Actor List, selects an Actor and views the Actor Detail, then selects one of the Actors scenes and views the scene detail, then uses the Left or Right arrow to scroll through the scene images, it is also scrolling through the Actor List pages in the background.

The existing process of Jumping to Actors based on the first letter was not ideal.  It would query Actors where the name is greater than that letter.  This works fine, but you then only have a subset of Actors from that letter on.  This has been changed to keep the full list of Actors and jump to the page that contains an Actor whose name is from that letter onwards.