### PR TITLE
Check Url doesn't already have the ContentBaseUrl prefix

### DIFF
--- a/pkg/api/trailers.go
+++ b/pkg/api/trailers.go
@@ -70,7 +70,7 @@ func ScrapeHtml(scrapeParams string) models.VideoSourceResponse {
 				origURLtmp := e.Attr(params.ContentPath)
 				quality := e.Attr(params.QualityPath)
 				if origURLtmp != "" {
-					if params.ContentBaseUrl != "" {
+					if params.ContentBaseUrl != "" && !strings.HasPrefix(origURLtmp, params.ContentBaseUrl) {
 						origURLtmp = params.ContentBaseUrl + origURLtmp
 					}
 					srcs = append(srcs, models.VideoSource{URL: origURLtmp, Quality: quality})
@@ -174,7 +174,7 @@ func extractFromJson(inputJson string, params models.TrailerScrape, srcs []model
 			if params.EncodingPath != "" {
 				encoding = gjson.Get(JsonMetadata, params.EncodingPath).String() + "-"
 			}
-			if params.ContentBaseUrl != "" {
+			if params.ContentBaseUrl != "" && !strings.HasPrefix(url, params.ContentBaseUrl) {
 				if params.ContentBaseUrl[len(params.ContentBaseUrl)-1:] == "/" && string(url[0]) == "/" {
 					url = params.ContentBaseUrl + url[1:]
 				} else {


### PR DESCRIPTION
Fixes an issue with VRLatina Trailers staring with https://https://

Some sources for Trailers don't always provide a full URL path.  An option (content_base_url) can be specified to prepend a literal string to make a full URL path.  Presumably, VRLatina now provides the full path and hence an extra https: preffix.

This fix checks the content_base_url does not already exist in the trailer URL scrapped.  This is a better approach than just changing the VRLatina trailer parameters and does not require a migration to fix existing trailers.