### PR TITLE
Rewrite VirtualPorn (using API as a Source)

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1925,6 +1925,13 @@ func Migrate() {
 				return err
 			},
 		},
+		{
+			ID: "0077-Update-VirtualPorn-ids",
+			Migrate: func(tx *gorm.DB) error {
+				err := scrape.UpdateVirtualPornIds()
+				return err
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -518,7 +518,7 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 
 	siteDetails = GenericScraperRuleSet{}
 	siteDetails.Domain = "virtualporn.com"
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `div.model__img-wrapper > img`, ResultType: "attr", Attribute: "src"})
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `section[data-cy="actorProfilePicture"] img`, ResultType: "attr", Attribute: "src"})
 	scrapeRules.GenericActorScrapingConfig["bvr scrape"] = siteDetails
 
 	siteDetails = GenericScraperRuleSet{}


### PR DESCRIPTION
Fixes #1568 

Rewrite of VirtualPorn scraper.  Most tag IDs on their new site look code generated, so I have used an API that they have called.

There is no references I can find to the old Scene Ids used by XBVR.  I have remapped scenes to new Ids based on the Release Date, this seems to work as they normally only release a scene every 2 weeks.  This requires calling the API and the old Scene Id is stored in the legacy_scene_id column.

The migration will update links, but to get updated filenames, the user can refresh the scenes, some may still want the old filenames, their choice.