### PR TITLE
Output StackTrace details For DB errors

### DIFF
--- a/pkg/common/debug.go
+++ b/pkg/common/debug.go
@@ -31,3 +31,9 @@ func getFrame(skipFrames int) runtime.Frame {
 
 	return frame
 }
+
+func GetStackTrace() string {
+	buf := make([]byte, 1<<32)
+	stackSize := runtime.Stack(buf, false)
+	return string(buf[:stackSize])
+}

--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -46,6 +46,7 @@ func SaveWithRetry(db *gorm.DB, i interface{}) error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 
@@ -72,6 +73,7 @@ func GetDB() (*gorm.DB, error) {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to connect to database ", err)
 	}
 

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/jinzhu/gorm"
 	"github.com/markphelps/optional"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type Actor struct {
@@ -111,6 +112,7 @@ func (i *Actor) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_aka.go
+++ b/pkg/models/model_aka.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type Aka struct {
@@ -34,6 +35,7 @@ func (i *Aka) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_file.go
+++ b/pkg/models/model_file.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type File struct {
@@ -63,6 +64,7 @@ func (f *File) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_playlist.go
+++ b/pkg/models/model_playlist.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 // Playlist data model
@@ -36,6 +37,7 @@ func (o *Playlist) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -48,6 +48,7 @@ func (o *SceneCuepoint) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 
@@ -147,6 +148,7 @@ func (i *Scene) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_site.go
+++ b/pkg/models/model_site.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type Site struct {
@@ -33,6 +34,7 @@ func (i *Site) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/thoas/go-funk"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type Tag struct {
@@ -30,6 +31,7 @@ func (t *Tag) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_taggroups.go
+++ b/pkg/models/model_taggroups.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
+	"github.com/xbapps/xbvr/pkg/common"
 )
 
 type TagGroup struct {
@@ -32,6 +33,7 @@ func (i *TagGroup) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 

--- a/pkg/models/model_volume.go
+++ b/pkg/models/model_volume.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/putdotio/go-putio"
+	"github.com/xbapps/xbvr/pkg/common"
 	"golang.org/x/oauth2"
 )
 
@@ -73,6 +74,7 @@ func (o *Volume) Save() error {
 	)
 
 	if err != nil {
+		log.Infof("%s", common.GetStackTrace())
 		log.Fatal("Failed to save ", err)
 	}
 


### PR DESCRIPTION
Adds a new function common.GetStackTrace() that returns a string with the current Call Stack details for debugging.

This has been added to the DB and model save functions.

Example:

time="2023-11-24T09:04:21+13:00" level=info msg="goroutine 1042 [running]:
github.com/xbapps/xbvr/pkg/common.GetStackTrace()
	F:/Projects/xbvr/xbvr/pkg/common/debug.go:37 +0x5a
github.com/xbapps/xbvr/pkg/models.SaveWithRetry(0xc00bd2c0d0, {0x7ff6144bdfe0, 0xc000a38840})
	F:/Projects/xbvr/xbvr/pkg/models/db.go:49 +0x117
github.com/xbapps/xbvr/pkg/models.SceneCreateUpdateFromExternal(_, {{0xc00998cf10, 0x9}, {0xc0009bb794, 0xa}, {0xc011be7f3a, 0x5}, {0x7ff61451bc08, 0x2}, {0xc012022f62, ...}, ...})
	F:/Projects/xbvr/xbvr/pkg/models/model_scene.go:442 +0x518
github.com/xbapps/xbvr/pkg/tasks.sceneDBWriter(0xc00934c660, 0xc00934c650, 0xc0104a24e0)
	F:/Projects/xbvr/xbvr/pkg/tasks/content.go:170 +0x3d8
created by github.com/xbapps/xbvr/pkg/tasks.Scrape
	F:/Projects/xbvr/xbvr/pkg/tasks/content.go:324 +0x8c5
"
time="2023-11-24T09:04:21+13:00" level=fatal msg="Failed to save All attempts fail:
#1: database is locked
#2: database is locked
#3: database is locked