### PR TITLE
Ability to Limit the Number of Scrapers Running Concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,18 @@ left arrow - cycles backwards in gallery
 right arrow - cycles forward in gallery  
 esc - closes details pane
 
-#### using Command Line Arguments
-| Command line parameter | Type | Description |
-|------------------------|-------|--------------
-| `--enableLocalStorage` | boolean |Use local folder to store application data|
-|	`--app_dir` | String|path to the application directory|
-|	`--cache_dir` | String|path to the tempoarary scraper cache directory|
-|	`--imgproxy_dir` | String|path to the imageproxy directory|
-|	`--search_dir` | String| path to the Search Index directory|
-|	`--preview_dir` | String| path to the Scraper Cache directory|
-|	`--scriptsheatmap_dir` | String| path to the scripts_heatmap directory|
-|	`--myfiles_dir` | String| path to the myfiles directory for serving users own content (eg images|
-|	`--databaseurl` | String|override default database path|
-|	`--web_port` | Int| override default Web Page port 9999|
-|	`--ws_addr` | String| override default Websocket address from the default 0.0.0.0:9998|
+#### using Command Line Arguments/Environment Variables
+| Command line parameter | Environment Variable | Type | Description |
+|------------------------|--------------|------|-------------|
+| `--enableLocalStorage` | | boolean |Use local folder to store application data|
+|	`--app_dir` | XBVR_APPDIR | String|path to the application directory|
+|	`--cache_dir` | XBVR_CACHEDIR | String|path to the tempoarary scraper cache directory|
+|	`--imgproxy_dir` | XBVR_IMAGEPROXYDIR | String|path to the imageproxy directory|
+|	`--search_dir` | XBVR_SEARCHDIR | String| path to the Search Index directory|
+|	`--preview_dir` | XBVR_VIDEOPREVIEWDIR | String| path to the Scraper Cache directory|
+|	`--scriptsheatmap_dir` | XBVR_SCRIPTHEATMAPDIR | String| path to the scripts_heatmap directory|
+|	`--myfiles_dir` | XBVR_MYFILESDIR | String| path to the myfiles directory for serving users own content (eg images|
+|	`--databaseurl` | DATABASE_URL | String|override default database path|
+|	`--web_port` | XBVR_WEB_PORT | Int| override default Web Page port 9999|
+|	`--ws_addr` | DB_CONNECTION_POOL_SIZE | String| override default Websocket address from the default 0.0.0.0:9998|
+|	`--concurrent_scrapers` | CONCURRENT_SCRAPERS | String| set the number of scrapers that run concurrently default 9999|

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -22,6 +22,7 @@ type EnvConfigSpec struct {
 	WsAddr               string `envconfig:"XBVR_WS_ADDR" required:"false" default:""`
 	WebPort              int    `envconfig:"XBVR_WEB_PORT" required:"false" default:"0"`
 	DBConnectionPoolSize int    `envconfig:"DB_CONNECTION_POOL_SIZE" required:"false" default:"0"`
+	ConcurrentScrapers   int    `envconfig:"CONCURRENT_SCRAPERS" required:"false" default:"9999"`
 }
 
 var EnvConfig EnvConfigSpec

--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -24,6 +24,7 @@ var MyFilesDir string
 var DownloadDir string
 var WebPort int
 var DBConnectionPoolSize int
+var ConcurrentScrapers int
 
 func DirSize(path string) (int64, error) {
 	var size int64
@@ -53,6 +54,7 @@ func InitPaths() {
 	web_port := flag.Int("web_port", 0, "Optional: override default Web Page port 9999")
 	ws_addr := flag.String("ws_addr", "", "Optional: override default Websocket address from the default 0.0.0.0:9998")
 	db_connection_pool_size := flag.Int("db_connection_pool_size", 0, "Optional: sets a limit to the number of db connections while scraping")
+	concurrentSscrapers := flag.Int("concurrent_scrapers", 0, "Optional: sets a limit to the number of concurrent scrapers")
 
 	flag.Parse()
 
@@ -119,6 +121,11 @@ func InitPaths() {
 		DBConnectionPoolSize = *db_connection_pool_size
 	} else {
 		DBConnectionPoolSize = EnvConfig.DBConnectionPoolSize
+	}
+	if *concurrentSscrapers != 0 {
+		ConcurrentScrapers = *concurrentSscrapers
+	} else {
+		ConcurrentScrapers = EnvConfig.ConcurrentScrapers
 	}
 
 	_ = os.MkdirAll(AppDir, os.ModePerm)


### PR DESCRIPTION
Fixes #1626 

This allows users to specify the maximum number of scrapers that can run concurrently.  It can be set with the Environment Variable CONCURRENT_SCRAPERS or runtime parameter concurrent_scrapers.

Note: it will run the scrapers in batches, all scrapers in the batch must complete before it will start the next batch, ie if you set the number of scrapers to 10 and 10 are been scraped and one scraper finishes another scraper will not start, all 10 must finish then another 10 will start