### PR TITLE
Too many connections

### DIFF
--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -710,10 +710,10 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 
 	var links []models.ExternalReferenceLink
 
-	db, _ := models.GetCommonDB()
+	commonDb, _ := models.GetCommonDB()
 
 	// find any links that were removed
-	db.Preload("ExternalReference").Where("internal_table = 'actors' and internal_db_id = ?", id).Find(&links)
+	commonDb.Preload("ExternalReference").Where("internal_table = 'actors' and internal_db_id = ?", id).Find(&links)
 	for _, link := range links {
 		found := false
 		for _, url := range urls {
@@ -723,7 +723,7 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 			}
 		}
 		if !found {
-			db.Delete(&link)
+			commonDb.Delete(&link)
 			models.AddActionActor(actor.ID, "edit_actor", "delete", "external_reference_link", link.ExternalReference.ExternalURL)
 		}
 	}

--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -710,8 +710,7 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 
 	var links []models.ExternalReferenceLink
 
-	db, _ := models.GetDB()
-	defer db.Close()
+	db, _ := models.GetCommonDB()
 
 	// find any links that were removed
 	db.Preload("ExternalReference").Where("internal_table = 'actors' and internal_db_id = ?", id).Find(&links)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -12,15 +12,16 @@ var (
 )
 
 type EnvConfigSpec struct {
-	Debug         bool   `envconfig:"DEBUG" default:"false"`
-	DebugRequests bool   `envconfig:"DEBUG_REQUESTS" default:"false"`
-	DebugSQL      bool   `envconfig:"DEBUG_SQL" default:"false"`
-	DebugWS       bool   `envconfig:"DEBUG_WS" default:"false"`
-	UIUsername    string `envconfig:"UI_USERNAME" required:"false"`
-	UIPassword    string `envconfig:"UI_PASSWORD" required:"false"`
-	DatabaseURL   string `envconfig:"DATABASE_URL" required:"false" default:""`
-	WsAddr        string `envconfig:"XBVR_WS_ADDR" required:"false" default:""`
-	WebPort       int    `envconfig:"XBVR_WEB_PORT" required:"false" default:"0"`
+	Debug                bool   `envconfig:"DEBUG" default:"false"`
+	DebugRequests        bool   `envconfig:"DEBUG_REQUESTS" default:"false"`
+	DebugSQL             bool   `envconfig:"DEBUG_SQL" default:"false"`
+	DebugWS              bool   `envconfig:"DEBUG_WS" default:"false"`
+	UIUsername           string `envconfig:"UI_USERNAME" required:"false"`
+	UIPassword           string `envconfig:"UI_PASSWORD" required:"false"`
+	DatabaseURL          string `envconfig:"DATABASE_URL" required:"false" default:""`
+	WsAddr               string `envconfig:"XBVR_WS_ADDR" required:"false" default:""`
+	WebPort              int    `envconfig:"XBVR_WEB_PORT" required:"false" default:"0"`
+	DBConnectionPoolSize int    `envconfig:"DB_CONNECTION_POOL_SIZE" required:"false" default:"0"`
 }
 
 var EnvConfig EnvConfigSpec

--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -23,6 +23,7 @@ var ScriptHeatmapDir string
 var MyFilesDir string
 var DownloadDir string
 var WebPort int
+var DBConnectionPoolSize int
 
 func DirSize(path string) (int64, error) {
 	var size int64
@@ -51,6 +52,7 @@ func InitPaths() {
 	databaseurl := flag.String("database_url", "", "Optional: override default database path")
 	web_port := flag.Int("web_port", 0, "Optional: override default Web Page port 9999")
 	ws_addr := flag.String("ws_addr", "", "Optional: override default Websocket address from the default 0.0.0.0:9998")
+	dB_connection_pool_size := flag.Int("dB_connection_pool_size", 0, "Optional: sets a limit to the number of db connections while scraping")
 
 	flag.Parse()
 
@@ -112,6 +114,11 @@ func InitPaths() {
 		if EnvConfig.WsAddr != "" {
 			WsAddr = EnvConfig.WsAddr
 		}
+	}
+	if *dB_connection_pool_size != 0 {
+		DBConnectionPoolSize = *dB_connection_pool_size
+	} else {
+		DBConnectionPoolSize = EnvConfig.DBConnectionPoolSize
 	}
 
 	_ = os.MkdirAll(AppDir, os.ModePerm)

--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -52,7 +52,7 @@ func InitPaths() {
 	databaseurl := flag.String("database_url", "", "Optional: override default database path")
 	web_port := flag.Int("web_port", 0, "Optional: override default Web Page port 9999")
 	ws_addr := flag.String("ws_addr", "", "Optional: override default Websocket address from the default 0.0.0.0:9998")
-	dB_connection_pool_size := flag.Int("dB_connection_pool_size", 0, "Optional: sets a limit to the number of db connections while scraping")
+	db_connection_pool_size := flag.Int("db_connection_pool_size", 0, "Optional: sets a limit to the number of db connections while scraping")
 
 	flag.Parse()
 
@@ -115,8 +115,8 @@ func InitPaths() {
 			WsAddr = EnvConfig.WsAddr
 		}
 	}
-	if *dB_connection_pool_size != 0 {
-		DBConnectionPoolSize = *dB_connection_pool_size
+	if *db_connection_pool_size != 0 {
+		DBConnectionPoolSize = *db_connection_pool_size
 	} else {
 		DBConnectionPoolSize = EnvConfig.DBConnectionPoolSize
 	}

--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"strings"
+	"time"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/jinzhu/gorm"
@@ -93,6 +94,7 @@ func GetCommonDB() (*gorm.DB, error) {
 		func() error {
 			commonConnection, err = gorm.Open(dbConn.Driver, dbConn.DSN)
 			commonConnection.LogMode(common.EnvConfig.DebugSQL)
+			commonConnection.DB().SetConnMaxIdleTime(4 * time.Minute)
 			if common.DBConnectionPoolSize > 0 {
 				commonConnection.DB().SetMaxOpenConns(common.DBConnectionPoolSize)
 			}

--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -16,6 +16,7 @@ import (
 var log = &common.Log
 var dbConn *dburl.URL
 var supportedDB = []string{"mysql", "sqlite3"}
+var commonConnection *gorm.DB
 
 func parseDBConnString() {
 	var err error
@@ -78,6 +79,37 @@ func GetDB() (*gorm.DB, error) {
 	return db, nil
 }
 
+func GetCommonDB() (*gorm.DB, error) {
+	if common.EnvConfig.DebugSQL {
+		log.Debug("Getting Common DB handle from ", common.GetCallerFunctionName())
+	}
+
+	var err error
+
+	if commonConnection != nil {
+		return commonConnection, nil
+	}
+	err = retry.Do(
+		func() error {
+			commonConnection, err = gorm.Open(dbConn.Driver, dbConn.DSN)
+			commonConnection.LogMode(common.EnvConfig.DebugSQL)
+			if common.DBConnectionPoolSize > 0 {
+				commonConnection.DB().SetMaxOpenConns(common.DBConnectionPoolSize)
+			}
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	)
+
+	if err != nil {
+		log.Fatal("Failed to connect to database ", err)
+	}
+
+	return commonConnection, nil
+}
+
 // Lock functions
 
 func CreateLock(lock string) {
@@ -127,4 +159,5 @@ func init() {
 	common.InitPaths()
 	common.InitLogging()
 	parseDBConnString()
+	GetCommonDB()
 }

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -97,8 +97,7 @@ type ActorLink struct {
 }
 
 func (i *Actor) Save() error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
@@ -118,8 +117,7 @@ func (i *Actor) Save() error {
 }
 
 func (i *Actor) CountActorTags() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	type CountResults struct {
 		ID            int
@@ -170,8 +168,7 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 	limit := r.Limit.OrElse(100)
 	offset := r.Offset.OrElse(0)
 
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var actors []Actor
 	tx := db.Model(&actors)
@@ -504,8 +501,7 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 }
 
 func (o *Actor) GetIfExist(id string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Scenes", func(db *gorm.DB) *gorm.DB {
@@ -515,8 +511,7 @@ func (o *Actor) GetIfExist(id string) error {
 }
 
 func (o *Actor) GetIfExistByPK(id uint) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Scenes", func(db *gorm.DB) *gorm.DB {
@@ -526,8 +521,7 @@ func (o *Actor) GetIfExistByPK(id uint) error {
 }
 
 func (o *Actor) GetIfExistByPKWithSceneAvg(id uint) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	tx := db.Model(&Actor{})
 	tx = tx.Select(`actors.*, 
@@ -631,8 +625,7 @@ func addToStringArray(inputArray string, newValue string) (string, bool) {
 
 func (a *Actor) CheckForSetImage() bool {
 	// check if the field was deleted by the user,
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 	var action ActionActor
 	db.Where("source = 'edit_actor' and actor_id = ? and changed_column = 'image_url' and action_type = 'setimage'", a.ID).Order("ID desc").First(&action)
 	return action.ID != 0
@@ -640,8 +633,7 @@ func (a *Actor) CheckForSetImage() bool {
 
 func (a *Actor) CheckForUserDeletes(fieldName string, newValue string) bool {
 	// check if the field was deleted by the user,
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 	var action ActionActor
 	db.Where("source = 'edit_actor' and actor_id = ? and changed_column = ? and new_value = ?", a.ID, fieldName, newValue).Order("ID desc").First(&action)
 	if action.ID != 0 && action.ActionType == "delete" {

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -97,11 +97,11 @@ type ActorLink struct {
 }
 
 func (i *Actor) Save() error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
-			err := db.Save(&i).Error
+			err := commonDb.Save(&i).Error
 			if err != nil {
 				return err
 			}
@@ -117,7 +117,7 @@ func (i *Actor) Save() error {
 }
 
 func (i *Actor) CountActorTags() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	type CountResults struct {
 		ID            int
@@ -129,7 +129,7 @@ func (i *Actor) CountActorTags() {
 
 	var results []CountResults
 
-	db.Model(&Actor{}).
+	commonDb.Model(&Actor{}).
 		Select("actors.id, count as existingcnt, count(*) cnt, sum(scenes.is_available ) is_available, avail_count as existingavail").
 		Group("actors.id").
 		Joins("join scene_cast on scene_cast.actor_id = actors.id").
@@ -139,7 +139,7 @@ func (i *Actor) CountActorTags() {
 	for i := range results {
 		var actor Actor
 		if results[i].Cnt != results[i].Existingcnt || results[i].IsAvailable != results[i].Existingavail {
-			db.First(&actor, results[i].ID)
+			commonDb.First(&actor, results[i].ID)
 			actor.Count = results[i].Cnt
 			actor.AvailCount = results[i].IsAvailable
 			actor.Save()
@@ -168,10 +168,10 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 	limit := r.Limit.OrElse(100)
 	offset := r.Offset.OrElse(0)
 
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var actors []Actor
-	tx := db.Model(&actors)
+	tx := commonDb.Model(&actors)
 
 	var out ResponseActorList
 
@@ -501,9 +501,9 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 }
 
 func (o *Actor) GetIfExist(id string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Scenes", func(db *gorm.DB) *gorm.DB {
 			return db.Where("is_hidden = 0")
 		}).
@@ -511,9 +511,9 @@ func (o *Actor) GetIfExist(id string) error {
 }
 
 func (o *Actor) GetIfExistByPK(id uint) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Scenes", func(db *gorm.DB) *gorm.DB {
 			return db.Where("is_hidden = 0")
 		}).
@@ -521,9 +521,9 @@ func (o *Actor) GetIfExistByPK(id uint) error {
 }
 
 func (o *Actor) GetIfExistByPKWithSceneAvg(id uint) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	tx := db.Model(&Actor{})
+	tx := commonDb.Model(&Actor{})
 	tx = tx.Select(`actors.*, 
 	(select AVG(s.star_rating) scene_avg from scene_cast sc join scenes s on s.id=sc.scene_id where sc.actor_id =actors.id and s.star_rating > 0 and is_hidden=0) as scene_rating_average`)
 
@@ -625,17 +625,17 @@ func addToStringArray(inputArray string, newValue string) (string, bool) {
 
 func (a *Actor) CheckForSetImage() bool {
 	// check if the field was deleted by the user,
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 	var action ActionActor
-	db.Where("source = 'edit_actor' and actor_id = ? and changed_column = 'image_url' and action_type = 'setimage'", a.ID).Order("ID desc").First(&action)
+	commonDb.Where("source = 'edit_actor' and actor_id = ? and changed_column = 'image_url' and action_type = 'setimage'", a.ID).Order("ID desc").First(&action)
 	return action.ID != 0
 }
 
 func (a *Actor) CheckForUserDeletes(fieldName string, newValue string) bool {
 	// check if the field was deleted by the user,
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 	var action ActionActor
-	db.Where("source = 'edit_actor' and actor_id = ? and changed_column = ? and new_value = ?", a.ID, fieldName, newValue).Order("ID desc").First(&action)
+	commonDb.Where("source = 'edit_actor' and actor_id = ? and changed_column = ? and new_value = ?", a.ID, fieldName, newValue).Order("ID desc").First(&action)
 	if action.ID != 0 && action.ActionType == "delete" {
 		return true
 	}

--- a/pkg/models/model_aka.go
+++ b/pkg/models/model_aka.go
@@ -20,11 +20,11 @@ type Aka struct {
 }
 
 func (i *Aka) Save() error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
-			err := db.Save(&i).Error
+			err := commonDb.Save(&i).Error
 			if err != nil {
 				return err
 			}
@@ -40,22 +40,22 @@ func (i *Aka) Save() error {
 }
 
 func (o *Aka) GetIfExistByPK(id uint) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Actors").
 		Where(&Aka{ID: id}).First(o).Error
 }
 
 func (o *Aka) UpdateAkaSceneCastRecords() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	// Queries to update the scene_cast table for the aka actor are comlex but fast.
 	//  Significating faster than iterating through the results of multiple simpler queries.
 	// 	The Raw Sql used is compatible between mysql & sqlite
 
 	// add missing scene_cast records for aka actors
-	db.Exec(`
+	commonDb.Exec(`
 	insert into scene_cast 
 	select distinct sc.scene_id, a.aka_actor_id 
 	from akas a 
@@ -66,7 +66,7 @@ func (o *Aka) UpdateAkaSceneCastRecords() {
 	`)
 
 	// delete scene_cast records for aka actors that have been removed
-	db.Exec(`
+	commonDb.Exec(`
 		with SceneIds as (
 			select distinct a.id, sc.scene_id
 			from akas a 
@@ -92,7 +92,7 @@ func (o *Aka) UpdateAkaSceneCastRecords() {
 }
 
 func (o *Aka) RefreshAkaActorNames() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	type SortedList struct {
 		AkaActorId uint
@@ -101,7 +101,7 @@ func (o *Aka) RefreshAkaActorNames() {
 	var sortedList []SortedList
 
 	// this update the aka names by reordering the actor names based on descending count
-	db.Raw(`
+	commonDb.Raw(`
 	with sorted as (
 		select a.aka_actor_id, a2.name, a2.count  from akas a 
 		join actor_akas aa on a.id =aa.aka_id 
@@ -114,7 +114,7 @@ func (o *Aka) RefreshAkaActorNames() {
 	for _, listItem := range sortedList {
 		var actor Actor
 		actor.ID = listItem.AkaActorId
-		db.Model(&actor).Where("name != ?", "aka:"+listItem.SortedName).Update("name", "aka:"+listItem.SortedName)
+		commonDb.Model(&actor).Where("name != ?", "aka:"+listItem.SortedName).Update("name", "aka:"+listItem.SortedName)
 	}
 }
 

--- a/pkg/models/model_aka.go
+++ b/pkg/models/model_aka.go
@@ -20,8 +20,7 @@ type Aka struct {
 }
 
 func (i *Aka) Save() error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
@@ -41,8 +40,7 @@ func (i *Aka) Save() error {
 }
 
 func (o *Aka) GetIfExistByPK(id uint) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Actors").
@@ -50,8 +48,7 @@ func (o *Aka) GetIfExistByPK(id uint) error {
 }
 
 func (o *Aka) UpdateAkaSceneCastRecords() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	// Queries to update the scene_cast table for the aka actor are comlex but fast.
 	//  Significating faster than iterating through the results of multiple simpler queries.
@@ -95,8 +92,7 @@ func (o *Aka) UpdateAkaSceneCastRecords() {
 }
 
 func (o *Aka) RefreshAkaActorNames() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	type SortedList struct {
 		AkaActorId uint

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -90,29 +90,25 @@ type SceneMatchRule struct {
 }
 
 func (o *ExternalReference) GetIfExist(id uint) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.Preload("XbvrLinks").Where(&ExternalReference{ID: id}).First(o).Error
 }
 
 func (o *ExternalReference) FindExternalUrl(externalSource string, externalUrl string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalURL: externalUrl}).First(o).Error
 }
 
 func (o *ExternalReference) FindExternalId(externalSource string, externalId string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalId: externalId}).First(o).Error
 }
 
 func (o *ExternalReference) Save() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
@@ -129,14 +125,12 @@ func (o *ExternalReference) Save() {
 }
 
 func (o *ExternalReference) Delete() {
-	db, _ := GetDB()
+	db, _ := GetCommonDB()
 	db.Delete(&o)
-	db.Close()
 }
 
 func (o *ExternalReference) AddUpdateWithUrl() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	existingRef := ExternalReference{ExternalSource: o.ExternalSource, ExternalURL: o.ExternalURL}
 	existingRef.FindExternalUrl(o.ExternalSource, o.ExternalURL)
@@ -166,8 +160,7 @@ func (o *ExternalReference) AddUpdateWithUrl() {
 }
 
 func (o *ExternalReference) AddUpdateWithId() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	existingRef := ExternalReference{ExternalSource: o.ExternalSource, ExternalId: o.ExternalId}
 	existingRef.FindExternalId(o.ExternalSource, o.ExternalId)
@@ -197,8 +190,7 @@ func (o *ExternalReference) AddUpdateWithId() {
 }
 
 func (o *ExternalReferenceLink) Save() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
@@ -215,8 +207,7 @@ func (o *ExternalReferenceLink) Save() {
 }
 
 func (o *ExternalReferenceLink) Find(externalSource string, internalName string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.Where(&ExternalReferenceLink{ExternalSource: externalSource, InternalNameId: internalName}).First(o).Error
 }
@@ -264,8 +255,7 @@ func (o *ExternalReference) DetermineActorScraperByUrl(url string) string {
 }
 
 func (o *ExternalReference) DetermineActorScraperBySiteId(siteId string) string {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var site Site
 	db.Where("id = ?", siteId).First(&site)
@@ -304,8 +294,7 @@ func (config ActorScraperConfig) loadActorScraperRules() {
 }
 
 func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 	var sites []Site
 
 	// To understand the regex used, sign up to chat.openai.com and just ask something like Explain (.*, )?(.*)$
@@ -1080,8 +1069,7 @@ func (scrapeRules ActorScraperConfig) getCustomRules() {
 }
 
 func (scrapeRules ActorScraperConfig) getSiteUrlMatchingRules() {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var sites []Site
 

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -90,29 +90,29 @@ type SceneMatchRule struct {
 }
 
 func (o *ExternalReference) GetIfExist(id uint) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.Preload("XbvrLinks").Where(&ExternalReference{ID: id}).First(o).Error
+	return commonDb.Preload("XbvrLinks").Where(&ExternalReference{ID: id}).First(o).Error
 }
 
 func (o *ExternalReference) FindExternalUrl(externalSource string, externalUrl string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalURL: externalUrl}).First(o).Error
+	return commonDb.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalURL: externalUrl}).First(o).Error
 }
 
 func (o *ExternalReference) FindExternalId(externalSource string, externalId string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalId: externalId}).First(o).Error
+	return commonDb.Preload("XbvrLinks").Where(&ExternalReference{ExternalSource: externalSource, ExternalId: externalId}).First(o).Error
 }
 
 func (o *ExternalReference) Save() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
-			err := db.Save(&o).Error
+			err := commonDb.Save(&o).Error
 			if err != nil {
 				return err
 			}
@@ -125,12 +125,12 @@ func (o *ExternalReference) Save() {
 }
 
 func (o *ExternalReference) Delete() {
-	db, _ := GetCommonDB()
-	db.Delete(&o)
+	commonDb, _ := GetCommonDB()
+	commonDb.Delete(&o)
 }
 
 func (o *ExternalReference) AddUpdateWithUrl() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	existingRef := ExternalReference{ExternalSource: o.ExternalSource, ExternalURL: o.ExternalURL}
 	existingRef.FindExternalUrl(o.ExternalSource, o.ExternalURL)
@@ -147,7 +147,7 @@ func (o *ExternalReference) AddUpdateWithUrl() {
 
 	err := retry.Do(
 		func() error {
-			err := db.Save(&o).Error
+			err := commonDb.Save(&o).Error
 			if err != nil {
 				return err
 			}
@@ -160,7 +160,7 @@ func (o *ExternalReference) AddUpdateWithUrl() {
 }
 
 func (o *ExternalReference) AddUpdateWithId() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	existingRef := ExternalReference{ExternalSource: o.ExternalSource, ExternalId: o.ExternalId}
 	existingRef.FindExternalId(o.ExternalSource, o.ExternalId)
@@ -177,7 +177,7 @@ func (o *ExternalReference) AddUpdateWithId() {
 
 	err := retry.Do(
 		func() error {
-			err := db.Save(&o).Error
+			err := commonDb.Save(&o).Error
 			if err != nil {
 				return err
 			}
@@ -190,11 +190,11 @@ func (o *ExternalReference) AddUpdateWithId() {
 }
 
 func (o *ExternalReferenceLink) Save() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	err := retry.Do(
 		func() error {
-			err := db.Save(&o).Error
+			err := commonDb.Save(&o).Error
 			if err != nil {
 				return err
 			}
@@ -207,9 +207,9 @@ func (o *ExternalReferenceLink) Save() {
 }
 
 func (o *ExternalReferenceLink) Find(externalSource string, internalName string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.Where(&ExternalReferenceLink{ExternalSource: externalSource, InternalNameId: internalName}).First(o).Error
+	return commonDb.Where(&ExternalReferenceLink{ExternalSource: externalSource, InternalNameId: internalName}).First(o).Error
 }
 
 func FormatInternalDbId(input uint) string {
@@ -255,10 +255,10 @@ func (o *ExternalReference) DetermineActorScraperByUrl(url string) string {
 }
 
 func (o *ExternalReference) DetermineActorScraperBySiteId(siteId string) string {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var site Site
-	db.Where("id = ?", siteId).First(&site)
+	commonDb.Where("id = ?", siteId).First(&site)
 	if site.Name == "" {
 		return siteId
 	}
@@ -294,7 +294,7 @@ func (config ActorScraperConfig) loadActorScraperRules() {
 }
 
 func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 	var sites []Site
 
 	// To understand the regex used, sign up to chat.openai.com and just ask something like Explain (.*, )?(.*)$
@@ -346,7 +346,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "aliases", Selector: `div[data-qa="model-info-aliases"] div.u-wh`})
 	scrapeRules.GenericActorScrapingConfig["slr-originals scrape"] = siteDetails
 	scrapeRules.GenericActorScrapingConfig["slr-jav-originals scrape"] = siteDetails
-	db.Where("name like ?", "%SLR)").Find(&sites)
+	commonDb.Where("name like ?", "%SLR)").Find(&sites)
 	scrapeRules.GenericActorScrapingConfig["slr scrape"] = siteDetails
 
 	siteDetails = GenericScraperRuleSet{}
@@ -1069,7 +1069,7 @@ func (scrapeRules ActorScraperConfig) getCustomRules() {
 }
 
 func (scrapeRules ActorScraperConfig) getSiteUrlMatchingRules() {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var sites []Site
 
@@ -1179,7 +1179,7 @@ func (scrapeRules ActorScraperConfig) getSiteUrlMatchingRules() {
 		Rules:   []SceneMatchRule{{XbvrField: "scene_url", XbvrMatch: `(lethalhardcorevr.com).*\/(\d{6,8})\/.*`, XbvrMatchResultPosition: 2, StashRule: `(lethalhardcorevr.com).*\/(\d{6,8})\/.*`, StashMatchResultPosition: 2}},
 	}
 
-	db.Where(&Site{IsEnabled: true}).Order("id").Find(&sites)
+	commonDb.Where(&Site{IsEnabled: true}).Order("id").Find(&sites)
 	for _, site := range sites {
 		if _, found := scrapeRules.StashSceneMatching[site.ID]; !found {
 			if strings.HasSuffix(site.Name, "SLR)") {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -34,8 +34,7 @@ type SceneCuepoint struct {
 }
 
 func (o *SceneCuepoint) Save() error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
@@ -133,8 +132,7 @@ type VideoSource struct {
 }
 
 func (i *Scene) Save() error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
@@ -162,8 +160,7 @@ func (i *Scene) FromJSON(data []byte) error {
 }
 
 func (o *Scene) GetIfExist(id string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Tags").
@@ -175,8 +172,7 @@ func (o *Scene) GetIfExist(id string) error {
 }
 
 func (o *Scene) GetIfExistByPK(id uint) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Tags").
@@ -188,8 +184,7 @@ func (o *Scene) GetIfExistByPK(id uint) error {
 }
 
 func (o *Scene) GetIfExistURL(u string) error {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	return db.
 		Preload("Tags").
@@ -215,8 +210,7 @@ func (o *Scene) GetFunscriptTitle() string {
 }
 
 func (o *Scene) GetFiles() ([]File, error) {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var files []File
 	db.Preload("Volume").Where(&File{SceneID: o.ID}).Find(&files)
@@ -225,8 +219,7 @@ func (o *Scene) GetFiles() ([]File, error) {
 }
 
 func (o *Scene) GetTotalWatchTime() int {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	totalResult := struct{ Total float64 }{}
 	db.Raw(`select sum(duration) as total from histories where scene_id = ?`, o.ID).Scan(&totalResult)
@@ -240,8 +233,7 @@ func (o *Scene) GetVideoFiles() ([]File, error) {
 }
 
 func (o *Scene) GetVideoFilesSorted(sort string) ([]File, error) {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var files []File
 	if sort == "" {
@@ -259,8 +251,7 @@ func (o *Scene) GetScriptFiles() ([]File, error) {
 }
 
 func (o *Scene) GetScriptFilesSorted(sort string) ([]File, error) {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var files []File
 	if sort == "" {
@@ -273,8 +264,7 @@ func (o *Scene) GetScriptFilesSorted(sort string) ([]File, error) {
 }
 
 func (o *Scene) GetHSPFiles() ([]File, error) {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var files []File
 	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "hsp").Find(&files)
@@ -283,8 +273,7 @@ func (o *Scene) GetHSPFiles() ([]File, error) {
 }
 
 func (o *Scene) GetSubtitlesFiles() ([]File, error) {
-	db, _ := GetDB()
-	defer db.Close()
+	db, _ := GetCommonDB()
 
 	var files []File
 	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "subtitles").Find(&files)

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -34,11 +34,11 @@ type SceneCuepoint struct {
 }
 
 func (o *SceneCuepoint) Save() error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
-			err := db.Save(&o).Error
+			err := commonDb.Save(&o).Error
 			if err != nil {
 				return err
 			}
@@ -132,11 +132,11 @@ type VideoSource struct {
 }
 
 func (i *Scene) Save() error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var err error = retry.Do(
 		func() error {
-			err := db.Save(&i).Error
+			err := commonDb.Save(&i).Error
 			if err != nil {
 				return err
 			}
@@ -160,9 +160,9 @@ func (i *Scene) FromJSON(data []byte) error {
 }
 
 func (o *Scene) GetIfExist(id string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Tags").
 		Preload("Cast").
 		Preload("Files").
@@ -172,9 +172,9 @@ func (o *Scene) GetIfExist(id string) error {
 }
 
 func (o *Scene) GetIfExistByPK(id uint) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Tags").
 		Preload("Cast").
 		Preload("Files").
@@ -184,9 +184,9 @@ func (o *Scene) GetIfExistByPK(id uint) error {
 }
 
 func (o *Scene) GetIfExistURL(u string) error {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
-	return db.
+	return commonDb.
 		Preload("Tags").
 		Preload("Cast").
 		Preload("Files").
@@ -210,19 +210,19 @@ func (o *Scene) GetFunscriptTitle() string {
 }
 
 func (o *Scene) GetFiles() ([]File, error) {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var files []File
-	db.Preload("Volume").Where(&File{SceneID: o.ID}).Find(&files)
+	commonDb.Preload("Volume").Where(&File{SceneID: o.ID}).Find(&files)
 
 	return files, nil
 }
 
 func (o *Scene) GetTotalWatchTime() int {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	totalResult := struct{ Total float64 }{}
-	db.Raw(`select sum(duration) as total from histories where scene_id = ?`, o.ID).Scan(&totalResult)
+	commonDb.Raw(`select sum(duration) as total from histories where scene_id = ?`, o.ID).Scan(&totalResult)
 
 	return int(totalResult.Total)
 }
@@ -233,13 +233,13 @@ func (o *Scene) GetVideoFiles() ([]File, error) {
 }
 
 func (o *Scene) GetVideoFilesSorted(sort string) ([]File, error) {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var files []File
 	if sort == "" {
-		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Find(&files)
+		commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Find(&files)
 	} else {
-		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Order(sort).Find(&files)
+		commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "video").Order(sort).Find(&files)
 	}
 
 	return files, nil
@@ -251,32 +251,32 @@ func (o *Scene) GetScriptFiles() ([]File, error) {
 }
 
 func (o *Scene) GetScriptFilesSorted(sort string) ([]File, error) {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var files []File
 	if sort == "" {
-		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Find(&files)
+		commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Find(&files)
 	} else {
-		db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Order(sort).Find(&files)
+		commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "script").Order(sort).Find(&files)
 	}
 
 	return files, nil
 }
 
 func (o *Scene) GetHSPFiles() ([]File, error) {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var files []File
-	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "hsp").Find(&files)
+	commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "hsp").Find(&files)
 
 	return files, nil
 }
 
 func (o *Scene) GetSubtitlesFiles() ([]File, error) {
-	db, _ := GetCommonDB()
+	commonDb, _ := GetCommonDB()
 
 	var files []File
-	db.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "subtitles").Find(&files)
+	commonDb.Preload("Volume").Where("scene_id = ? AND type = ?", o.ID, "subtitles").Find(&files)
 
 	return files, nil
 }

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -31,9 +31,6 @@ func BadoinkSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	siteCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com", "kinkvr.com")
 	trailerCollector := cloneCollector(sceneCollector)
 
-	db, _ := models.GetDB()
-	defer db.Close()
-
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
 		sc.ScraperID = scraperID

--- a/pkg/scrape/czechvr.go
+++ b/pkg/scrape/czechvr.go
@@ -17,8 +17,6 @@ import (
 func CzechVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, nwID string, singeScrapeAdditionalInfo string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
-	db, _ := models.GetDB()
-	defer db.Close()
 
 	sceneCollector := createCollector("www.czechvrnetwork.com")
 	siteCollector := createCollector("www.czechvrnetwork.com")

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -34,19 +34,19 @@ func GenericActorScrapers() {
 	tlog := log.WithField("task", "scrape")
 	tlog.Infof("Scraping Actor Details from Sites")
 
-	db, _ := models.GetCommonDB()
+	commonDb, _ := models.GetCommonDB()
 
 	scraperConfig := models.BuildActorScraperRules()
 
 	var actors []models.Actor
-	db.Preload("Scenes").
+	commonDb.Preload("Scenes").
 		Where("id =1").
 		Find(&actors)
 
 	sqlcmd := ""
 
 	var output []outputList
-	switch db.Dialect().GetName() {
+	switch commonDb.Dialect().GetName() {
 	// gets the list of an actors Urls for scraper and join to external_reference_links to see if the haven't been linked
 	case "mysql":
 		sqlcmd = `
@@ -77,7 +77,7 @@ func GenericActorScrapers() {
 
 	processed := 0
 	lastMessage := time.Now()
-	db.Raw(sqlcmd).Scan(&output)
+	commonDb.Raw(sqlcmd).Scan(&output)
 
 	var wg sync.WaitGroup
 	concurrentLimit := 10 // Maximum number of concurrent tasks
@@ -132,15 +132,15 @@ func processAuthorLink(row outputList, siteRules map[string]models.GenericScrape
 
 func GenericSingleActorScraper(actorId uint, actorPage string) {
 	log.Infof("Scraping Actor Details from %s", actorPage)
-	db, _ := models.GetCommonDB()
+	commonDb, _ := models.GetCommonDB()
 
 	var actor models.Actor
 	actor.ID = actorId
-	db.Find(&actor)
+	commonDb.Find(&actor)
 	scraperConfig := models.BuildActorScraperRules()
 
 	var extRefLink models.ExternalReferenceLink
-	db.Preload("ExternalReference").
+	commonDb.Preload("ExternalReference").
 		Where(&models.ExternalReferenceLink{ExternalId: actorPage, InternalDbId: actor.ID}).
 		First(&extRefLink)
 
@@ -158,14 +158,14 @@ func GenericActorScrapersBySite(site string) {
 	tlog := log.WithField("task", "scrape")
 	tlog.Infof("Scraping Actor Details from %s", site)
 
-	db, _ := models.GetCommonDB()
+	commonDb, _ := models.GetCommonDB()
 	scraperConfig := models.BuildActorScraperRules()
 
 	er := models.ExternalReference{}
 	scrapeId := er.DetermineActorScraperBySiteId(site)
 
 	var actors []models.Actor
-	db.Debug().Select("DISTINCT actors.*").
+	commonDb.Debug().Select("DISTINCT actors.*").
 		Joins("JOIN scene_cast ON scene_cast.actor_id = actors.id").
 		Joins("JOIN scenes ON scenes.id = scene_cast.scene_id").
 		Where("scenes.scraper_id = ?", site).
@@ -180,7 +180,7 @@ func GenericActorScrapersBySite(site string) {
 
 		// find the url for the actor for this site
 		var extreflink models.ExternalReferenceLink
-		db.Where(`internal_table = 'actors' and internal_db_id = ? and external_source = ?`, actor.ID, scrapeId).First(&extreflink)
+		commonDb.Where(`internal_table = 'actors' and internal_db_id = ? and external_source = ?`, actor.ID, scrapeId).First(&extreflink)
 		for source, rule := range scraperConfig.GenericActorScrapingConfig {
 			if source == scrapeId {
 				applyRules(extreflink.ExternalId, scrapeId, rule, &actor, true)
@@ -274,8 +274,8 @@ func applyRules(actorPage string, source string, rules models.GenericScraperRule
 	var extref models.ExternalReference
 	var extreflink models.ExternalReferenceLink
 
-	db, _ := models.GetCommonDB()
-	db.Preload("ExternalReference").
+	commonDb, _ := models.GetCommonDB()
+	commonDb.Preload("ExternalReference").
 		Where(&models.ExternalReferenceLink{ExternalSource: source, InternalDbId: actor.ID}).
 		First(&extreflink)
 	extref = extreflink.ExternalReference

--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -34,8 +34,7 @@ func GenericActorScrapers() {
 	tlog := log.WithField("task", "scrape")
 	tlog.Infof("Scraping Actor Details from Sites")
 
-	db, _ := models.GetDB()
-	defer db.Close()
+	db, _ := models.GetCommonDB()
 
 	scraperConfig := models.BuildActorScraperRules()
 
@@ -133,8 +132,7 @@ func processAuthorLink(row outputList, siteRules map[string]models.GenericScrape
 
 func GenericSingleActorScraper(actorId uint, actorPage string) {
 	log.Infof("Scraping Actor Details from %s", actorPage)
-	db, _ := models.GetDB()
-	defer db.Close()
+	db, _ := models.GetCommonDB()
 
 	var actor models.Actor
 	actor.ID = actorId
@@ -160,9 +158,7 @@ func GenericActorScrapersBySite(site string) {
 	tlog := log.WithField("task", "scrape")
 	tlog.Infof("Scraping Actor Details from %s", site)
 
-	db, _ := models.GetDB()
-	defer db.Close()
-
+	db, _ := models.GetCommonDB()
 	scraperConfig := models.BuildActorScraperRules()
 
 	er := models.ExternalReference{}
@@ -278,8 +274,7 @@ func applyRules(actorPage string, source string, rules models.GenericScraperRule
 	var extref models.ExternalReference
 	var extreflink models.ExternalReferenceLink
 
-	db, _ := models.GetDB()
-	defer db.Close()
+	db, _ := models.GetCommonDB()
 	db.Preload("ExternalReference").
 		Where(&models.ExternalReferenceLink{ExternalSource: source, InternalDbId: actor.ID}).
 		First(&extreflink)

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -22,7 +22,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	sceneCollector := createCollector("www.sexlikereal.com")
 	siteCollector := createCollector("www.sexlikereal.com")
 
-	db, _ := models.GetCommonDB()
+	commonDb, _ := models.GetCommonDB()
 
 	// RegEx Patterns
 	coverRegEx := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
@@ -48,7 +48,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 				// see if we can find the site record, there may not be
 				var site models.Site
-				db.Where("id = ? or name like ? or (name = ? and name like 'SLR%')", studioId, sc.Studio+"%SLR)", sc.Studio).First(&site)
+				commonDb.Where("id = ? or name like ? or (name = ? and name like 'SLR%')", studioId, sc.Studio+"%SLR)", sc.Studio).First(&site)
 				if site.ID != "" {
 					sc.ScraperID = site.ID
 				}

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -22,8 +22,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	sceneCollector := createCollector("www.sexlikereal.com")
 	siteCollector := createCollector("www.sexlikereal.com")
 
-	db, _ := models.GetDB()
-	defer db.Close()
+	db, _ := models.GetCommonDB()
 
 	// RegEx Patterns
 	coverRegEx := regexp.MustCompile(`background(?:-image)?\s*?:\s*?url\s*?\(\s*?(.*?)\s*?\)`)
@@ -48,8 +47,6 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				studioId = strings.TrimSuffix(strings.ReplaceAll(studioId, "/studios/", ""), "/")
 
 				// see if we can find the site record, there may not be
-				db, _ := models.GetDB()
-				defer db.Close()
 				var site models.Site
 				db.Where("id = ? or name like ? or (name = ? and name like 'SLR%')", studioId, sc.Studio+"%SLR)", sc.Studio).First(&site)
 				if site.ID != "" {

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -45,9 +45,9 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 				sc.Studio = strings.TrimSpace(e.Text)
 				sc.Site = sc.Studio
 				// see if we can find the site record, there may not be
-				db, _ := models.GetCommonDB()
+				commonDb, _ := models.GetCommonDB()
 				var site models.Site
-				db.Where("name like ?", sc.Studio+"%VRPorn) or id = ?", sc.Studio, studioId).First(&site)
+				commonDb.Where("name like ?", sc.Studio+"%VRPorn) or id = ?", sc.Studio, studioId).First(&site)
 				if site.ID != "" {
 					sc.ScraperID = site.ID
 				}

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -45,8 +45,7 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 				sc.Studio = strings.TrimSpace(e.Text)
 				sc.Site = sc.Studio
 				// see if we can find the site record, there may not be
-				db, _ := models.GetDB()
-				defer db.Close()
+				db, _ := models.GetCommonDB()
 				var site models.Site
 				db.Where("name like ?", sc.Studio+"%VRPorn) or id = ?", sc.Studio, studioId).First(&site)
 				if site.ID != "" {


### PR DESCRIPTION
This change aims to address issues related to "Too Many Connections" errors, particularly for users experiencing such problems due to the utilization of numerous Custom Sites.

The modification introduces a new database function called GetCommonDB, mirroring the existing GetDB function. However, it establishes and maintains a shared connection pool created at startup, which should remain open throughout. In the case of MySQL, the gorm.Open function invoked within these functions initiates a connection pool, not a single connection.

The db.GetDB functions utilized during scraping and some update functions in the models have been updated to use the newly introduced GetCommonDB. By default, XBVR will still attempt to create as many connections as requested, potentially resulting in the same "Too Many Connections" failures. However, the size of the common connection pool can optionally be restricted by configuring the runtime parameter **dB_connection_pool_size** or the environment variable **DB_CONNECTION_POOL_SIZE**. This limitation then regulates the number of concurrent connections the GetCommonDB pool will open. Queries surpassing this limit will be queued until a connection becomes available, after which they will proceed.

Setting the pool size too low may decelerate scraping, as threads wait for an idle connection if the limit is exceeded. Conversely, setting it excessively high may still lead to "Too Many Connections" errors, as other functions using GetDB still need to create other connections.

To enhance clarity, the db variable, normally assigned to gorm.DB, has been renamed to commonDB when GetCommonDB is used. This adjustment helps developers easily discern which connection pool is in use. It is imperative that developers refrain from calling Close on the common pool.

Tests have indicated that utilizing a common pool yields faster results. For instance, performing 10,000 reads of a scene, pre-loading tags, cast, files, history, and cue points takes approximately 40 seconds with GetCommonDB compared to about 60 seconds with GetDB.