### PR TITLE
WetVR Scraper changes

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -1049,6 +1049,8 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 		tx = tx.Order("updated_at desc")
 	case "script_published_desc":
 		tx = tx.Order("script_published desc")
+	case "scene_id_desc":
+		tx = tx.Order("scene_id desc")
 	case "random":
 		if dbConn.Driver == "mysql" {
 			tx = tx.Order("rand()")

--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -2,8 +2,6 @@ package scrape
 
 import (
 	"encoding/json"
-	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,61 +22,57 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 	sceneCollector := createCollector("wetvr.com")
 	siteCollector := createCollector("wetvr.com")
 
-	// RegEx Patterns
-	durationRegEx := regexp.MustCompile(`(?i)DURATION:\W(\d+)`)
-
-	sceneCollector.OnHTML(`div#t2019`, func(e *colly.HTMLElement) {
+	sceneCollector.OnHTML(`div#trailer_player`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
 		sc.ScraperID = scraperID
 		sc.SceneType = "VR"
 		sc.Studio = "WetVR"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
-		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://wetvr.com/", "https://members.wetvr.com/", 1)
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://wetvr.com/", "https://wetvr.com/members/", 1)
 
 		// Scene ID - get from previous page
 		sc.SiteID = e.Request.Ctx.GetAny("scene-id").(string)
 		sc.SceneID = slugify.Slugify(sc.Site + "-" + sc.SiteID)
 
 		// Title
-		sc.Title = strings.TrimSpace(e.ChildText(`h1.t2019-stitle`))
+		sc.Title = strings.TrimSpace(e.ChildText(`div.scene-info h1`))
 
-		// Date
 		scenedate := e.Request.Ctx.GetAny("scene-date").(string)
 		if scenedate != "" {
-			tmpDate, _ := goment.New(scenedate, "MMMM DD, YYYY")
+			tmpDate, _ := goment.New(scenedate, "MM/DD/YYYY")
 			sc.Released = tmpDate.Format("YYYY-MM-DD")
 		}
 
-		// Duration
-		tmpDuration := durationRegEx.FindStringSubmatch(e.ChildText(`div#t2019-stime`))[1]
-		sc.Duration, _ = strconv.Atoi(tmpDuration)
-
 		// Cover URLs
-		coverSrc := e.ChildAttr(`div#t2019-video deo-video`, "cover-image")
+		coverSrc := e.ChildAttr(`div[id="player-wrapper"] deo-video`, "cover-image")
 		if coverSrc == "" {
-			coverSrc = e.ChildAttr(`div#t2019-video img#no-player-image`, "src")
+			coverSrc = strings.Split(e.ChildAttr(`div[id="no-player-wrapper"] div.bg-cover`, "style"), "background-image: url(")[1]
+			coverSrc = strings.TrimPrefix(coverSrc, "'")
+			coverSrc = strings.TrimSuffix(coverSrc, "')")
 		}
 		if coverSrc != "" {
 			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(coverSrc))
 		}
 
 		// Gallery
-		e.ForEach(`div.t2019-thumbs img`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div.items-center  a[href="/join" ] img`, func(id int, e *colly.HTMLElement) {
 			if id > 0 {
 				sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("src")))
 			}
 		})
 
 		// Synopsis
-		sc.Synopsis = strings.TrimSpace(e.ChildText(`div#t2019-description`))
+		sc.Synopsis = strings.TrimSpace(e.ChildText(`div.items-start span`))
 
 		// trailer details
-		sc.TrailerType = "deovr"
-		sc.TrailerSrc = strings.Replace(sc.HomepageURL, "/video/", "/deovr/", 1)
+		sc.TrailerType = "scrape_html"
+		params := models.TrailerScrape{SceneUrl: sc.HomepageURL, HtmlElement: "deo-video source", ContentPath: "src", QualityPath: "quality"}
+		strParams, _ := json.Marshal(params)
+		sc.TrailerSrc = string(strParams)
 
 		// Cast
-		e.ForEach(`div#t2019-models a`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`a[href^="/models/"]`, func(id int, e *colly.HTMLElement) {
 			sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
 		})
 
@@ -86,17 +80,21 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		// no tags on this site
 
 		// Filenames
-		// NOTE: no way to guess filename
+		baseFilename := strings.TrimPrefix(sc.HomepageURL, "https://wetvr.com/video/")
+		sc.Filenames = append(sc.Filenames, "wetvr-"+baseFilename+"-2700.mp4")
+		sc.Filenames = append(sc.Filenames, "wetvr-"+baseFilename+"-2048.mp4")
+		sc.Filenames = append(sc.Filenames, "wetvr-"+baseFilename+"-1600.mp4")
+		sc.Filenames = append(sc.Filenames, "wetvr-"+baseFilename+"-960.mp4")
 
 		out <- sc
 	})
 
-	siteCollector.OnHTML(`ul.pagination a.page-link`, func(e *colly.HTMLElement) {
+	siteCollector.OnHTML(`ul a.page-link`, func(e *colly.HTMLElement) {
 		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
 		siteCollector.Visit(pageURL)
 	})
 
-	siteCollector.OnHTML(`div.card`, func(e *colly.HTMLElement) {
+	siteCollector.OnHTML(`div:has(p:contains("Latest")) div[id^="r-"]`, func(e *colly.HTMLElement) {
 		sceneURL := e.Request.AbsoluteURL(e.ChildAttr("a", "href"))
 
 		// If scene exist in database, there's no need to scrape
@@ -104,9 +102,14 @@ func WetVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 
 			// SceneID and release date are only available here on div.card
 			ctx := colly.NewContext()
-			ctx.Put("scene-id", e.Attr("data-video-id"))
-			ctx.Put("scene-date", e.Attr("data-date"))
-
+			ctx.Put("scene-id", strings.TrimPrefix(e.Attr("id"), "r-"))
+			// get the date if it exists
+			pDate := e.DOM.Find(`div.video-thumbnail-footer div>span`)
+			if pDate.Length() > 0 {
+				ctx.Put("scene-date", pDate.Text())
+			} else {
+				ctx.Put("scene-date", "")
+			}
 			sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
 		}
 	})

--- a/ui/src/views/scenes/Filters.vue
+++ b/ui/src/views/scenes/Filters.vue
@@ -56,6 +56,7 @@
             <option value="last_opened_desc">↓ {{ $t("Last viewed date") }}</option>
             <option value="last_opened_asc">↑ {{ $t("Last viewed date") }}</option>
             <option value="script_published_desc">↓ {{ $t("Published Script Added") }}</option>
+            <option value="scene_id_desc">↓ {{ $t("Scene Id") }}</option>
             <option value="random">↯ {{ $t("Random") }}</option>
           </select>
         </div>


### PR DESCRIPTION
Fixes #1477 
Fixes changes to WetVr site. 

Duration no longer appears to be available. 
The release date also only appears to be available on scenes published since Aug 2023, these were available a few days ago either, so the site maybe still changing, and hopefully older scenes will eventually get a Release Date back as well.  If a scene does not have a release date available, but your scene in XBVR did have already have one before the site changes, Refreshing/rescraping, does not appear to lose the Release Date you already have.

For new clean loads of WetVR where a lot of Release Dates are missing, I have added a Descending Sort based on Scene Id, this at least sequences scenes in release order.

Filenames should now be predictable.