### PR TITLE
SLR scraper filenames

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -206,6 +206,9 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 					// Title
 					sc.Title = gjson.Get(JsonMetadata, "title").String()
 
+					// Fix Scene ID Collisions
+					sc.SceneID = "slr-trans-" + sc.SiteID
+
 					// Duration - Not Available
 
 					// Filenames
@@ -234,7 +237,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		}
 
 		// Filenames
-		appendFilenames(&sc, siteID, filenameRegEx, videotype, FB360, alphA, JsonMetadataA)
+		appendFilenames(&sc, siteID, filenameRegEx, videotype, FB360, alphA, JsonMetadataA, isTransScene)
 
 		// actor details
 		sc.ActorDetails = make(map[string]models.ActorDetails)
@@ -355,51 +358,93 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	return nil
 }
 
-func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *regexp.Regexp, videotype string, FB360 string, AlphA string, JsonMetadataA string) {
+func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *regexp.Regexp, videotype string, FB360 string, AlphA string, JsonMetadataA string, isTransScene bool) {
 	// Only shown for logged in users so need to generate them
 	// Format: SLR_siteID_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
-	viewAngle := gjson.Get(JsonMetadataA, "viewAngle").String()
-	projSuffix := "_LR_180.mp4"
-	if viewAngle == "190" || viewAngle == "200" || viewAngle == "220" {
-		screentype := strings.ToUpper(gjson.Get(JsonMetadataA, "screenType").String())
-		projSuffix = "_" + screentype
-		if AlphA == "true" {
-			projSuffix = "_" + screentype + "_alpha"
+	if !isTransScene {
+		viewAngle := gjson.Get(JsonMetadataA, "viewAngle").String()
+		projSuffix := "_LR_180.mp4"
+		if viewAngle == "190" || viewAngle == "200" || viewAngle == "220" {
+			screentype := strings.ToUpper(gjson.Get(JsonMetadataA, "screenType").String())
+			projSuffix = "_" + screentype
+			if AlphA == "true" {
+				projSuffix = "_" + screentype + "_alpha"
+			}
+			if FB360 != "" {
+				FB360 = projSuffix + "_FB360.mkv"
+			}
+			projSuffix = projSuffix + ".mp4"
+		} else if viewAngle == "360" {
+			monotb := gjson.Get(JsonMetadataA, "stereomode").String()
+			if monotb == "mono" {
+				projSuffix = "_MONO_360.mp4"
+			} else {
+				projSuffix = "_TB_360.mp4"
+			}
+		}
+		resolutions := []string{"_original_"}
+		encodings := gjson.Get(JsonMetadataA, "encodings.#(name=h265).videoSources.#.resolution")
+		for _, name := range encodings.Array() {
+			resolutions = append(resolutions, "_"+name.String()+"p_")
+		}
+		baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
+		switch videotype {
+		case "360°":
+			for i := range resolutions {
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
+			}
+		case "Fisheye": // 200° videos named with MKX200
+			for i := range resolutions {
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
+			}
+		default: // Assuming everything else is 180 and LR, yet to find a TB_180
+			for i := range resolutions {
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
+			}
 		}
 		if FB360 != "" {
-			FB360 = projSuffix + "_FB360.mkv"
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+FB360)
 		}
-		projSuffix = projSuffix + ".mp4"
-	} else if viewAngle == "360" {
-		monotb := gjson.Get(JsonMetadataA, "stereomode").String()
-		if monotb == "mono" {
-			projSuffix = "_MONO_360.mp4"
-		} else {
-			projSuffix = "_TB_360.mp4"
+	} else {
+		resolutions := []string{"_6400p_", "_4096p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_3000p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
+		baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
+		switch videotype {
+		case "360°": // Sadly can't determine if TB or MONO so have to add both
+			for i := range resolutions {
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MONO_360.mp4")
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_TB_360.mp4")
+			}
+		case "Fisheye": // 200° videos named with MKX200
+			for i := range resolutions {
+				if AlphA == "true" {
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX200_alpha.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX220_alpha.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_RF52_alpha.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_FISHEYE190_alpha.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_VRCA220_alpha.mp4")
+				} else {
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX200.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_MKX220.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_RF52.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_FISHEYE190.mp4")
+					sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_VRCA220.mp4")
+				}
+			}
+		default: // Assuming everything else is 180 and LR, yet to find a TB_180
+			for i := range resolutions {
+				sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+"_LR_180.mp4")
+			}
 		}
-	}
-	resolutions := []string{"_original_"}
-	encodings := gjson.Get(JsonMetadataA, "encodings.#(name=h265).videoSources.#.resolution")
-	for _, name := range encodings.Array() {
-		resolutions = append(resolutions, "_"+name.String()+"p_")
-	}
-	baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
-	switch videotype {
-	case "360°":
-		for i := range resolutions {
-			sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
+		if FB360 != "" {
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_LR_180"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MKX200"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MKX220"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_RF52"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"FISHEYE190"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_VRCA220"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_MONO_360"+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+"_TB_360"+FB360)
 		}
-	case "Fisheye": // 200° videos named with MKX200
-		for i := range resolutions {
-			sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
-		}
-	default: // Assuming everything else is 180 and LR, yet to find a TB_180
-		for i := range resolutions {
-			sc.Filenames = append(sc.Filenames, baseName+resolutions[i]+sc.SiteID+projSuffix)
-		}
-	}
-	if FB360 != "" {
-		sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+FB360)
 	}
 }
 


### PR DESCRIPTION
The SLR scraper currently sets filenames for every resolution possible, and every fisheye projection possible when the video is fisheye. It adds both `MONO` and `TB` for 360. All of this can be determined via their API...

I'm not sure if it adds up to much, or how the DB compression works, but compare 5,847 bytes of "filenames" when every single name possible is used for a fisheye projection video with 580 bytes when only the actually possible ones are used. There are 40,000 some odd scenes on SLR if you scrape everything from every studio...

<details>
  <summary>Gigantic wall of text</summary>
  
```json
["SLR_SLR Originals_Notes of Affection_6400p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_6400p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_6400p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_6400p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_6400p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_4096p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_4096p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_4096p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_4096p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_4096p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3160p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_3160p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3160p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_3160p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3160p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3072p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_3072p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3072p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_3072p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3072p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3000p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_3000p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_3000p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_3000p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3000p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2900p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_2900p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2900p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_2900p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2900p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2700p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_2700p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2700p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_2700p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2700p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2650p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_2650p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2650p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_2650p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2650p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1080p_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_1080p_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_1080p_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_1080p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_1080p_37756_VRCA220_alpha.mp4","SLR_SLR Originals_Notes of Affection_original_37756_MKX200_alpha.mp4","SLR_SLR Originals_Notes of Affection_original_37756_MKX220_alpha.mp4","SLR_SLR Originals_Notes of Affection_original_37756_RF52_alpha.mp4","SLR_SLR Originals_Notes of Affection_original_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_original_37756_VRCA220_alpha.mp4"]
```

vs.

```json
["SLR_SLR Originals_Notes of Affection_original_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_4000p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3840p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_3360p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2880p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_2160p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_1920p_37756_FISHEYE190_alpha.mp4","SLR_SLR Originals_Notes of Affection_1440p_37756_FISHEYE190_alpha.mp4"]
```
</details>

Before:
![image](https://github.com/xbapps/xbvr/assets/81622808/0d184828-aa47-4371-a599-c9077c43ad25)

After:
![image](https://github.com/xbapps/xbvr/assets/81622808/8dc61818-f6fc-4940-9fdb-c1f7c5f5c776)

It can now also determine the correct projection
![image](https://github.com/xbapps/xbvr/assets/81622808/ee4281bf-6e78-46c0-8cb9-2bfcd9cb38e2)

For 360 video as well as other fisheye projections
![image](https://github.com/xbapps/xbvr/assets/81622808/02989b24-9a97-4fed-8167-80d78d6a6195)

![image](https://github.com/xbapps/xbvr/assets/81622808/b66ab85d-fad9-43cf-9173-95af992a1672)

The entire scraper might need a looksie (by someone more knowledgeable!!!) to see where the API can be used instead; we're already grabbing that JSON anyways, but then using colly for almost everything.