### PR TITLE
SexBabesVR cover images

### DIFF
--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -43,7 +43,7 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 		e.ForEach(`dl8-video`, func(id int, e *colly.HTMLElement) {
 			sc.SiteID = e.Attr("data-scene")
 			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
-			sc.Covers = append(sc.Covers, e.Attr("poster"))
+			sc.Covers = append(sc.Covers, strings.Replace(e.Attr("poster"), "/videoDetail2x", "", -1))
 		})
 
 		// Title


### PR DESCRIPTION
Restores uncropped and not-upscaled 1000x667 SexBabesVR covers. The videoDetail2x URL is serving a terrible looking 2x DPI upscale of an already upscaled crop (videoDetail). Removing that part of the path entirely returns the same type of cover image their site used before the latest redesign.

Download and compare:
```
https://public.sexbabesvr.com/76bb/9b6c/videoDetail2x/76bb9b6c19b83c47aaa92a2f275cbd2ee29501f7.jpg - Cropped, 2x DPI Upscale
https://public.sexbabesvr.com/76bb/9b6c/videoDetail/76bb9b6c19b83c47aaa92a2f275cbd2ee29501f7.jpg - Cropped, Upscaled
https://public.sexbabesvr.com/76bb/9b6c/galleryDetail/76bb9b6c19b83c47aaa92a2f275cbd2ee29501f7.jpg - Uncropped, Still Upscaled
https://public.sexbabesvr.com/76bb/9b6c/76bb9b6c19b83c47aaa92a2f275cbd2ee29501f7.jpg - the actual cover
```

Removing the `galleryDetail` path from the actual gallery images also works, but I don't want to needlessly bloat everyone's image cache with 3000x2000 images.