### PR TITLE
Fixes: Rate Limiter Panics

### DIFF
--- a/pkg/scrape/scrape_rate_limiter.go
+++ b/pkg/scrape/scrape_rate_limiter.go
@@ -67,7 +67,9 @@ func WaitBeforeVisit(rateLimiter string, visitFunc func(string) error, pageURL s
 func ScraperRateLimiterCheckErrors(domain string, err error) {
 	if err != nil {
 		limiter := GetRateLimiter(domain)
-		limiter.lastRequest = time.Time{}
+		if limiter != nil {
+			limiter.lastRequest = time.Time{}
+		}
 	}
 }
 


### PR DESCRIPTION
If there is an error visiting a scene page, the rate limiter code may panic if no rate limiting is in use.
