### PR TITLE
Add option to show heatmaps in the scene list

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -56,6 +56,7 @@ type RequestSaveOptionsWeb struct {
 	ShowHspFile       bool   `json:"showHspFile"`
 	ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
 	SceneTrailerlist  bool   `json:"sceneTrailerlist"`
+	ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
 	UpdateCheck       bool   `json:"updateCheck"`
 }
 
@@ -379,6 +380,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.ShowHspFile = r.ShowHspFile
 	config.Config.Web.ShowSubtitlesFile = r.ShowSubtitlesFile
 	config.Config.Web.SceneTrailerlist = r.SceneTrailerlist
+	config.Config.Web.ShowScriptHeatmap = r.ShowScriptHeatmap
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.SaveConfig()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,7 @@ type ObjectConfig struct {
 		ShowHspFile       bool   `default:"true" json:"showHspFile"`
 		ShowSubtitlesFile bool   `default:"true" json:"showSubtitlesFile"`
 		SceneTrailerlist  bool   `default:"true" json:"sceneTrailerlist"`
+		ShowScriptHeatmap bool   `default:"true" json:"showScriptHeatmap"`
 		UpdateCheck       bool   `default:"true" json:"updateCheck"`
 	} `json:"web"`
 	Advanced struct {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -24,6 +24,7 @@ type ObjectState struct {
 		ShowHspFile       bool   `json:"showHspFile"`
 		ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
 		SceneTrailerlist  bool   `json:"sceneTrailerlist"`
+		ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
 		UpdateCheck       bool   `json:"updateCheck"`
 	} `json:"web"`
 	DLNA struct {

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -15,6 +15,7 @@ const state = {
     showHspFile: true,
     showSubtitlesFile: true,
     sceneTrailerlist: true,
+    showScriptHeatmap: false,
     updateCheck: true
   }
 }
@@ -39,6 +40,7 @@ const actions = {
         state.web.showHspFile = data.config.web.showHspFile
         state.web.showSubtitlesFile = data.config.web.showSubtitlesFile
         state.web.sceneTrailerlist = data.config.web.sceneTrailerlist
+        state.web.showScriptHeatmap = data.config.web.showScriptHeatmap
         state.web.updateCheck = data.config.web.updateCheck
         state.loading = false
       })
@@ -60,6 +62,7 @@ const actions = {
         state.web.showHspFile = data.showHspFile
         state.web.showSubtitlesFile = data.showSubtitlesFile
         state.web.sceneTrailerlist = data.sceneTrailerlist
+        state.web.showScriptHeatmap = data.showScriptHeatmap
         state.web.updateCheck = data.updateCheck
         state.loading = false
       })

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -75,6 +75,11 @@
                 show subtitles File button
               </b-switch>
             </b-field>
+            <b-field>
+              <b-switch v-model="ScriptHeatmap" type="is-dark">
+                show Script Heatmap
+              </b-switch>
+            </b-field>
 
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
@@ -166,6 +171,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.sceneEdit = value
+      }
+    },
+    ScriptHeatmap: {
+      get () {
+        return this.$store.state.optionsWeb.web.showScriptHeatmap
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showScriptHeatmap = value
       }
     },
     updateCheck: {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -163,10 +163,7 @@ export default {
       return `/api/dms/heatmap/${fileId}`
     },
     getFunscript () {
-      if (this.item.file !== null && this.item.file.slice().some(a => a.type === 'script')) {
-        return this.item.file.slice().find(a => a.type === 'script')
-      }
-      return
+      return this.item.file !== null && this.item.file.find(a => a.type === 'script' && a.has_heatmap);
     }
   }
 }

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -40,11 +40,11 @@
               <b-icon pack="mdi" icon="clock" size="is-small"/>
               {{item.duration}}m
             </b-tag>
-            <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap">
-              <div v-if="f = getFunscript()">
-                <div v-if="f.has_heatmap" class="heatmapFunscript">
-                  <img :src="getHeatmapURL(f.id)"/>
-                </div>
+          </div>
+          <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap" style="padding: 5px, padding-top: 0px">
+            <div v-if="f = getFunscript()" >
+              <div v-if="f.has_heatmap" class="heatmapFunscript">
+                <img :src="getHeatmapURL(f.id)"/>
               </div>
             </div>
           </div>
@@ -220,6 +220,8 @@ export default {
   .align-bottom-left {
     align-items: flex-end;
     justify-content: flex-end;
+    flex-wrap: wrap;
+    flex-direction: column
   }
 
   .bbox:after {
@@ -243,7 +245,6 @@ export default {
 .heatmapFunscript {
   width: auto;
   padding: 0;
-  margin-top: 0.25em;
   margin-left: 0.2em;
   margin-right: 0.2em;
 }

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -41,11 +41,9 @@
               {{item.duration}}m
             </b-tag>
           </div>
-          <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap" style="padding: 5px, padding-top: 0px">
-            <div v-if="f = getFunscript()" >
-              <div v-if="f.has_heatmap" class="heatmapFunscript">
-                <img :src="getHeatmapURL(f.id)"/>
-              </div>
+          <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap && (f = getFunscript())" style="padding: 0px 5px 5px">
+            <div v-if="f.has_heatmap" class="heatmapFunscript">
+              <img :src="getHeatmapURL(f.id)"/>
             </div>
           </div>
         </div>
@@ -244,19 +242,13 @@ export default {
 
 .heatmapFunscript {
   width: auto;
-  padding: 0;
-  margin-left: 0.2em;
-  margin-right: 0.2em;
 }
 
 .heatmapFunscript img {
   border: 1px #888 solid;
   width: 100%;
   height: 15px;
-  margin: 0;
-  padding: 0;
-  border-bottom-left-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem;
+  border-radius: 0.25rem;
 }
 
 </style>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -40,6 +40,13 @@
               <b-icon pack="mdi" icon="clock" size="is-small"/>
               {{item.duration}}m
             </b-tag>
+            <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap">
+              <div v-if="f = getFunscript()">
+                <div v-if="f.has_heatmap" class="heatmapFunscript">
+                  <img :src="getHeatmapURL(f.id)"/>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -153,6 +160,15 @@ export default {
         this.$store.commit('overlay/showDetails', { scene: scene })
       }
       this.$store.commit('overlay/hideActorDetails')
+    },
+    getHeatmapURL (fileId) {
+      return `/api/dms/heatmap/${fileId}`
+    },
+    getFunscript () {
+      if (this.item.file !== null && this.item.file.slice().some(a => a.type === 'script')) {
+        return this.item.file.slice().find(a => a.type === 'script')
+      }
+      return
     }
   }
 }
@@ -223,4 +239,23 @@ export default {
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+.heatmapFunscript {
+  width: auto;
+  padding: 0;
+  margin-top: 0.25em;
+  margin-left: 0.2em;
+  margin-right: 0.2em;
+}
+
+.heatmapFunscript img {
+  border: 1px #888 solid;
+  width: 100%;
+  height: 15px;
+  margin: 0;
+  padding: 0;
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
 </style>


### PR DESCRIPTION
Adds the funscript heatmaps to the scene list view if a funscript and a heatmap for it is available.
![Untitled](https://github.com/xbapps/xbvr/assets/148326204/08573844-f78d-4425-9208-b45c0806ee46)

Since this makes the list look way more cluttered I made it a toggleable option because not everyone might like it.

Reason for this is I like to have a quick overview of the funscripts I have and which scene/funscript combination looks worth getting without having to go through each detail view individually.  Not sure if this is a usecase for anyone else but I might aswell contribute.