### PR TITLE
Search Changes

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -578,6 +578,20 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 
 	db, _ := models.GetDB()
 	defer db.Close()
+	var scenes []models.Scene
+
+	if strings.HasPrefix(q, "http") {
+		// if searching for a link, see if it is in the external ref table for scene alternate source
+		var scene models.Scene
+		splits := strings.Split(q, "?")
+		q = splits[0]
+
+		// see if the url matches a scrapped scene
+		scene.GetIfExistURL(q)
+		if scene.ID != 0 {
+			scenes = append(scenes, scene)
+		}
+	}
 
 	idx, err := tasks.NewIndex("scenes")
 	if err != nil {
@@ -600,7 +614,6 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 		return
 	}
 
-	var scenes []models.Scene
 	for _, v := range searchResults.Hits {
 		var scene models.Scene
 		err := scene.GetIfExist(v.ID)

--- a/ui/src/QuickFind.vue
+++ b/ui/src/QuickFind.vue
@@ -10,10 +10,10 @@
       <b-taglist>
         <b-tag class="tag is-info is-small">{{$t('Search Fields')}}</b-tag>
         <b-tooltip :label="$t('Optional: select one or more words to target searching to a specific field')" :delay="500" position="is-top">
-          <b-button @click='searchPrefix("title:")' class="tag is-info is-small is-light">title:</b-button>
+          <b-button @click='searchPrefix("+title:")' class="tag is-info is-small is-light">title:</b-button>
           <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
-          <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
-          <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+          <b-button @click='searchPrefix("+site:")' class="tag is-info is-small is-light">site:</b-button>
+          <b-button @click='searchPrefix("+id:")' class="tag is-info is-small is-light">id:</b-button>
         </b-tooltip>&nbsp;
         <b-tooltip :label="$t('Add file duration to search')" :delay="500" position="is-top">
           <b-button @click='searchDurationPrefix("duration:")' class="tag is-info is-small is-light">duration:</b-button>

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -30,10 +30,10 @@
             <b-taglist>
               <b-tag class="tag is-info is-small">{{$t('Search Fields')}}</b-tag>
               <b-tooltip :label="$t('Optional: select one or more words to target searching to a specific field')" :delay="500" position="is-top">
-                <b-button @click='searchPrefix("title:")' class="tag is-info is-small is-light">title:</b-button>
+                <b-button @click='searchPrefix("+title:")' class="tag is-info is-small is-light">title:</b-button>
                 <b-button @click='searchPrefix("cast:")' class="tag is-info is-small is-light">cast:</b-button>
-                <b-button @click='searchPrefix("site:")' class="tag is-info is-small is-light">site:</b-button>
-                <b-button @click='searchPrefix("id:")' class="tag is-info is-small is-light">id:</b-button>
+                <b-button @click='searchPrefix("+site:")' class="tag is-info is-small is-light">site:</b-button>
+                <b-button @click='searchPrefix("+id:")' class="tag is-info is-small is-light">id:</b-button>
               </b-tooltip>&nbsp;
               <b-tooltip :label="$t('Add file duration to search')" :delay="500" position="is-top">
                 <b-button @click='searchDurationPrefix("duration:")' class="tag is-info is-small is-light">duration:</b-button>


### PR DESCRIPTION
When using the field prefixes, id:, title: and site: the prefixes will now have a + before them, indicating results must include that value.  Without a + the prefix just makes a significant boost to their ranking but still allows scenes matching other elements of the search query, e.g. if you were searching on title and cast, scenes for that cast member that didn't match the title can still show.  I think this is more in line with what people would be expecting is happening.

Other prefixes are not changed, there is a higher likelihood that they may not match exactly, e.g.

- duration may be rounded different, or the scene could have edits
- dates will almost certainly vary if you download from sites like slr, vrporn, etc
- cast members names can be different due to misspellings and akas

I have also added the ability to search for a scene by the scene URL.