### PR TITLE
Log Colly error massages

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -30,7 +30,7 @@ func createCollector(domains ...string) *colly.Collector {
 
 	// Set error handler
 	c.OnError(func(r *colly.Response, err error) {
-		log.Infof("Error visiting %s %s", r.Request.URL, err)
+		log.Errorf("Error visiting %s %s", r.Request.URL, err)
 	})
 
 	c = createCallbacks(c)

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -28,6 +28,11 @@ func createCollector(domains ...string) *colly.Collector {
 		colly.UserAgent(UserAgent),
 	)
 
+	// Set error handler
+	c.OnError(func(r *colly.Response, err error) {
+		log.Infof("Error visiting %s %s", r.Request.URL, err)
+	})
+
 	c = createCallbacks(c)
 	return c
 }


### PR DESCRIPTION
Log errors from colly scene scraper. 
Note: doesn't help if XBVR crashes before logging is reached

e.g.
SLR Studio now gone
time="2023-11-06T19:52:31+13:00" level=info msg="Error visiting https://www.sexlikereal.com/studios/mutiny-vr?sort=most_recent Not Found"

NaughtyAmerica captcha
time="2023-11-06T20:37:12+13:00" level=error msg="Error visiting https://www.naughtyamerica.com/vr-porn Method Not Allowed"