### PR TITLE
SLR Cover and Gallery Images

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -135,7 +135,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 			re := regexp.MustCompile(`(https:\/\/cdn-vr\.(sexlikereal|trannypornvr)\.com\/images\/\d+\/)vr-porn-[\w\-]+?-(\d+)-original(\.webp|\.jpg)`)
 			if e.Attr("name") != "twitter:image" { // we need image1, image2...
 				if !isTransScene {
-					sc.Gallery = append(sc.Gallery, re.ReplaceAllStringFunc(e.Request.AbsoluteURL(e.Attr("content")),absolutegallery))
+					sc.Gallery = append(sc.Gallery, re.ReplaceAllStringFunc(e.Request.AbsoluteURL(e.Attr("content")), absolutegallery))
 				} //else {
 				//	sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("content")))
 				//}
@@ -162,7 +162,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 						sc.Covers = append(sc.Covers, m[1])
 					}
 				}
-		}
+			}
 		} else {
 			tcoverURL := e.ChildAttr(`.splash-screen > img`, "src")
 			if len(tcoverURL) > 0 {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -78,7 +78,8 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		// Gallery
 		e.ForEach(`meta[name^="twitter:image"]`, func(id int, e *colly.HTMLElement) {
 			if e.Attr("name") != "twitter:image" { // we need image1, image2...
-				sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("content")))
+				re := regexp.MustCompile("(https:\/\/cdn-vr.sexlikereal.com\/images\/\d+\/)(?:(?:vr-porn-)(?:[\w\-])+?(\d+)(-original))(.webp|.jpg)")
+				sc.Gallery = append(sc.Gallery, re.ReplaceAll(e.Request.AbsoluteURL(e.Attr("content")),"$1$2_o.jpg")
 			}
 		})
 
@@ -396,7 +397,7 @@ func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *rege
 				projSuffix = "_TB_360.mp4"
 			}
 		}
-		resolutions := []string{"_original_"}
+		resolutions := []string{"__"}
 		encodings := gjson.Get(JsonMetadataA, "encodings.#(name=h265).videoSources.#.resolution")
 		for _, name := range encodings.Array() {
 			resolutions = append(resolutions, "_"+name.String()+"p_")
@@ -417,10 +418,10 @@ func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *rege
 			}
 		}
 		if FB360 != "" {
-			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"__"+sc.SiteID+FB360)
 		}
 	} else {
-		resolutions := []string{"_6400p_", "_4096p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_3000p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
+		resolutions := []string{"_6400p_", "_4096p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_3000p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "__"}
 		baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
 		switch videotype {
 		case "360°": // Sadly can't determine if TB or MONO so have to add both

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -16,6 +16,15 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
+func absolutegallery(match string) string {
+	re := regexp.MustCompile(`(https:\/\/cdn-vr\.(sexlikereal|trannypornvr)\.com\/images\/\d+\/)vr-porn-[\w\-]+?-(\d+)-original(\.webp|\.jpg)`)
+	submatches := re.FindStringSubmatch(match)
+	if len(submatches) == 0 {
+		return match // no match, return original string
+	}
+	return submatches[1] + submatches[3] + "_o.jpg" // construct new string with desired format
+}
+
 func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, company string, siteURL string, singeScrapeAdditionalInfo string, limitScraping bool, masterSiteId string) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
@@ -63,25 +72,6 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		tmp := strings.Split(sc.HomepageURL, "-")
 		sc.SiteID = tmp[len(tmp)-1]
 		sc.SceneID = "slr-" + sc.SiteID
-
-		// Cover
-		coverURL := e.ChildAttr(`.splash-screen > img`, "src")
-		if len(coverURL) > 0 {
-			sc.Covers = append(sc.Covers, coverURL)
-		} else {
-			m := coverRegEx.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`.c-webxr-splash-screen`, "style")))
-			if len(m) > 0 && len(m[1]) > 0 {
-				sc.Covers = append(sc.Covers, m[1])
-			}
-		}
-
-		// Gallery
-		e.ForEach(`meta[name^="twitter:image"]`, func(id int, e *colly.HTMLElement) {
-			if e.Attr("name") != "twitter:image" { // we need image1, image2...
-				re := regexp.MustCompile("(https:\/\/cdn-vr.sexlikereal.com\/images\/\d+\/)(?:(?:vr-porn-)(?:[\w\-])+?(\d+)(-original))(.webp|.jpg)")
-				sc.Gallery = append(sc.Gallery, re.ReplaceAll(e.Request.AbsoluteURL(e.Attr("content")),"$1$2_o.jpg")
-			}
-		})
 
 		// Synopsis
 		sc.Synopsis = strings.TrimSpace(
@@ -139,6 +129,51 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		JsonMetadataA := s.String()
 
 		isTransScene := e.Request.Ctx.GetAny("isTransScene").(bool)
+
+		// Gallery
+		e.ForEach(`meta[name^="twitter:image"]`, func(id int, e *colly.HTMLElement) {
+			re := regexp.MustCompile(`(https:\/\/cdn-vr\.(sexlikereal|trannypornvr)\.com\/images\/\d+\/)vr-porn-[\w\-]+?-(\d+)-original(\.webp|\.jpg)`)
+			if e.Attr("name") != "twitter:image" { // we need image1, image2...
+				if !isTransScene {
+					sc.Gallery = append(sc.Gallery, re.ReplaceAllStringFunc(e.Request.AbsoluteURL(e.Attr("content")),absolutegallery))
+				} //else {
+				//	sc.Gallery = append(sc.Gallery, e.Request.AbsoluteURL(e.Attr("content")))
+				//}
+				// Trans scenes currently do not scrape gallery images at all
+				// I'm not sure how to, since we're using "twitter:image" and there are none for trans scenes
+				// The URLs are available on the "Photos" tab and they can be re-written to redirect to original images similarly
+				// The RegEx will work for either
+				// i.e. "https://cdn-vr.trannypornvr.com/images/861/vr-porn-Welcome-Back-4570.webp" -> "https://cdn-vr.trannypornvr.com/images/861/4570_o.jpg"
+			}
+		})
+
+		// Cover
+		if !isTransScene {
+			coverURL := strings.Replace(gjson.Get(JsonMetadataA, "thumbnailUrl").String(), "app", "desktop", -1)
+			if len(coverURL) > 0 {
+				sc.Covers = append(sc.Covers, coverURL)
+			} else {
+				coverURL := e.ChildAttr(`.splash-screen > img`, "src")
+				if len(coverURL) > 0 {
+					sc.Covers = append(sc.Covers, coverURL)
+				} else {
+					m := coverRegEx.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`.c-webxr-splash-screen`, "style")))
+					if len(m) > 0 && len(m[1]) > 0 {
+						sc.Covers = append(sc.Covers, m[1])
+					}
+				}
+		}
+		} else {
+			tcoverURL := e.ChildAttr(`.splash-screen > img`, "src")
+			if len(tcoverURL) > 0 {
+				sc.Covers = append(sc.Covers, tcoverURL)
+			} else {
+				m := coverRegEx.FindStringSubmatch(strings.TrimSpace(e.ChildAttr(`.c-webxr-splash-screen`, "style")))
+				if len(m) > 0 && len(m[1]) > 0 {
+					sc.Covers = append(sc.Covers, m[1])
+				}
+			}
+		}
 
 		// straight and trans videos use a different page structure
 		if !isTransScene {
@@ -397,7 +432,7 @@ func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *rege
 				projSuffix = "_TB_360.mp4"
 			}
 		}
-		resolutions := []string{"__"}
+		resolutions := []string{"_original_"}
 		encodings := gjson.Get(JsonMetadataA, "encodings.#(name=h265).videoSources.#.resolution")
 		for _, name := range encodings.Array() {
 			resolutions = append(resolutions, "_"+name.String()+"p_")
@@ -418,10 +453,10 @@ func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *rege
 			}
 		}
 		if FB360 != "" {
-			sc.Filenames = append(sc.Filenames, baseName+"__"+sc.SiteID+FB360)
+			sc.Filenames = append(sc.Filenames, baseName+"_original_"+sc.SiteID+FB360)
 		}
 	} else {
-		resolutions := []string{"_6400p_", "_4096p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_3000p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "__"}
+		resolutions := []string{"_6400p_", "_4096p_", "_4000p_", "_3840p_", "_3360p_", "_3160p_", "_3072p_", "_3000p_", "_2900p_", "_2880p_", "_2700p_", "_2650p_", "_2160p_", "_1920p_", "_1440p_", "_1080p_", "_original_"}
 		baseName := "SLR_" + strings.TrimSuffix(siteID, " (SLR)") + "_" + filenameRegEx.ReplaceAllString(sc.Title, "_")
 		switch videotype {
 		case "360°": // Sadly can't determine if TB or MONO so have to add both


### PR DESCRIPTION
Aims to be a more permanent fix, plus cover and gallery images need not be dependent on the title/slug.

Trans scenes seemingly do not scrape gallery images at all - with or without my changes. The RegEx I wrote will work for either type of scene (with a minor change - since `-original` is not part of those URLs) should someone try and implement it directly using the links on the "Photos" tab.