### PR TITLE
Fix search timeouts

### DIFF
--- a/ui/src/store/sceneList.js
+++ b/ui/src/store/sceneList.js
@@ -166,7 +166,10 @@ const actions = {
     q.limit = state.limit
 
     const data = await ky
-      .post('/api/scene/list', { json: q })
+      .post('/api/scene/list', {
+        json: q,
+        timeout: 6e6
+      })
       .json()
 
     state.isLoading = false


### PR DESCRIPTION
Trying to use the built-in search with large libraries (20k+ scenes) times out randomly - for at least one other person. This is the fix I have been running locally since the issue appeared a month or so ago.