### PR TITLE
Baberoticvr fixes & change

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1833,6 +1833,13 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0072-Update-Baberotica-Studio",
+			Migrate: func(tx *gorm.DB) error {
+				sql := `update scenes set studio = 'Baberotica' where site = 'BaberoticaVR' and studio <> 'Baberotica';`
+				return tx.Exec(sql).Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/baberoticavr.go
+++ b/pkg/scrape/baberoticavr.go
@@ -76,7 +76,7 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 	for _, row := range data {
 		sc := models.ScrapedScene{}
 		sceneURL := row[3]
-		if funk.ContainsString(knownScenes, sceneURL) {
+		if funk.ContainsString(knownScenes, sceneURL) && sceneURL != singleSceneURL {
 			continue
 		}
 
@@ -129,8 +129,6 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 				url := "https://baberoticavr.com/model/" + slug.Make(actor) + "/"
 				sc.ActorDetails[actor] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: url}
 			}
-			sc.Studio = actor
-			break
 		}
 
 		// trailer details

--- a/pkg/scrape/baberoticavr.go
+++ b/pkg/scrape/baberoticavr.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/gocolly/colly/v2"
 	"github.com/gosimple/slug"
 	"github.com/thoas/go-funk"
 	"github.com/xbapps/xbvr/pkg/models"
@@ -20,6 +21,15 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 	scraperID := "baberoticavr"
 	siteID := "BaberoticaVR"
 	logScrapeStart(scraperID, siteID)
+	additionalDetailCollector := createCollector("baberoticavr.com")
+
+	additionalDetailCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+		sc := e.Request.Ctx.GetAny("scene").(models.ScrapedScene)
+		e.ForEach(`div.videoinfo>p`, func(id int, e *colly.HTMLElement) {
+			sc.Synopsis = strings.TrimSpace(e.Text)
+		})
+		out <- sc
+	})
 
 	resp, err := resty.New().R().
 		SetHeader("User-Agent", UserAgent).
@@ -141,7 +151,9 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 			sc.SceneID = fmt.Sprintf("baberoticavr-%v", sc.SiteID)
 		}
 
-		out <- sc
+		ctx := colly.NewContext()
+		ctx.Put("scene", sc)
+		additionalDetailCollector.Request("GET", sc.HomepageURL, nil, ctx, nil)
 	}
 
 	if updateSite {
@@ -150,7 +162,6 @@ func BaberoticaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out
 	logScrapeFinished(scraperID, siteID)
 	return nil
 }
-
 func init() {
 	registerScraper("baberoticavr", "BaberoticaVR", "https://baberoticavr.com/wp-content/themes/baberoticavr/images/fav/android-chrome-192x192.png", "baberoticavr.com", BaberoticaVR)
 }


### PR DESCRIPTION
Fixes 2 issues:

- The Scene Studio is set to the Actors Name
- If you use the "Scrape a Single Scene function" but you already have the scene, it will not re-scrape it

New
Added description to the scraping.  Currently the scraper just reads a csv file to scrape scenes.  However, the description is blank and to get it requires scraping the scene detail web pages.  I would probably not scrape the description since it requires extra web page scrapes, however, the description will be beneficial for an upcoming PR.