### PR TITLE
Fixed the icon URLs for kinkvr and babevr

### DIFF
--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -292,6 +292,6 @@ func init() {
 	registerScraper("badoinkvr", "BadoinkVR", "https://pbs.twimg.com/profile_images/618071358933610497/QaMV81nF_200x200.png", "badoinkvr.com", BadoinkVR)
 	registerScraper("18vr", "18VR", "https://pbs.twimg.com/profile_images/989481761783545856/w-iKqgqV_200x200.jpg", "18vr.com", B18VR)
 	registerScraper("vrcosplayx", "VRCosplayX", "https://pbs.twimg.com/profile_images/900675974039298049/ofMytpkQ_200x200.jpg", "vrcosplayx.com", VRCosplayX)
-	registerScraper("babevr", "BabeVR", "https://babevr.com/babevr_icons/apple-touch-icon.png", "babevr.com", BabeVR)
-	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/kinkvr_icons/apple-touch-icon.png", "kinkvr.com", KinkVR)
+	registerScraper("babevr", "BabeVR", "https://babevr.com/icons/babevr/apple-touch-icon.png", "babevr.com", BabeVR)
+	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/icons/kinkvr/apple-touch-icon.png", "kinkvr.com", KinkVR)
 }


### PR DESCRIPTION
The icon images for kinkvr and babevr cannot be transformed and give an error. This is because the URLs of the images are incorrect. Fixed with the correct URLs.

Error:
```
2024/06/05 16:21:41 error transforming image https://kinkvr.com/kinkvr_icons/apple-touch-icon.png#128x0: image: unknown format
2024/06/05 16:21:41 error transforming image https://babevr.com/babevr_icons/apple-touch-icon.png#128x0: image: unknown format
```
