### PR TITLE
Configuration options

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -19,7 +19,8 @@ type EnvConfigSpec struct {
 	UIUsername    string `envconfig:"UI_USERNAME" required:"false"`
 	UIPassword    string `envconfig:"UI_PASSWORD" required:"false"`
 	DatabaseURL   string `envconfig:"DATABASE_URL" required:"false" default:""`
-	WsAddr        string `envconfig:"WS_ADDR" required:"false" default:""`
+	WsAddr        string `envconfig:"XBVR_WS_ADDR" required:"false" default:""`
+	WebPort       int    `envconfig:"XBVR_WEB_PORT" required:"false" default:"0"`
 }
 
 var EnvConfig EnvConfigSpec
@@ -30,8 +31,5 @@ func init() {
 	err := envconfig.Process("", &EnvConfig)
 	if err != nil {
 		Log.Fatal(err.Error())
-	}
-	if EnvConfig.WsAddr != "" {
-		WsAddr = EnvConfig.WsAddr
 	}
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -19,6 +19,7 @@ type EnvConfigSpec struct {
 	UIUsername    string `envconfig:"UI_USERNAME" required:"false"`
 	UIPassword    string `envconfig:"UI_PASSWORD" required:"false"`
 	DatabaseURL   string `envconfig:"DATABASE_URL" required:"false" default:""`
+	WsAddr        string `envconfig:"WS_ADDR" required:"false" default:""`
 }
 
 var EnvConfig EnvConfigSpec
@@ -29,5 +30,8 @@ func init() {
 	err := envconfig.Process("", &EnvConfig)
 	if err != nil {
 		Log.Fatal(err.Error())
+	}
+	if EnvConfig.WsAddr != "" {
+		WsAddr = EnvConfig.WsAddr
 	}
 }

--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -21,6 +21,7 @@ var VideoPreviewDir string
 var VideoThumbnailDir string
 var ScriptHeatmapDir string
 var DownloadDir string
+var WebPort int
 
 func DirSize(path string) (int64, error) {
 	var size int64
@@ -38,41 +39,76 @@ func DirSize(path string) (int64, error) {
 
 func InitPaths() {
 
-	enableLocalStorage := flag.Bool("localstorage", false, "Use local folder to store application data")
+	enableLocalStorage := flag.Bool("localstorage", false, "Optional: Use local folder to store application data")
+	app_dir := flag.String("app_dir", "", "Optional: path to the application directory")
+	cache_dir := flag.String("cache_dir", "", "Optional: path to the tempoarary scraper cache directory")
+	imgproxy_dir := flag.String("imgproxy_dir", "", "Optional: path to the imageproxy directory")
+	search_dir := flag.String("search_dir", "", "Optional: path to the Search Index directory")
+	preview_dir := flag.String("preview_dir", "", "Optional: path to the Scraper Cache directory")
+	scriptsheatmap_dir := flag.String("scripts_heatmap_dir", "", "Optional: path to the scripts_heatmap directory")
+	databaseurl := flag.String("database_url", "", "Optional: override default database path")
+	web_port := flag.Int("web_port", 0, "Optional: override default Web Page port 9999")
+	ws_addr := flag.String("ws_addr", "", "Optional: override default Websocket address from the default 0.0.0.0:9998")
+
 	flag.Parse()
 
-	if *enableLocalStorage {
-		executable, err := os.Executable()
+	if *app_dir == "" {
+		tmp := os.Getenv("XBVR_APPDIR")
+		app_dir = &tmp
+	}
+	if *app_dir == "" {
+		if *enableLocalStorage {
+			executable, err := os.Executable()
 
-		if err != nil {
-			panic(err)
+			if err != nil {
+				panic(err)
+			}
+
+			AppDir = filepath.Dir(executable)
+		} else {
+			AppDir = appdir.New("xbvr").UserConfig()
 		}
-
-		AppDir = filepath.Dir(executable)
 	} else {
-		AppDir = appdir.New("xbvr").UserConfig()
+		AppDir = *app_dir
 	}
 
-	CacheDir = filepath.Join(AppDir, "cache")
+	CacheDir = getPath(*cache_dir, "XBVR_CACHEDIR", "cache")
 	BinDir = filepath.Join(AppDir, "bin")
-	ImgDir = filepath.Join(AppDir, "imageproxy")
+	ImgDir = getPath(*imgproxy_dir, "XBVR_IMAGEPROXYDIR", "imageproxy")
 	MetricsDir = filepath.Join(AppDir, "metrics")
 	HeatmapDir = filepath.Join(AppDir, "heatmap")
-	IndexDirV2 = filepath.Join(AppDir, "search-v2")
+	IndexDirV2 = getPath(*search_dir, "XBVR_SEARCHDIR", "search-v2")
 
 	ScrapeCacheDir = filepath.Join(CacheDir, "scrape_cache")
 
-	VideoPreviewDir = filepath.Join(AppDir, "video_preview")
+	VideoPreviewDir = getPath(*preview_dir, "XBVR_VIDEOPREVIEWDIR", "video_preview")
 	VideoThumbnailDir = filepath.Join(AppDir, "video_thumbnail")
-	ScriptHeatmapDir = filepath.Join(AppDir, "script_heatmap")
+	ScriptHeatmapDir = getPath(*scriptsheatmap_dir, "XBVR_SCRIPTHEATMAPDIR", "script_heatmap")
 
 	DownloadDir = filepath.Join(AppDir, "download")
 
 	// Initialize DATABASE_URL once appdir path is known
-	if EnvConfig.DatabaseURL != "" {
-		DATABASE_URL = EnvConfig.DatabaseURL
+	if *databaseurl != "" {
+		DATABASE_URL = *databaseurl
 	} else {
-		DATABASE_URL = fmt.Sprintf("sqlite:%v", filepath.Join(AppDir, "main.db"))
+		if EnvConfig.DatabaseURL != "" {
+			DATABASE_URL = EnvConfig.DatabaseURL
+		} else {
+			DATABASE_URL = fmt.Sprintf("sqlite:%v", filepath.Join(AppDir, "main.db"))
+		}
+	}
+
+	if *web_port != 0 {
+		WebPort = *web_port
+	} else {
+		WebPort = EnvConfig.WebPort
+	}
+	if *ws_addr != "" {
+		WsAddr = *ws_addr
+	} else {
+		if EnvConfig.WsAddr != "" {
+			WsAddr = EnvConfig.WsAddr
+		}
 	}
 
 	_ = os.MkdirAll(AppDir, os.ModePerm)
@@ -85,4 +121,13 @@ func InitPaths() {
 	_ = os.MkdirAll(ScrapeCacheDir, os.ModePerm)
 	_ = os.MkdirAll(ScriptHeatmapDir, os.ModePerm)
 	_ = os.MkdirAll(DownloadDir, os.ModePerm)
+}
+func getPath(commandLinePath string, environmentName string, directoryName string) string {
+	if commandLinePath != "" {
+		return commandLinePath
+	}
+	if os.Getenv(environmentName) != "" {
+		return os.Getenv(environmentName)
+	}
+	return filepath.Join(AppDir, directoryName)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,6 +167,10 @@ func LoadConfig() {
 		if err := json.Unmarshal([]byte(obj.Value), &Config); err != nil {
 			common.Log.Error("Failed to load config from database")
 		}
+		if common.WebPort != 0 && common.WebPort != Config.Server.Port {
+			Config.Server.Port = common.WebPort
+			SaveConfig()
+		}
 	}
 }
 

--- a/ui/src/Socket.vue
+++ b/ui/src/Socket.vue
@@ -30,8 +30,7 @@ export default {
       onReconnectSuccess: () => {
         this.wsStatus = 'connected'
       }
-    })
-    console.log("wampy ", ws)
+    })    
 
     ws.subscribe('service.log', (dataArr, dataObj) => {
       if (dataArr.argsDict.level == 'debug') {

--- a/ui/src/Socket.vue
+++ b/ui/src/Socket.vue
@@ -31,6 +31,7 @@ export default {
         this.wsStatus = 'connected'
       }
     })
+    console.log("wampy ", ws)
 
     ws.subscribe('service.log', (dataArr, dataObj) => {
       if (dataArr.argsDict.level == 'debug') {


### PR DESCRIPTION
The following items and now configurable at runtime.  

Command Switch/Environment variable - Description

- app_dir/XBVR_APPDIR - base XBVR directory
- cache_dir/XBVR_CACHEDIR - tempoary cache for scrapers
- imgproxy_dir/XBVR_IMAGEPROXYDIR - internal image proxy location
- search_dir/XBVR_SEARCHDIR - Search Index location
- preview_dir/XBVR_VIDEOPREVIEWDIR - Video preview files
- scripts_heatmap_dir/XBVR_SCRIPTHEATMAPDIR - Heatmap images
- database_url/DATABASE_URL (existing) - database connection string
- web_port/XBVR_WS_ADDR - Web Page port, note using this will update the setting in the db
- ws_addr/XBVR_WEB_PORT - Web Service port 9998

These changes are primarily of use to help with Development environments.  However, they may be useful to other users e.g. overriding the default directory location, can help manage space, e.g., on Windows the default location is the system drive.  Overriding individual directories can also allow sharing directories between multiple instances, eg developers could override the Video Preview directory to share a single preview directory between multiple development instances.

The Web Service port is now configurable to allow multiple instances of XBVR on a platform, eg Windows, not really required if using Dockers. Overriding the default APPDIR also helps run multiple instances.

All switches are Optional. Run Command take priority over Environment variables, which take priority over database settings (where applicable)
Example run command: c:\xbvr\xbvr.exe -app_dir "D:\xbvr_dev1" -web_port 9980 -ws_addr 0.0.0.0:9981 -database_url "mysql://root:password@192.168.1.1:3306/xbvr_dev1?charset=utf8mb4&parseTime=True&loc=Local"
