### PR TITLE
Fixes VRSpy Trailers

### DIFF
--- a/pkg/api/trailers.go
+++ b/pkg/api/trailers.go
@@ -5,6 +5,8 @@ import (
 	"html"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"regexp"
 	"strings"
 
@@ -78,11 +80,12 @@ func ScrapeHtml(scrapeParams string) models.VideoSourceResponse {
 			} else {
 				//  extract match with regex expression if one was specified
 				re := regexp.MustCompile(params.ExtractRegex)
-				r := re.FindStringSubmatch(e.Text)
-				if len(r) > 0 {
-					if r[1] != "" {
-						srcs = append(srcs, models.VideoSource{URL: r[1], Quality: "unknown"})
-					}
+				results := re.FindAllStringSubmatch(e.Text, -1)
+				for _, result := range results {
+					parsedURL, _ := url.Parse(result[0])
+					filename := path.Base(parsedURL.Path)
+					baseFilename := strings.TrimSuffix(filename, path.Ext(filename))
+					srcs = append(srcs, models.VideoSource{URL: result[1], Quality: baseFilename})
 				}
 			}
 		})

--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -117,17 +117,11 @@ func VRSpy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		imageRegex := regexp.MustCompile(regexp.QuoteMeta(cdnSceneURL.String()) + `/photos/[^?"]*\.jpg`)
 		sc.Gallery = imageRegex.FindAllString(nuxtData, -1)
 
-		sc.TrailerType = "urls"
-		params := models.VideoSourceResponse{}
-		trailersRegex := regexp.MustCompile(regexp.QuoteMeta(cdnSceneURL.String()) + `/trailers/([^?"]*)\.mp4`)
-		for _, trailer := range trailersRegex.FindAllStringSubmatch(nuxtData, -1) {
-			params.VideoSources = append(params.VideoSources, models.VideoSource{
-				URL:     trailer[0],
-				Quality: trailer[1],
-			})
-		}
-		strParams, _ := json.Marshal(params)
-		sc.TrailerSrc = string(strParams)
+		// trailer details
+		sc.TrailerType = "scrape_html"
+		paramsdata := models.TrailerScrape{SceneUrl: sc.HomepageURL, HtmlElement: "script[id=\"__NUXT_DATA__\"]", ExtractRegex: `(https:\/\/cdn.vrspy.com\/videos\/\d*\/trailers\/\dk\.mp4\?token.*?)"`}
+		jsonStr, _ := json.Marshal(paramsdata)
+		sc.TrailerSrc = string(jsonStr)
 
 		out <- sc
 	})


### PR DESCRIPTION
VRSpy trailers now require a token and expiry query parameter, the old ones now return Forbidden.

This changes from a static URL list to use the scrape_html function that will get the URL at runtime.

I have also changed the scrape_html function, so when using a regex expression to get the urls, it will add all url matches, rather than just the first one.