### PR TITLE
feat: add option to show all heatmaps in scene list

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -56,6 +56,7 @@ type RequestSaveOptionsWeb struct {
 	ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
 	SceneTrailerlist  bool   `json:"sceneTrailerlist"`
 	ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
+	ShowAllHeatmaps   bool   `json:"showAllHeatmaps"`
 	UpdateCheck       bool   `json:"updateCheck"`
 	IsAvailOpacity    int    `json:"isAvailOpacity"`
 }
@@ -381,6 +382,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.ShowSubtitlesFile = r.ShowSubtitlesFile
 	config.Config.Web.SceneTrailerlist = r.SceneTrailerlist
 	config.Config.Web.ShowScriptHeatmap = r.ShowScriptHeatmap
+	config.Config.Web.ShowAllHeatmaps = r.ShowAllHeatmaps
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.Config.Web.IsAvailOpacity = r.IsAvailOpacity
 	config.SaveConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type ObjectConfig struct {
 		ShowSubtitlesFile bool   `default:"true" json:"showSubtitlesFile"`
 		SceneTrailerlist  bool   `default:"true" json:"sceneTrailerlist"`
 		ShowScriptHeatmap bool   `default:"true" json:"showScriptHeatmap"`
+		ShowAllHeatmaps   bool   `default:"false" json:"showAllHeatmaps"`
 		UpdateCheck       bool   `default:"true" json:"updateCheck"`
 		IsAvailOpacity    int    `default:"40" json:"isAvailOpacity"`
 	} `json:"web"`

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -25,6 +25,7 @@ type ObjectState struct {
 		ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
 		SceneTrailerlist  bool   `json:"sceneTrailerlist"`
 		ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
+		ShowAllHeatmaps   bool   `json:"showAllHeatmaps"`
 		UpdateCheck       bool   `json:"updateCheck"`
 		IsAvailOpacity    int    `json:"isAvailOpacity"`
 	} `json:"web"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -18,6 +18,7 @@ const state = {
     updateCheck: true,
     isAvailOpacity: 40,
     showScriptHeatmap: false,
+    showAllHeatmaps: false,
     updateCheck: true
   }
 }
@@ -43,6 +44,7 @@ const actions = {
         state.web.showSubtitlesFile = data.config.web.showSubtitlesFile
         state.web.sceneTrailerlist = data.config.web.sceneTrailerlist
         state.web.showScriptHeatmap = data.config.web.showScriptHeatmap
+        state.web.showAllHeatmaps = data.config.web.showAllHeatmaps
         state.web.updateCheck = data.config.web.updateCheck
         state.web.isAvailOpacity = data.config.web.isAvailOpacity        
         state.loading = false
@@ -66,6 +68,7 @@ const actions = {
         state.web.showSubtitlesFile = data.showSubtitlesFile
         state.web.sceneTrailerlist = data.sceneTrailerlist
         state.web.showScriptHeatmap = data.showScriptHeatmap
+        state.web.showAllHeatmaps = data.showAllHeatmaps
         state.web.updateCheck = data.updateCheck
         state.web.isAvailOpacity = data.isAvailOpacity        
         state.loading = false

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -80,6 +80,11 @@
                 show Script Heatmap
               </b-switch>
             </b-field>
+            <b-field v-if="ScriptHeatmap">
+              <b-switch v-model="AllHeatmaps" type="is-dark">
+                show All Heatmaps
+              </b-switch>
+            </b-field>
             <b-field label="Opacity of unavailable scenes">
               <div class="columns">
                 <div class="column is-two-thirds">
@@ -186,6 +191,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.showScriptHeatmap = value
+      }
+    },
+    AllHeatmaps: {
+      get () {
+        return this.$store.state.optionsWeb.web.showAllHeatmaps
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showAllHeatmaps = value
       }
     },
     updateCheck: {

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -41,9 +41,9 @@
               {{item.duration}}m
             </b-tag>
           </div>
-          <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap && (f = getFunscript())" style="padding: 0px 5px 5px">
-            <div v-if="f.has_heatmap" class="heatmapFunscript">
-              <img :src="getHeatmapURL(f.id)"/>
+          <div v-if="this.$store.state.optionsWeb.web.showScriptHeatmap && (files = getFunscripts(this.$store.state.optionsWeb.web.showAllHeatmaps))" style="padding: 0px 5px 5px">
+            <div v-if="files.length" class="heatmapFunscript">
+              <img v-for="file in files" :src="getHeatmapURL(file.id)"/>
             </div>
           </div>
         </div>
@@ -168,17 +168,21 @@ export default {
     getHeatmapURL (fileId) {
       return `/api/dms/heatmap/${fileId}`
     },
-    getFunscript() {
-      if (this.item.file !== null) {
-        let script;
-        if (script = this.item.file.find((a) => a.type === 'script' && a.has_heatmap && a.is_selected_script)) {
-          return script
+    getFunscripts (showAll) {
+      if (showAll) {
+        return this.item.file !== null && this.item.file.filter(a => a.type === 'script' && a.has_heatmap);
+      } else {
+        if (this.item.file !== null) {
+          let script;
+          if (script = this.item.file.find((a) => a.type === 'script' && a.has_heatmap && a.is_selected_script)) {
+            return [script]
+          }
+          if (script = this.item.file.find((a) => a.type === 'script' && a.has_heatmap)) {
+            return [script]
+          }
         }
-        if (script = this.item.file.find((a) => a.type === 'script' && a.has_heatmap)) {
-          return script
-        }
+        return false;
       }
-      return false;
     }
   }
 }


### PR DESCRIPTION
Add an option to show all script heatmaps in the scene list, rather than just the selected one.
Useful for multipart scenes that have a different funscript for each part.