### PR TITLE
Fix  VRHush crashes getting filenames

### DIFF
--- a/pkg/scrape/vrhush.go
+++ b/pkg/scrape/vrhush.go
@@ -3,6 +3,8 @@ package scrape
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -43,41 +45,61 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		content := jsonResult["content"].(map[string]interface{})
 
 		// Scene ID - get from json scene code (url no longer has the code)
-		tmp := strings.Split(content["scene_code"].(string), "_")[0]
-		sc.SiteID = strings.Replace(tmp, "vrh", "", -1)
+		if _, ok := content["scene_code"]; ok {
+			tmp := strings.Split(content["scene_code"].(string), "_")[0]
+			sc.SiteID = strings.Replace(tmp, "vrh", "", -1)
+		} else {
+			log.Warnf("Unable to process %s - no scene code", e.Request.URL)
+			return
+		}
 		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
 
 		// Title / Cover
-		sc.Title = content["title"].(string)
-		sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(content["trailer_screencap"].(string)))
+		if _, ok := content["title"]; ok {
+			sc.Title = content["title"].(string)
+		}
+
+		if _, ok := content["trailer_screencap"]; ok {
+			sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(content["trailer_screencap"].(string)))
+		}
 
 		// Synopsis
-		sc.Synopsis = content["description"].(string)
+		if _, ok := content["description"]; ok {
+			sc.Synopsis = content["description"].(string)
+		}
 
 		// Tags
-		tagList := content["tags"].([]interface{})
-		for _, tag := range tagList {
-			sc.Tags = append(sc.Tags, tag.(string))
+		if _, ok := content["tags"]; ok {
+			tagList := content["tags"].([]interface{})
+			for _, tag := range tagList {
+				sc.Tags = append(sc.Tags, tag.(string))
+			}
 		}
 
 		// Cast
 		sc.ActorDetails = make(map[string]models.ActorDetails)
-		modelList := jsonResult["models"].([]interface{})
-		for _, model := range modelList {
-			modelMap, _ := model.(map[string]interface{})
-			if modelMap["gender"] == "Female" {
-				sc.Cast = append(sc.Cast, modelMap["name"].(string))
-				sc.ActorDetails[modelMap["name"].(string)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: "https://vrhush.com/models/" + modelMap["slug"].(string)}
+		if _, ok := content["models"]; ok {
+			modelList := jsonResult["models"].([]interface{})
+			for _, model := range modelList {
+				modelMap, _ := model.(map[string]interface{})
+				if modelMap["gender"] == "Female" {
+					sc.Cast = append(sc.Cast, modelMap["name"].(string))
+					sc.ActorDetails[modelMap["name"].(string)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: "https://vrhush.com/models/" + modelMap["slug"].(string)}
+				}
 			}
 		}
 
 		// Date & duration
-		tmpDate, _ := goment.New(content["publish_date"].(string), "YYYY/MM/DD")
-		sc.Released = tmpDate.Format("YYYY-MM-DD")
-		dur_str := content["videos_duration"].(string)
-		if dur_str != "" {
-			num, _ := strconv.ParseFloat(dur_str, 64)
-			sc.Duration = int(num / 60)
+		if _, ok := content["publish_date"]; ok {
+			tmpDate, _ := goment.New(content["publish_date"].(string), "YYYY/MM/DD")
+			sc.Released = tmpDate.Format("YYYY-MM-DD")
+		}
+		if _, ok := content["videos_duration"]; ok {
+			dur_str := content["videos_duration"].(string)
+			if dur_str != "" {
+				num, _ := strconv.ParseFloat(dur_str, 64)
+				sc.Duration = int(num / 60)
+			}
 		}
 		// trailer details
 
@@ -93,11 +115,21 @@ func VRHush(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sc.TrailerSrc = string(tmpjson)
 
 		// Filenames
-		videolList := content["videos"].(map[string]interface{})
-		for _, video := range videolList {
-			videoMap, _ := video.(map[string]interface{})
-			tmp := strings.Split(videoMap["file"].(string), "/")
-			sc.Filenames = append(sc.Filenames, tmp[len(tmp)-1])
+		if _, ok := content["videos"]; ok {
+			videolList := content["videos"].(map[string]interface{})
+			for _, video := range videolList {
+				videoMap, _ := video.(map[string]interface{})
+				if _, ok := videoMap["file"]; ok {
+					tmp := strings.Split(videoMap["file"].(string), "/")
+					sc.Filenames = append(sc.Filenames, tmp[len(tmp)-1])
+				} else {
+					if _, ok := videoMap["url"]; ok {
+						parsedURL, _ := url.Parse(videoMap["url"].(string))
+						baseName := path.Base(parsedURL.Path)
+						sc.Filenames = append(sc.Filenames, baseName)
+					}
+				}
+			}
 		}
 
 		out <- sc


### PR DESCRIPTION
Fixes VRHush crashing for some users.

For some it appears the file attribute in the json data is missing.  This causes XBVR to crash when it is referenced.

I have added checks to ensure it exists before using it. I have also made similar checks to other fields eg title, just in case if they have no value they aren't also missing, rather than existing with a bank value.