### PR TITLE
Add Index for scene_id and Url column size changes

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -756,6 +756,17 @@ func Migrate() {
 				return tx.AutoMigrate(File{}).Error
 			},
 		},
+		{
+			ID: "0073-scene-_id-index-plus-columns_size_changes",
+			Migrate: func(tx *gorm.DB) error {
+				type Scene struct {
+					SceneID  string `gorm:"index" json:"scene_id" xbvrbackup:"scene_id"`
+					CoverURL string `gorm:"size:500" json:"cover_url" xbvrbackup:"cover_url"`
+					SceneURL string `gorm:"size:500" json:"scene_url" xbvrbackup:"scene_url"`
+				}
+				return tx.AutoMigrate(&Scene{}).Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -61,7 +61,7 @@ type Scene struct {
 	UpdatedAt time.Time  `json:"updated_at" xbvrbackup:"updated_at"`
 	DeletedAt *time.Time `sql:"index" json:"-" xbvrbackup:"-"`
 
-	SceneID         string    `json:"scene_id" xbvrbackup:"scene_id"`
+	SceneID         string    `gorm:"index" json:"scene_id" xbvrbackup:"scene_id"`
 	Title           string    `json:"title" sql:"type:varchar(1024);" xbvrbackup:"title"`
 	SceneType       string    `json:"scene_type" xbvrbackup:"scene_type"`
 	ScraperId       string    `json:"scraper_id" xbvrbackup:"scraper_id"`
@@ -76,8 +76,8 @@ type Scene struct {
 	Synopsis        string    `json:"synopsis" sql:"type:text;" xbvrbackup:"synopsis"`
 	ReleaseDate     time.Time `json:"release_date" xbvrbackup:"release_date"`
 	ReleaseDateText string    `json:"release_date_text" xbvrbackup:"release_date_text"`
-	CoverURL        string    `json:"cover_url" xbvrbackup:"cover_url"`
-	SceneURL        string    `json:"scene_url" xbvrbackup:"scene_url"`
+	CoverURL        string    `gorm:"size:500" json:"cover_url" xbvrbackup:"cover_url"`
+	SceneURL        string    `gorm:"size:500" json:"scene_url" xbvrbackup:"scene_url"`
 	MemberURL       string    `json:"members_url" xbvrbackup:"members_url"`
 	IsMultipart     bool      `json:"is_multipart" xbvrbackup:"is_multipart"`
 


### PR DESCRIPTION
This changes adds an index to the scene_id on the scene table.
It also increases the size of the cover_url and scene_url

I added an index to the scene.scene_id when I first started using xbvr and loaded up every site with about 35-40K scenes (have since cut that back).  I had slow response that was solved by adding an index to scene_id in the scene table.  There didn't seem to be any need to submit it, but with recent reports of slow responses it may help.  Hard to know, as the reports didn't really provide much detail.  However, with plenty of queries with the scene_id, it is probably beneficial regardless.

The change also increases the sizes of cover_url and scene_url.  I had one case of each over the default column size limit in mysql.  They were both cases of just one character and they were one custom sites, so this isn't a big problem, although I think there has been one or two others with column size issues, so I have included them as well.