### PR TITLE
scraper: Fix duplicate actors on RealJamVR & PornCornVR

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1844,14 +1844,14 @@ func Migrate() {
 			ID: "0073-reset-RealJamVR-scenes-with-duped-actors",
 			Migrate: func(tx *gorm.DB) error {
 
-				rj := [...]string{"realjam-vr-39859", "realjam-vr-39861", "realjam-vr-40044", "realjam-vr-40064"}
+				rjn := [...]string{"realjam-vr-39859", "realjam-vr-39861", "realjam-vr-40044", "realjam-vr-40064", "porncorn-vr-39827", "porncorn-vr-39902", "porncorn-vr-40031", "porncorn-vr-39903"}
 				var scenes []models.Scene
-				err := tx.Where("site = ?", "RealJam VR").Find(&scenes).Error
+				err := tx.Where("studio = ?", "Real Jam Network").Find(&scenes).Error
 				if err != nil {
 					return err
 				}
 				for _, scene := range scenes {
-					for _, v := range rj {
+					for _, v := range rjn {
 						if scene.SceneID == v {
 							scene.NeedsUpdate = true
 							err = tx.Save(&scene).Error

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1840,6 +1840,31 @@ func Migrate() {
 				return tx.Exec(sql).Error
 			},
 		},
+		{
+			ID: "0073-reset-RealJamVR-scenes-with-duped-actors",
+			Migrate: func(tx *gorm.DB) error {
+
+				rj := [...]string{"realjam-vr-39859", "realjam-vr-39861", "realjam-vr-40044", "realjam-vr-40064"}
+				var scenes []models.Scene
+				err := tx.Where("site = ?", "RealJam VR").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+				for _, scene := range scenes {
+					for _, v := range rj {
+						if scene.SceneID == v {
+							scene.NeedsUpdate = true
+							err = tx.Save(&scene).Error
+							if err != nil {
+								return err
+							}
+							// common.Log.Infof("Updated scene %s", scene.SceneID)
+						}
+					}
+				}
+				return nil
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -68,7 +68,7 @@ func RealJamSite(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Cast
 		sc.ActorDetails = make(map[string]models.ActorDetails)
-		e.ForEach(`div.scene-view a[href^='/actor/']`, func(id int, e *colly.HTMLElement) {
+		e.ForEach(`div.scene-view > a[href^='/actor/']`, func(id int, e *colly.HTMLElement) {
 			sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
 			sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
 		})


### PR DESCRIPTION
removes existing duplicates from 12/27/2023 - 01/11/2024. If duplicates newer than these dates, just force update the scene.