### PR TITLE
fix: missing aggregator logos

### DIFF
--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -159,6 +159,10 @@ func addPOVRScraper(id string, name string, company string, avatarURL string, cu
 	} else {
 		suffixedName += " (POVR)"
 	}
+	if avatarURL == "" {
+		avatarURL = "https://images.povr.com/img/povr/android-icon-192x192.png"
+	}
+
 	if masterSiteId == "" {
 		registerScraper(id, suffixedName, avatarURL, "povr.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
 			return POVR(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo, limitScraping, "")

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -179,6 +179,10 @@ func addVRPornScraper(id string, name string, company string, avatarURL string, 
 	} else {
 		suffixedName += " (VRPorn)"
 	}
+	if avatarURL == "" {
+		avatarURL = "https://vrporn.com/assets/favicon.png"
+	}
+
 	if masterSiteId == "" {
 		registerScraper(id, suffixedName, avatarURL, "vrporn.com", func(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
 			return VRPorn(wg, updateSite, knownScenes, out, singleSceneURL, id, siteNameSuffix, company, siteURL, singeScrapeAdditionalInfo, limitScraping, "")


### PR DESCRIPTION
POVR & VRPORN missing "option" to use default logo when user doesn't supply one (leaving blank entry in avatar_url)

resolves #1625 