### PR TITLE
Fix VirtualPorn migration

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1941,8 +1941,8 @@ func Migrate() {
 		{
 			ID: "0077-Update-VirtualPorn-ids",
 			Migrate: func(tx *gorm.DB) error {
-				err := scrape.UpdateVirtualPornIds()
-				return err
+				scrape.UpdateVirtualPornIds()
+				return nil
 			},
 		},
 	})

--- a/pkg/scrape/virtualporn.go
+++ b/pkg/scrape/virtualporn.go
@@ -2,7 +2,6 @@ package scrape
 
 import (
 	"encoding/json"
-	"errors"
 	"regexp"
 	"strconv"
 	"strings"
@@ -177,7 +176,7 @@ func init() {
 }
 
 // one off conversion routine called by migrations.go
-func UpdateVirtualPornIds() error {
+func UpdateVirtualPornIds() {
 	collector := createCollector("virtualporn.com")
 	apiCollector := createCollector("site-api.project1service.com")
 	offset := 0
@@ -245,10 +244,8 @@ func UpdateVirtualPornIds() error {
 
 	collector.Visit("https://virtualporn.com/videos")
 
-	if sceneCnt > 0 {
-		return nil
-	} else {
-		return errors.New("No scenes updated")
+	if sceneCnt == 0 {
+		log.Info("Unable to access VirtualPorn scenes, existing scenes could not be upgraded with new Scene Ids")
 	}
 
 }


### PR DESCRIPTION
VirtualPorn may be blocked in some areas, causing the migration to fail.

This will log a message in the log that Scenes Ids could not be migrated if VirtualPorn could not be accessed, but will not cause the migration to fail.

If a user wants to retry, they should remove the "0077-Update-VirtualPorn-ids" entry from the migrations table