### PR TITLE
feat: Ability to request single models.File by id from api

### DIFF
--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -55,10 +55,29 @@ func (i FilesResource) WebService() *restful.WebService {
 	ws.Route(ws.POST("/unmatch").To(i.unmatchFile).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
+	ws.Route(ws.GET("/file/{file-id}").To(i.getFile).
+		Param(ws.PathParameter("file-id", "File ID").DataType("int")).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.File{}))
+
 	ws.Route(ws.DELETE("/file/{file-id}").To(i.removeFile).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
 	return ws
+}
+
+func (i FilesResource) getFile(req *restful.Request, resp *restful.Response) {
+	var file models.File
+
+	id, err := strconv.Atoi(req.PathParameter("file-id"))
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	_ = file.GetIfExistByPK(uint(id))
+
+	resp.WriteHeaderAndEntity(http.StatusOK, file)
 }
 
 func (i FilesResource) listFiles(req *restful.Request, resp *restful.Response) {


### PR DESCRIPTION
This PR adds ability to query the api for a single `models.File` with provided id.

Currently there is no way to get matched `scene-id` from `file-id`. You have to query for all files via `/api/files/list` which returns `[]models.File` and then select one object from the resulting list. Obviously for large libraries that is very wasteful.

Fixes #1737