### PR TITLE
Ability To Limit the Scraping Rates by Site & Scraper ie Domain

### DIFF
--- a/pkg/scrape/genericactorscraper.go
+++ b/pkg/scrape/genericactorscraper.go
@@ -266,10 +266,13 @@ func applyRules(actorPage string, source string, rules models.GenericScraperRule
 			}
 		})
 	}
+	url, _ := url.Parse(actorPage)
 	if rules.IsJson {
-		actorCollector.Request("GET", actorPage, nil, nil, nil)
+		ScraperRateLimiterWait(url.Host)
+		err := actorCollector.Request("GET", actorPage, nil, nil, nil)
+		ScraperRateLimiterCheckErrors(url.Host, err)
 	} else {
-		actorCollector.Visit(actorPage)
+		WaitBeforeVisit(url.Host, actorCollector.Visit, actorPage)
 	}
 	var extref models.ExternalReference
 	var extreflink models.ExternalReferenceLink

--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -126,21 +126,21 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 
 		// If scene exists in database, or the slternate source exists, there's no need to scrape
 		if !funk.ContainsString(knownScenes, sceneURL) && !strings.Contains(sceneURL, "/join") {
-			sceneCollector.Visit(sceneURL)
+			WaitBeforeVisit("povr.com", sceneCollector.Visit, sceneURL)
 		}
 	})
 
 	siteCollector.OnHTML(`div.pagination a[class="pagination__page next"]`, func(e *colly.HTMLElement) {
 		if !limitScraping {
 			pageURL := e.Request.AbsoluteURL(e.Attr("href"))
-			siteCollector.Visit(pageURL)
+			WaitBeforeVisit("povr.com", siteCollector.Visit, pageURL)
 		}
 	})
 
 	if singleSceneURL != "" {
 		sceneCollector.Visit(singleSceneURL)
 	} else {
-		siteCollector.Visit(siteURL)
+		WaitBeforeVisit("povr.com", siteCollector.Visit, siteURL)
 	}
 
 	if updateSite {

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -40,9 +40,10 @@ func createCollector(domains ...string) *colly.Collector {
 		if Limiters == nil {
 			LoadScraperRateLimits()
 		}
-		if Limiters[domain] != nil {
-			randomdelay := Limiters[domain].maxDelay - Limiters[domain].minDelay
-			delay := Limiters[domain].minDelay
+		limiter := GetRateLimiter(domain)
+		if limiter != nil {
+			randomdelay := limiter.maxDelay - limiter.minDelay
+			delay := limiter.minDelay
 			c.Limit(&colly.LimitRule{
 				DomainGlob:  "*",
 				Delay:       delay,       // Delay between requests to domains matching the glob

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -34,6 +34,24 @@ func createCollector(domains ...string) *colly.Collector {
 	})
 
 	c = createCallbacks(c)
+
+	// see if the domain has a limit and set it
+	for _, domain := range domains {
+		if Limiters == nil {
+			LoadScraperRateLimits()
+		}
+		if Limiters[domain] != nil {
+			randomdelay := Limiters[domain].maxDelay - Limiters[domain].minDelay
+			delay := Limiters[domain].minDelay
+			c.Limit(&colly.LimitRule{
+				DomainGlob:  "*",
+				Delay:       delay,       // Delay between requests to domains matching the glob
+				RandomDelay: randomdelay, // Max additional random delay added to the delay
+			})
+			break
+		}
+	}
+
 	return c
 }
 

--- a/pkg/scrape/scrape_rate_limiter.go
+++ b/pkg/scrape/scrape_rate_limiter.go
@@ -1,0 +1,108 @@
+package scrape
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+// Colly provides Rate Limiting on collectors and this works in most scrapers.
+// For scrapers that handle multiple sites, eg SLR, VRPorn, this does not work, as each
+// each site creates it's own instance of the scraper with it's own colly collector, and it's own independent limits
+
+// The ScraperRateLimiter is provides a way to limit visits across multiple instances of the same scraper.
+// The calls to the colly collector Visit function must first be passed to the ScraperRateLimiter which will then coridinate
+// between all instances and then call the colly Visit function
+var Limiters map[string]*ScraperRateLimiter
+
+type ScraperRateLimiter struct {
+	mutex       sync.Mutex
+	lastRequest time.Time
+	minDelay    time.Duration
+	maxDelay    time.Duration
+}
+
+func CreateRateLimiter(minDelay time.Duration, maxDelay time.Duration) *ScraperRateLimiter {
+	return &ScraperRateLimiter{
+		minDelay: minDelay,
+		maxDelay: maxDelay,
+		//		response: true,
+	}
+}
+
+func ScraperRateLimiterWait(rateLimiter string) {
+	if Limiters[rateLimiter] == nil {
+		return
+	}
+	Limiters[rateLimiter].mutex.Lock()
+	defer Limiters[rateLimiter].mutex.Unlock()
+
+	if Limiters[rateLimiter].lastRequest.IsZero() {
+		// no previous time, don't wait
+		Limiters[rateLimiter].lastRequest = time.Now()
+		return
+	}
+	timeSinceLast := time.Since(Limiters[rateLimiter].lastRequest)
+
+	delay := Limiters[rateLimiter].minDelay
+	if Limiters[rateLimiter].maxDelay > Limiters[rateLimiter].minDelay {
+		// Introduce a random delay between minDelay and maxDelay
+		delay += time.Duration(rand.Int63n(int64(Limiters[rateLimiter].maxDelay - Limiters[rateLimiter].minDelay)))
+	}
+	if timeSinceLast < delay {
+		time.Sleep(delay - timeSinceLast)
+	}
+	Limiters[rateLimiter].lastRequest = time.Now()
+}
+
+func WaitBeforeVisit(rateLimiter string, visitFunc func(string) error, pageURL string) {
+	ScraperRateLimiterWait(rateLimiter)
+	err := visitFunc(pageURL)
+	if err != nil {
+		// if an err is returned, then a html a call was not made by colly.  These are errors colly checks before calling the URL
+		//		ie the url has not been called.  No need to wait before the next call, as the site was never visited
+		if Limiters[rateLimiter] != nil {
+			Limiters[rateLimiter].lastRequest = time.Time{}
+		}
+	}
+}
+func ScraperRateLimiterCheckErrors(domain string, err error) {
+	if err != nil {
+		Limiters[domain].lastRequest = time.Time{}
+	}
+
+}
+func AddScraperRateLimiter(key string, l *ScraperRateLimiter) {
+	if Limiters == nil {
+		LoadScraperRateLimits()
+	}
+	Limiters[key] = l
+}
+
+func LoadScraperRateLimits() {
+	var mutex sync.Mutex
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	limiters := make(map[string]*ScraperRateLimiter)
+	commonDb, _ := models.GetCommonDB()
+	var kv models.KV
+	commonDb.Where(models.KV{Key: "scraper_rate_limits"}).Find(&kv)
+	if kv.Key == "scraper_rate_limits" {
+		sites := gjson.Get(kv.Value, "sites")
+		for _, site := range sites.Array() {
+			name := site.Get("name").String()
+			minDelay := int(site.Get("mindelay").Int())
+			maxDelay := int(site.Get("maxdelay").Int())
+			if maxDelay < minDelay {
+				maxDelay = minDelay
+			}
+			limiters[name] = &ScraperRateLimiter{minDelay: time.Duration(minDelay) * time.Millisecond, maxDelay: time.Duration(maxDelay) * time.Millisecond}
+		}
+
+		Limiters = limiters
+	}
+}

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -304,7 +304,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 	siteCollector.OnHTML(`div.c-pagination ul li a`, func(e *colly.HTMLElement) {
 		if !limitScraping {
 			pageURL := e.Request.AbsoluteURL(e.Attr("href"))
-			siteCollector.Visit(pageURL)
+			WaitBeforeVisit("www.sexlikereal.com", siteCollector.Visit, pageURL)
 		}
 	})
 
@@ -385,7 +385,9 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 				ctx := colly.NewContext()
 				ctx.Put("duration", duration)
 				ctx.Put("isTransScene", isTransScene)
-				sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
+				ScraperRateLimiterWait("www.sexlikereal.com")
+				err := sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
+				ScraperRateLimiterCheckErrors("www.sexlikereal.com", err)
 			}
 		}
 	})
@@ -398,7 +400,7 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 
 	} else {
-		siteCollector.Visit(siteURL + "?sort=most_recent")
+		WaitBeforeVisit("www.sexlikereal.com", siteCollector.Visit, siteURL+"?sort=most_recent")
 	}
 
 	if updateSite {

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -191,7 +191,9 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 			ctx := colly.NewContext()
 			ctx.Put("scene", &sc)
 
-			sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
+			ScraperRateLimiterWait("vrphub.com")
+			err := sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
+			ScraperRateLimiterCheckErrors("vrphub.com", err)
 		}
 	})
 
@@ -201,7 +203,7 @@ func VRPHub(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		ctx.Put("scene", &sc)
 		sceneCollector.Request("GET", singleSceneURL, nil, ctx, nil)
 	} else {
-		siteCollector.Visit(siteURL)
+		WaitBeforeVisit("vrphub.com", siteCollector.Visit, siteURL)
 	}
 
 	if updateSite {

--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -145,7 +145,7 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 	siteCollector.OnHTML(`div.pagination a.next`, func(e *colly.HTMLElement) {
 		if !limitScraping {
 			pageURL := e.Request.AbsoluteURL(e.Attr("href"))
-			siteCollector.Visit(pageURL)
+			WaitBeforeVisit("vrporn.com", siteCollector.Visit, pageURL)
 		}
 	})
 
@@ -153,14 +153,14 @@ func VRPorn(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<
 		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 		// If scene exists in database, or the slternate source exists, there's no need to scrape
 		if !funk.ContainsString(knownScenes, sceneURL) {
-			sceneCollector.Visit(sceneURL)
+			WaitBeforeVisit("vrporn.com", sceneCollector.Visit, sceneURL)
 		}
 	})
 
 	if singleSceneURL != "" {
 		sceneCollector.Visit(singleSceneURL)
 	} else {
-		siteCollector.Visit(siteURL + "/?sort=newest")
+		WaitBeforeVisit("vrporn.com", siteCollector.Visit, siteURL+"/?sort=newest")
 	}
 
 	if updateSite {


### PR DESCRIPTION
Fixes #1626 

The change allows you to control the rate at which pages are scraped from a site.  This is most useful when first scraping sites such as Naughty America or VRPorn which have DOS attack preventions.  Although, it may also be useful for day-to-day use if you have a large number of custom sites for VRPorn.

Rate limiting uses the rate limiting options built into colly collectors for most scrapers.  However, this does not work for scrapers that handle multiple sites/studios.  Each studio/site has it's own collector and each would have their own separate rate limits, so in these cases the rate needs to be managed across multiple colly collectors for each studio.  In these cases, the colly Visit methods calls are passed to another method first to manage the flow of calls.  Other scrapers where dealing with multiple studios is not an issue, do not require any changes to implement rate limits, this is managed in the common CreateCollector function they all use

If no rate limits are set, then a scraper performs as it current does.  The Rate Limits are stored in the kvs table, with the key "scraper_rate_limits", the suggested values for Naughty America and VRPorn are:
{ "sites": [ { "name": "www.naughtyamerica.com", "mindelay": 1000, "maxdelay": 2500 }, { "name": "vrporn.com", "mindelay": 4000, "maxdelay": 7500 } ] }

For users not comfortable modifying the database, the config can be loaded via a bundle, they will need to turn on Include Config Settings which is off by default.  Copy of a bundle with suggested values attached.

FYI: Scenes from VRPorn can be scraped faster than the settings allow, however, scraping the Actor details seems to be a lot more sensitive.

People can add other sites if rrequired, these are just the 2 I know of and tested the settings with.
[xbvr-content-bundle (Rate Limits).json](https://github.com/xbapps/xbvr/files/14676024/xbvr-content-bundle.Rate.Limits.json)
