### PR TITLE
Add JAVDatabase actor scraping

### DIFF
--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -1007,21 +1007,11 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		{Function: "DOMNextText"},
 	}})
 
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Native: func(e interface{}) []string {
-		html := e.(*colly.HTMLElement)
-		var value = "Female"
-
-		result := html.DOM.Find(`a[href*="_body_type=trans"]`)
-
-		if result.Length() > 0 {
-			value = "Transgender Female"
-		}
-
-		return []string{value}
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `a[href*="_body_type=trans"]`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "ConstantValue", Params: []string{"Transgender Female"}},
 	}})
 
 	scrapeRules.GenericActorScrapingConfig["javdatabase scrape"] = siteDetails
-
 }
 
 // Loads custom rules from actor_scrapers_examples.json

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -983,7 +983,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]:not([href^="https://pics.dmm.co.jp/digital/video/mdj010/"])`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
 		{Function: "AbsoluteUrl"},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography + div`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography > div`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `b:contains("Hair Color(s):") + a`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "birth_date", Selector: `b:contains("DOB:") + a`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "height", Selector: `b:contains("Height:") + a`, ResultType: "text", PostProcessing: []PostProcessing{

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -1011,8 +1011,17 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		{Function: "DOMNextText"},
 	}})
 
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `a[href*="_body_type=trans1"]`, ResultType: "text", PostProcessing: []PostProcessing{
-		{Function: "ConstantValue", Params: []string{"Transgender Female"}},
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Native: func(e interface{}) []string {
+		html := e.(*colly.HTMLElement)
+		var value = "Female"
+
+		result := html.DOM.Find(`a[href*="_body_type=trans"]`)
+
+		if result.Length() > 0 {
+			value = "Transgender Female"
+		}
+
+		return []string{value}
 	}})
 
 	scrapeRules.GenericActorScrapingConfig["javdatabase scrape"] = siteDetails

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -12,7 +12,6 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/gocolly/colly/v2"
 	"github.com/markphelps/optional"
-	"github.com/sirupsen/logrus"
 
 	"github.com/xbapps/xbvr/pkg/common"
 )
@@ -69,7 +68,6 @@ type GenericActorScraperRule struct {
 	Last           optional.Int     `json:"last"`            // used to limit how many results you want, the end position you want
 	ResultType     string           `json:"result_type"`     // how to treat the result, text, attribute value, json
 	Attribute      string           `json:"attribute"`       // name of the atribute you want
-	DefaultValue   string
 }
 type PostProcessing struct {
 	Function string                  `json:"post_processing"` // call routines for specific handling, eg dates, json extracts
@@ -246,8 +244,6 @@ func (o *ExternalReference) DetermineActorScraperByUrl(url string) string {
 	if len(match) >= 3 {
 		site = match[3]
 	}
-
-	log.Logln(logrus.InfoLevel, "TEST:"+site)
 
 	switch site {
 	case "stashdb":
@@ -984,7 +980,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `img[data-src^="https://www.javdatabase.com/idolimages/full/"]`, ResultType: "attr", Attribute: "data-src", PostProcessing: []PostProcessing{
 		{Function: "AbsoluteUrl"},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]:not([href^="https://pics.dmm.co.jp/digital/video/mdj010/"])`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
 		{Function: "AbsoluteUrl"},
 	}})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography > div:first-of-type`, ResultType: "text"})
@@ -1025,6 +1021,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	}})
 
 	scrapeRules.GenericActorScrapingConfig["javdatabase scrape"] = siteDetails
+
 }
 
 // Loads custom rules from actor_scrapers_examples.json

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -983,27 +983,27 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]:not([href^="https://pics.dmm.co.jp/digital/video/mdj010/"])`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
 		{Function: "AbsoluteUrl"},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography > div`, ResultType: "text"})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `b:contains("Hair Color(s):") + a`, ResultType: "text"})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "birth_date", Selector: `b:contains("DOB:") + a`, ResultType: "text"})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "height", Selector: `b:contains("Height:") + a`, ResultType: "text", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `div[id="biography"] > div`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `div > b:contains("Hair Color(s):") + a`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "birth_date", Selector: `div > b:contains("DOB:") + a`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "height", Selector: `div > b:contains("Height:") + a`, ResultType: "text", PostProcessing: []PostProcessing{
 		{Function: "RegexString", Params: []string{`\d+`, "0"}},
 	}})
 
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "band_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "band_size", Selector: `div > b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
 		{Function: "DOMNextText"},
 		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "1"}},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "cup_size", Selector: `b:contains("Cup:") + a`, ResultType: "text"})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "waist_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "cup_size", Selector: `div > b:contains("Cup:") + a`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "waist_size", Selector: `div > b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
 		{Function: "DOMNextText"},
 		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "2"}},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hip_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hip_size", Selector: `div > b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
 		{Function: "DOMNextText"},
 		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "3"}},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "aliases", Selector: `b:contains("Alt:")`, ResultType: "text", PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "aliases", Selector: `div > p > b:contains("Alt:")`, ResultType: "text", PostProcessing: []PostProcessing{
 		{Function: "DOMNextText"},
 	}})
 

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -69,6 +69,7 @@ type GenericActorScraperRule struct {
 	Last           optional.Int     `json:"last"`            // used to limit how many results you want, the end position you want
 	ResultType     string           `json:"result_type"`     // how to treat the result, text, attribute value, json
 	Attribute      string           `json:"attribute"`       // name of the atribute you want
+	DefaultValue   string
 }
 type PostProcessing struct {
 	Function string                  `json:"post_processing"` // call routines for specific handling, eg dates, json extracts
@@ -980,7 +981,12 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 
 	siteDetails = GenericScraperRuleSet{}
 	siteDetails.Domain = "www.javdatabase.com"
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `img[data-src^="https://www.javdatabase.com/idolimages/full/"]`, ResultType: "attr", Attribute: "data-src", PostProcessing: []PostProcessing{{Function: "AbsoluteUrl"}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `img[data-src^="https://www.javdatabase.com/idolimages/full/"]`, ResultType: "attr", Attribute: "data-src", PostProcessing: []PostProcessing{
+		{Function: "AbsoluteUrl"},
+	}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
+		{Function: "AbsoluteUrl"},
+	}})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography > div:first-of-type`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `b:contains("Hair Color(s):") + a`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "birth_date", Selector: `b:contains("DOB:") + a`, ResultType: "text"})
@@ -1001,24 +1007,12 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		{Function: "DOMNextText"},
 		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "3"}},
 	}})
-
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "ethnicity", Native: func(e interface{}) []string {
-		var value = "Japanese"
-		values := []string{value}
-
-		return values
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "aliases", Selector: `b:contains("Alt:")`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "DOMNextText"},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "nationality", Native: func(e interface{}) []string {
-		var value = "Japan"
-		values := []string{value}
 
-		return values
-	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Native: func(e interface{}) []string {
-		var value = "Female"
-		values := []string{value}
-
-		return values
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `a[href*="_body_type=trans1"]`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "ConstantValue", Params: []string{"Transgender Female"}},
 	}})
 
 	scrapeRules.GenericActorScrapingConfig["javdatabase scrape"] = siteDetails

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -983,7 +983,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "images", Selector: `a[href^="https://pics.dmm.co.jp/digital/video/"]:not([href^="https://pics.dmm.co.jp/digital/video/mdj010/"])`, ResultType: "attr", Attribute: "href", PostProcessing: []PostProcessing{
 		{Function: "AbsoluteUrl"},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography > div:first-of-type`, ResultType: "text"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `#biography + div`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `b:contains("Hair Color(s):") + a`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "birth_date", Selector: `b:contains("DOB:") + a`, ResultType: "text"})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "height", Selector: `b:contains("Height:") + a`, ResultType: "text", PostProcessing: []PostProcessing{
@@ -1007,8 +1007,9 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		{Function: "DOMNextText"},
 	}})
 
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `a[href*="_body_type=trans"]`, ResultType: "text", PostProcessing: []PostProcessing{
-		{Function: "ConstantValue", Params: []string{"Transgender Female"}},
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `div > p:contains("Tags")`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "SetWhenValueContains", Params: []string{"Trans", "Transgender Female"}},
+		{Function: "SetWhenValueNotContains", Params: []string{"Trans", "Female"}},
 	}})
 
 	scrapeRules.GenericActorScrapingConfig["javdatabase scrape"] = siteDetails

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/markphelps/optional"
 	"github.com/sirupsen/logrus"
-	dg "golang.org/x/net/html"
 
 	"github.com/xbapps/xbvr/pkg/common"
 )
@@ -989,95 +988,18 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		{Function: "RegexString", Params: []string{`\d+`, "0"}},
 	}})
 
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "band_size", Native: func(e interface{}) []string {
-		html := e.(*colly.HTMLElement)
-		var values []string
-
-		result := html.DOM.Find(`b:contains("Measurements:")`)
-
-		// not found
-		if result.Length() == 0 || result.Length() > 1 {
-			return values
-		}
-
-		m := result.Get(0)
-		mSibling := m.NextSibling
-
-		// not found
-		if mSibling == nil {
-			return values
-		}
-
-		// not found
-		if mSibling.Type != dg.TextNode {
-			return values
-		}
-
-		data := strings.Split(strings.TrimSpace(strings.TrimSuffix(mSibling.Data, " - ")), "-")
-		values = append(values, data[0])
-
-		return values
-	}, PostProcessing: []PostProcessing{
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "band_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "DOMNextText"},
 		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "1"}},
 	}})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "cup_size", Selector: `b:contains("Cup:") + a`, ResultType: "text"})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "waist_size", Native: func(e interface{}) []string {
-		html := e.(*colly.HTMLElement)
-		var values []string
-
-		result := html.DOM.Find(`b:contains("Measurements:")`)
-
-		// not found
-		if result.Length() == 0 || result.Length() > 1 {
-			return values
-		}
-
-		m := result.Get(0)
-		mSibling := m.NextSibling
-
-		// not found
-		if mSibling == nil {
-			return values
-		}
-
-		// not found
-		if mSibling.Type != dg.TextNode {
-			return values
-		}
-
-		data := strings.Split(strings.TrimSpace(strings.TrimSuffix(mSibling.Data, " - ")), "-")
-		values = append(values, data[1])
-
-		return values
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "waist_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "DOMNextText"},
+		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "2"}},
 	}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hip_size", Native: func(e interface{}) []string {
-		html := e.(*colly.HTMLElement)
-		var values []string
-
-		result := html.DOM.Find(`b:contains("Measurements:")`)
-
-		// not found
-		if result.Length() == 0 || result.Length() > 1 {
-			return values
-		}
-
-		m := result.Get(0)
-		mSibling := m.NextSibling
-
-		// not found
-		if mSibling == nil {
-			return values
-		}
-
-		// not found
-		if mSibling.Type != dg.TextNode {
-			return values
-		}
-
-		data := strings.Split(strings.TrimSpace(strings.TrimSuffix(mSibling.Data, " - ")), "-")
-		values = append(values, data[2])
-
-		return values
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hip_size", Selector: `b:contains("Measurements:")`, ResultType: "text", PostProcessing: []PostProcessing{
+		{Function: "DOMNextText"},
+		{Function: "RegexString", Params: []string{`(\d+)-(\d+)-(\d+)`, "3"}},
 	}})
 
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "ethnicity", Native: func(e interface{}) []string {

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -535,8 +535,6 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 			if nextSibling != nil && nextSibling.Type == textNodeType {
 				value = strings.TrimSpace(nextSibling.Data)
 			}
-		case "ConstantValue":
-			value = postprocessing.Params[0]
 		case "UnescapeString":
 			value = html.UnescapeString(value)
 		}

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/externalreference"
 	"github.com/xbapps/xbvr/pkg/models"
+	nethtml "golang.org/x/net/html"
 )
 
 type outputList struct {
@@ -524,7 +525,16 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 		case "CollyForEach":
 			value = getSubRuleResult(postprocessing.SubRule, htmlElement)
 		case "DOMNext":
-			value = strings.TrimSpace(htmlElement.DOM.Next().Text())
+			next := htmlElement.DOM.Next()
+			value = strings.TrimSpace(next.Text())
+		case "DOMNextText":
+			node := htmlElement.DOM.Get(0)
+			textNodeType := nethtml.TextNode
+			nextSibling := node.NextSibling
+
+			if nextSibling != nil && nextSibling.Type == textNodeType {
+				value = strings.TrimSpace(nextSibling.Data)
+			}
 		case "UnescapeString":
 			value = html.UnescapeString(value)
 		}

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -534,13 +534,39 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 			if nextSibling != nil && nextSibling.Type == textNodeType {
 				value = strings.TrimSpace(nextSibling.Data)
 			}
-		case "ConstantValue":
-			value = postprocessing.Params[0]
+		case "SetWhenValueContains":
+			searchValue := postprocessing.Params[0]
+			newValue := postprocessing.Params[1]
+
+			if strings.Contains(value, searchValue) {
+				value = newValue
+			}
+		case "SetWhenValueNotContains":
+			searchValue := postprocessing.Params[0]
+			newValue := postprocessing.Params[1]
+
+			if !strings.Contains(value, searchValue) {
+				value = newValue
+			}
 		case "UnescapeString":
 			value = html.UnescapeString(value)
 		}
 	}
 	return value
+}
+
+func substr(s string, start, end int) string {
+	counter, startIdx := 0, 0
+	for i := range s {
+		if counter == start {
+			startIdx = i
+		}
+		if counter == end {
+			return s[startIdx:i]
+		}
+		counter++
+	}
+	return s[startIdx:]
 }
 
 func getCountryCode(countryName string) string {

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -525,8 +525,7 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 		case "CollyForEach":
 			value = getSubRuleResult(postprocessing.SubRule, htmlElement)
 		case "DOMNext":
-			next := htmlElement.DOM.Next()
-			value = strings.TrimSpace(next.Text())
+			value = strings.TrimSpace(htmlElement.DOM.Next().Text())
 		case "DOMNextText":
 			node := htmlElement.DOM.Get(0)
 			textNodeType := nethtml.TextNode

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -535,6 +535,8 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 			if nextSibling != nil && nextSibling.Type == textNodeType {
 				value = strings.TrimSpace(nextSibling.Data)
 			}
+		case "ConstantValue":
+			value = postprocessing.Params[0]
 		case "UnescapeString":
 			value = html.UnescapeString(value)
 		}

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -534,6 +534,8 @@ func postProcessing(rule models.GenericActorScraperRule, value string, htmlEleme
 			if nextSibling != nil && nextSibling.Type == textNodeType {
 				value = strings.TrimSpace(nextSibling.Data)
 			}
+		case "ConstantValue":
+			value = postprocessing.Params[0]
 		case "UnescapeString":
 			value = html.UnescapeString(value)
 		}


### PR DESCRIPTION
This PR adds the functionality to scrape actors from JAVDatabase. The following XbvrFields will be populated:
- image_url
- images
- biography
- hair_color
- birth_date
- height
- band_size
- cup_size
- waist_size
- hip_size
- aliases
- gender
  - JAVDatabase only has female actors. But some of them are tagged as transgender. So I added a Native function which searches for the transgender tag. If found we return Transgender Female (as stashdb), otherwise Female

Also I added the post processing function "DOMNextText". It will try to locate the NextSibling, check if it is a text node and when yes extract the text.