### PR TITLE
Use sql rather than automigrate to create index

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -760,10 +760,12 @@ func Migrate() {
 			ID: "0073-scene-_id-index-plus-columns_size_changes",
 			Migrate: func(tx *gorm.DB) error {
 				type Scene struct {
-					SceneID  string `gorm:"index" json:"scene_id" xbvrbackup:"scene_id"`
 					CoverURL string `gorm:"size:500" json:"cover_url" xbvrbackup:"cover_url"`
 					SceneURL string `gorm:"size:500" json:"scene_url" xbvrbackup:"scene_url"`
 				}
+
+				sql := `CREATE INDEX idx_scenes_scene_id ON scenes (scene_id)`
+				tx.Exec(sql)
 				return tx.AutoMigrate(&Scene{}).Error
 			},
 		},


### PR DESCRIPTION
2 users reported 0073-scene-_id-index-plus-columns_size_changes failing when creating the index on scene_id using the automigrate function.

Have changed to using SQL, if it errors with the index existing of column existing, then it will still continue and complete successfully