### PR TITLE
Fix Adding a New Custom site for POVR

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -919,7 +919,7 @@ func (i ConfigResource) createCustomSite(req *restful.Request, resp *restful.Res
 		scraper := config.ScraperConfig{URL: r.Url, Name: r.Name, Company: r.Company, AvatarUrl: r.Avatar}
 		switch match[3] {
 		case "povr":
-			scrapers["povr"] = append(scrapers["povrr"], scraper)
+			scrapers["povr"] = append(scrapers["povr"], scraper)
 		case "sexlikereal":
 			scrapers["slr"] = append(scrapers["slr"], scraper)
 		case "vrphub":


### PR DESCRIPTION
If you add a new Custom Site for POVR via the Advanced/Create Custom Site, then existing Custom Sites for POVR will be deleted