### PR TITLE
Fix for missing cover 403 on low resolution SLR covers

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -161,12 +161,12 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 					coverURL := appCover
 					sc.Covers = append(sc.Covers, coverURL)
 					defer appCresp.Body.Close()
-					} else {
+				} else {
 					e.ForEach(`link[as="image"]`, func(id int, e *colly.HTMLElement) {
 						sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("href")))
-						})
-					}
+					})
 				}
+			}
 			defer desktopCresp.Body.Close()
 		} else {
 			posterURLFound := false

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -3,6 +3,7 @@ package scrape
 import (
 	"encoding/json"
 	"html"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -148,14 +149,25 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 
 		// Cover
 		if !isTransScene {
-			coverURL := strings.Replace(gjson.Get(JsonMetadataA, "thumbnailUrl").String(), "app", "desktop", -1)
-			if len(coverURL) > 0 {
+			appCover := gjson.Get(JsonMetadataA, "thumbnailUrl").String()
+			desktopCover := strings.Replace(gjson.Get(JsonMetadataA, "thumbnailUrl").String(), "app", "desktop", -1)
+			desktopCresp, desktopCerr := http.Head(desktopCover)
+			if desktopCresp.StatusCode == 200 {
+				coverURL := desktopCover
 				sc.Covers = append(sc.Covers, coverURL)
 			} else {
-				e.ForEach(`link[as="image"]`, func(id int, e *colly.HTMLElement) {
-					sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("href")))
-				})
-			}
+				appCresp, appCerr := http.Head(appCover)
+				if appCresp.StatusCode == 200 {
+					coverURL := appCover
+					sc.Covers = append(sc.Covers, coverURL)
+					defer appResp.Body.Close()
+					} else {
+					e.ForEach(`link[as="image"]`, func(id int, e *colly.HTMLElement) {
+						sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("href")))
+						})
+					}
+				}
+			defer desktopResp.Body.Close()
 		} else {
 			posterURLFound := false
 			e.ForEach(`script[type="text/javascript"]`, func(id int, e *colly.HTMLElement) {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -151,23 +151,23 @@ func SexLikeReal(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out 
 		if !isTransScene {
 			appCover := gjson.Get(JsonMetadataA, "thumbnailUrl").String()
 			desktopCover := strings.Replace(gjson.Get(JsonMetadataA, "thumbnailUrl").String(), "app", "desktop", -1)
-			desktopCresp, desktopCerr := http.Head(desktopCover)
+			desktopCresp, _ := http.Head(desktopCover)
 			if desktopCresp.StatusCode == 200 {
 				coverURL := desktopCover
 				sc.Covers = append(sc.Covers, coverURL)
 			} else {
-				appCresp, appCerr := http.Head(appCover)
+				appCresp, _ := http.Head(appCover)
 				if appCresp.StatusCode == 200 {
 					coverURL := appCover
 					sc.Covers = append(sc.Covers, coverURL)
-					defer appResp.Body.Close()
+					defer appCresp.Body.Close()
 					} else {
 					e.ForEach(`link[as="image"]`, func(id int, e *colly.HTMLElement) {
 						sc.Covers = append(sc.Covers, e.Request.AbsoluteURL(e.Attr("href")))
 						})
 					}
 				}
-			defer desktopResp.Body.Close()
+			defer desktopCresp.Body.Close()
 		} else {
 			posterURLFound := false
 			e.ForEach(`script[type="text/javascript"]`, func(id int, e *colly.HTMLElement) {


### PR DESCRIPTION
Never had to do something like this in Go, if there's a more elegant way than checking HEAD for 200 vs. 403 in a nested if/else like this do let me know.

Tested on:
* the problem scene in #1702
* a currently working scene
* a trans scene