### PR TITLE
VRHush site change

### DIFF
--- a/pkg/api/trailers.go
+++ b/pkg/api/trailers.go
@@ -156,7 +156,8 @@ func extractFromJson(inputJson string, params models.TrailerScrape, srcs []model
 	if params.RecordPath != "" {
 		u := gjson.Get(JsonMetadata, params.RecordPath)
 		u.ForEach(func(key, value gjson.Result) bool {
-			url := gjson.Get(value.String(), params.ContentPath).String()
+			url := params.ContentBaseUrl
+			url += gjson.Get(value.String(), params.ContentPath).String()
 			quality := gjson.Get(value.String(), params.QualityPath).String()
 			encoding := ""
 			if params.EncodingPath != "" {

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -597,20 +597,18 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 
 	siteDetails = GenericScraperRuleSet{}
 	siteDetails.Domain = "vrhush.com"
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `img[id="model-thumbnail"]`, ResultType: "attr", Attribute: "src", PostProcessing: []PostProcessing{{Function: "AbsoluteUrl"}}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `div[id="model-info-block"] p`})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "ethnicity", Selector: `ul.model-attributes li:contains("Ethnicity")`, PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`Ethnicity (.*)`, "1"}}}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "eye_color", Selector: `ul.model-attributes li:contains("Eye Color")`, PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`Eye Color (.*)`, "1"}}}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{
-		XbvrField: "height", Selector: `ul.model-attributes li:contains("Height")`,
-		PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`^(Height )(.+)`, "2"}}, {Function: "Feet+Inches to cm", Params: []string{`(\d+)\'(\d+)\"`, "1", "2"}}},
-	})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `ul.model-attributes li:contains("Gender")`, PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`Gender (.*)`, "1"}}}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `ul.model-attributes li:contains("Hair Color")`, PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`Hair Color (.*)`, "1"}}}})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{
-		XbvrField: "weight", Selector: `ul.model-attributes li:contains("Weight")`,
-		PostProcessing: []PostProcessing{{Function: "RegexString", Params: []string{`^(Weight )(.+)`, "2"}}, {Function: "lbs to kg"}},
-	})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "gender", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"props.pageProps.model.gender"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `.thumbnail img`, ResultType: "attr", Attribute: "src", PostProcessing: []PostProcessing{{Function: "AbsoluteUrl"}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "biography", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"props.pageProps.model.Bio"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "eye_color", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"props.pageProps.model.eyes"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"props.pageProps.model.hair"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "ethnicity", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"props.pageProps.model.race"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "height", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{
+		{Function: "jsonString", Params: []string{"props.pageProps.model.height"}},
+		{Function: "Feet+Inches to cm", Params: []string{`(\d+)\'(\d+)\"`, "1", "2"}}}})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "weight", Selector: `script[Id="__NEXT_DATA__"]`, PostProcessing: []PostProcessing{
+		{Function: "jsonString", Params: []string{"props.pageProps.model.weight"}},
+		{Function: "lbs to kg"}}})
 	scrapeRules.GenericActorScrapingConfig["vrhush scrape"] = siteDetails
 
 	siteDetails.Domain = "vrallure.com"
@@ -1137,6 +1135,13 @@ func (scrapeRules ActorScraperConfig) getSiteUrlMatchingRules() {
 	scrapeRules.StashSceneMatching["realjamvr"] = StashSiteConfig{
 		StashId: "2059fbf9-94fe-4986-8565-2a7cc199636a",
 		Rules:   []SceneMatchRule{{XbvrField: "scene_url", XbvrMatch: `(realjamvr.com)(.*)\/(\d*-?)([^\/]+)\/?$`, XbvrMatchResultPosition: 4, StashRule: `(realjamvr.com)(.*)\/(\d*-?)([^\/]+)\/?$`, StashMatchResultPosition: 4}},
+	}
+	scrapeRules.StashSceneMatching["vrhush"] = StashSiteConfig{
+		StashId: "c85a3d13-c1b9-48d0-986e-3bfceaf0afe5",
+		// ignores optional /vrh999_ from old urls
+		Rules: []SceneMatchRule{{XbvrField: "scene_url", XbvrMatch: `\/([^\/]+)$`, XbvrMatchResultPosition: 4, StashRule: `\/((vrh\d+)_)?([^\/?]+)(?:\?.*)?$`, StashMatchResultPosition: 3}, // handle trailing query params
+			{XbvrField: "scene_url", XbvrMatch: `\/([^\/]+)$`, XbvrMatchResultPosition: 4, StashRule: `\/((vrh\d+)_)?([^\/?]+)(?:_180.*)?$`, StashMatchResultPosition: 3}, // handle _180 suffix now gone from urls
+		},
 	}
 	scrapeRules.StashSceneMatching["sexbabesvr"] = StashSiteConfig{
 		StashId: "b80d419c-4a81-44c9-ae79-d9614dd30351",

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -80,7 +80,7 @@ func GenericActorScrapers() {
 	db.Raw(sqlcmd).Scan(&output)
 
 	var wg sync.WaitGroup
-	concurrentLimit := 20 // Maximum number of concurrent tasks
+	concurrentLimit := 10 // Maximum number of concurrent tasks
 
 	semaphore = make(chan struct{}, concurrentLimit)
 	actorSemMap := make(map[uint]chan struct{})


### PR DESCRIPTION
Replacement VRHush scraper for new site.

Note: Scene URLs on the site have all been changed, the Scene Id is also no longer in the URL.  This means the first time running the scraper, it will think all scenes need scraping as the URL will not existing in an existing XBVR database.  The Scene Ids still match so the existing scene will be updated with the new URL.  The old URL are redirected by the site to the new location.

The new URLs use the scene title. VRHush have a lot of duplicate titles (due to POV/Voyeur/Anal variants for a lot of scenes), all are listed on their site, but the links only take you to one scene.  Therefore, if you do a full scan with an empty database, you will get less scenes than before.

A few fields were missing from the Web pages, however, the pages have a script tag with a dump of Json data that is very complete, so most fields are now populated from the Json data.  This applies for scraping from the VRHush actor profile pages.  

Paging the scene list seems to be done in JS, rather than a URL link.  So, I loop through bumping the page number manually and stop when the Next Page button is disabled.

There was an oversight with the existing VRHush scraper not linking with Stashdb.  I have fixed this, but it will be of little value for old scenes, since the URL are completely different now.

Trailers play, but do seem to stutter a lot in Hereshpere for me, but do play.

Also, fixed a bug where using the scrape_json method for trailer did not add the ContentBaseUrl when provided.
I have also dropped the number of concurrent Actor scrapes from 20 to 10, I have seen occasional timeouts in testing, this effects all actor site scrapes.