### PR TITLE
Added a tooltip to the Alternate Sites available on the Scene Details page

### DIFF
--- a/ui/src/components/RescrapeButton.vue
+++ b/ui/src/components/RescrapeButton.vue
@@ -1,0 +1,55 @@
+<template>
+  <a class="button is-dark is-outlined is-small"
+    @click="rescrapeSingleScene()"
+    :title="'Rescrape scene'">
+    <b-icon pack="mdi" icon="web-refresh" size="is-small"/>
+  </a>
+</template>
+
+<script>
+import ky from 'ky'
+export default {
+  name: 'RescrapeButton',
+  props: { item: Object },
+  methods: {
+    async rescrapeSingleScene () {
+      let site = ""
+
+      if (this.item.scene_url.toLowerCase().includes("dmm.co.jp")) {
+        ky.post('/api/task/scrape-javr', { json: { s: "r18d", q: this.item.scene_id } })
+      } else {
+
+        const sites = await ky.get('/api/options/sites').json()
+        console.info(sites)
+
+        for (const element of sites) {
+          if (this.item.scene_url.toLowerCase().includes(element.id)) {
+            site = element.id
+          }
+        }
+
+        if (this.item.scene_url.toLowerCase().includes("sexlikereal.com")) {
+          site = "slr-single_scene"
+        }
+        if (this.item.scene_url.toLowerCase().includes("czechvrnetwork.com")) {
+          site = "czechvr-single_scene"
+        }
+        if (this.item.scene_url.toLowerCase().includes("povr.com")) {
+          site = "povr-single_scene"
+        }
+        if (this.item.scene_url.toLowerCase().includes("vrporn.com")) {
+          site = "vrporn-single_scene"
+        }
+        if (this.item.scene_url.toLowerCase().includes("vrphub.com")) {
+          site = "vrphub-single_scene"
+        }
+        if (site == "") {
+          this.$buefy.toast.open({message: `No scrapers exist for this domain`, type: 'is-danger', duration: 5000})      
+          return
+        }    
+        ky.post(`/api/task/singlescrape`, {timeout: false, json: { site: site, sceneurl: this.item.scene_url, additionalinfo:[] }})
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -129,11 +129,13 @@
                   </div>
                 </div>
                 <div class="image-row is-flex is-pulled-right" v-if="getAlternateSceneSources != 0">
-                  <div v-for="(altsrc, idx) in this.alternateSources" :key="idx" class="altsrc-image-wrapper" @click="showExtRefScene(altsrc)">
+                  <div v-for="(altsrc, idx) in alternateSourcesWithTitles" :key="idx" class="altsrc-image-wrapper" @click="showExtRefScene(altsrc)">
+                    <b-tooltip type="is-light" :label="altsrc.title" :delay="100" append-to-body>
                       <vue-load-image>
                         <img slot="image" :src="getImageURL(altsrc.site_icon)" alt="Image" width="28px" />                        
                         <b-icon slot="error" pack="mdi" icon="link" size="is-small" />
                       </vue-load-image>
+                    </b-tooltip>
                   </div>
                 </div>
               </div>
@@ -576,6 +578,15 @@ export default {
     },
     quickFindOverlayState() {
       return this.$store.state.overlay.quickFind.show
+    },
+    alternateSourcesWithTitles() {
+      return this.alternateSources.map(altsrc => {
+        const extdata = JSON.parse(altsrc.external_data);
+        return {
+          ...altsrc,
+          title: extdata.scene?.title || 'No Title'
+        };
+      });
     }
   },
   mounted () {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -125,6 +125,7 @@
                       <watched-button :item="item" v-if="!displayingAlternateSource"/>
                       <edit-button :item="item"/>
                       <refresh-button :item="item" v-if="!displayingAlternateSource"/>
+                      <rescrape-button :item="item" v-if="!displayingAlternateSource"/>
                     </div>
                   </div>
                 </div>
@@ -404,12 +405,13 @@ import WishlistButton from '../../components/WishlistButton'
 import WatchedButton from '../../components/WatchedButton'
 import EditButton from '../../components/EditButton'
 import RefreshButton from '../../components/RefreshButton'
+import RescrapeButton from '../../components/RescrapeButton'
 import TrailerlistButton from '../../components/TrailerlistButton'
 import HiddenButton from '../../components/HiddenButton'
 
 export default {
   name: 'Details',
-  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WishlistButton, WatchedButton, EditButton, RefreshButton, TrailerlistButton, HiddenButton },
+  components: { VueLoadImage, GlobalEvents, StarRating, WatchlistButton, FavouriteButton, WishlistButton, WatchedButton, EditButton, RefreshButton, RescrapeButton, TrailerlistButton, HiddenButton },
   data () {
     return {
       index: 1,

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -69,13 +69,15 @@
         </span>        
       </span>
       <div class="image-row" v-if="getAlternateSceneSources != 0">
-        <div v-for="(altsrc, idx) in this.alternateSources" :key="idx" class="altsrc-image-wrapper">
-          <a :href="altsrc.url" target="_blank">
-            <vue-load-image>
-              <img slot="image" :src="getImageURL(altsrc.site_icon)" alt="Image" class="thumbnail" width="20" />
-              <b-icon slot="error" pack="mdi" icon="link" size="is-small" />
-            </vue-load-image>
-          </a>
+        <div v-for="(altsrc, idx) in alternateSourcesWithTitles" :key="idx" class="altsrc-image-wrapper">
+          <b-tooltip type="is-light" :label="altsrc.title" :delay="100">
+            <a :href="altsrc.url" target="_blank">
+              <vue-load-image>
+                <img slot="image" :src="getImageURL(altsrc.site_icon)" alt="Image" class="thumbnail" width="20" />
+                <b-icon slot="error" pack="mdi" icon="link" size="is-small" />
+              </vue-load-image>
+            </a>
+          </b-tooltip>
         </div>
       </div>    
     </div>
@@ -170,6 +172,15 @@ export default {
         return 0; // Return 0 or handle error as needed
       }
     },
+    alternateSourcesWithTitles() {
+      return this.alternateSources.map(altsrc => {
+        const extdata = JSON.parse(altsrc.external_data);
+        return {
+          ...altsrc,
+          title: extdata.scene?.title || 'No Title'
+        };
+      });
+    }
   },
   methods: {
     getImageURL (u) {


### PR DESCRIPTION
I don't know why, but Gitpod decided to merge both PRs...

But it is two different PRs.

The first added a tooltip to the Alternate Sites available on the Scene Details page.
The second added a Rescrape Scene button on the Scene Details page.