### PR TITLE
Filter Multiple Scenes Available at an Alternate Site

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -390,6 +390,7 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "Available from POVR")
 	outAttributes = append(outAttributes, "Available from VRPorn")
 	outAttributes = append(outAttributes, "Available from SLR")
+	outAttributes = append(outAttributes, "Multiple Scenes Available at an Alternate Site")
 	type Results struct {
 		Result string
 	}

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -913,6 +913,8 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 			where = "exists (select 1 from external_reference_links where external_source like 'alternate scene %' and external_id like 'slr-%' and internal_db_id = scenes.id)"
 		case "Available from Alternate Sites":
 			where = "exists (select 1 from external_reference_links where external_source like 'alternate scene %' and internal_db_id = scenes.id)"
+		case "Multiple Scenes Available at an Alternate Site":
+			where = "exists (select 1 from external_reference_links where external_source like 'alternate scene %' and internal_db_id = scenes.id  group by external_source having count(*)>1)"
 		}
 
 		if negate {


### PR DESCRIPTION
Adds a filter Attribute to find scenes that have multiple scenes matched from an Alternate Site, i.e. 2 scenes matched at SLR, not 1 scene at SLR and one at VRPorn.

Note: this can help find mismatches, however, this does not necessarily indicate a mismatch.  e.g. in the past VRHush would release a POV and Voyeur as a single scene but partner sites would usually publish 2 separate scenes.