### PR TITLE
Fixes: Tmwvrnet Pagination

### DIFF
--- a/pkg/scrape/tmwvrnet.go
+++ b/pkg/scrape/tmwvrnet.go
@@ -99,9 +99,11 @@ func TmwVRnet(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		out <- sc
 	})
 
-	siteCollector.OnHTML(`div.pagination__element.next a`, func(e *colly.HTMLElement) {
-		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
-		siteCollector.Visit(pageURL)
+	siteCollector.OnHTML(`a.pagination-element__link`, func(e *colly.HTMLElement) {
+		if strings.Contains(e.Text, "Next") {
+			pageURL := e.Request.AbsoluteURL(e.Attr("href"))
+			siteCollector.Visit(pageURL)
+		}
 	})
 
 	siteCollector.OnHTML(`div.thumb-photo`, func(e *colly.HTMLElement) {


### PR DESCRIPTION
Fixes an issue with Tmwvrnet  scraper only scraping the first page of scenes.

Regular scraping on a system with all the scene from tmwvrnet will not show an issue, but a new system of loading tmwvrnet for the first time, you will only have 12 scenes.