### PR TITLE
Force siteID to populate in filename when scraping a single scene from SLR

### DIFF
--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -415,6 +415,10 @@ func appendFilenames(sc *models.ScrapedScene, siteID string, filenameRegEx *rege
 	// Only shown for logged in users so need to generate them
 	// Format: SLR_siteID_Title_<Resolutions>_SceneID_<LR/TB>_<180/360>.mp4
 	if !isTransScene {
+		// Force siteID when scraping individual scenes without a custom site
+		if siteID == "" {
+			siteID = gjson.Get(JsonMetadataA, "paysite.name").String()
+		}
 		viewAngle := gjson.Get(JsonMetadataA, "viewAngle").String()
 		projSuffix := "_LR_180.mp4"
 		if viewAngle == "190" || viewAngle == "200" || viewAngle == "220" {


### PR DESCRIPTION
Filenames currently end up with `SLR__Scene Name...` when scraping from "Scrape a scene" or clicking the button to make a linked scene an actual scene. This fixes that by checking the JSON metadata.