### PR TITLE
Check for Deleted Actors when updating from Stashdb

### DIFF
--- a/pkg/externalreference/stashdb.go
+++ b/pkg/externalreference/stashdb.go
@@ -279,7 +279,10 @@ func UpdateXbvrActor(performer models.StashPerformer, xbvrActorID uint) {
 
 	changed := false
 	actor := models.Actor{ID: xbvrActorID}
-	db.Where(&actor).First(&actor)
+	err := db.Where(&actor).First(&actor).Error
+	if err != nil {
+		return
+	}
 
 	if len(performer.Images) > 0 {
 		if actor.ImageUrl != performer.Images[0].URL && !actor.CheckForSetImage() {


### PR DESCRIPTION
When updating actors from Stashdb, need to check the Actor still exists, if it has been deleted, otherwise a blank Actor will be created