### PR TITLE
fix: Fix trailing slash in media urls returned from heresphere api

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -229,7 +229,7 @@ func (i HeresphereResource) getHeresphereFile(req *restful.Request, resp *restfu
 				Height:     height,
 				Width:      width,
 				Size:       file.Size,
-				URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v", getProto(req), req.Request.Host, file.ID, dnt),
+				URL:        fmt.Sprintf("%v://%v/api/dms/file/%v%v", getProto(req), req.Request.Host, file.ID, dnt),
 			},
 		},
 	})
@@ -344,7 +344,7 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 					Height:     height,
 					Width:      width,
 					Size:       file.Size,
-					URL:        fmt.Sprintf("%v://%v/api/dms/file/%v/%v", getProto(req), req.Request.Host, file.ID, dnt),
+					URL:        fmt.Sprintf("%v://%v/api/dms/file/%v%v", getProto(req), req.Request.Host, file.ID, dnt),
 				},
 			},
 		}


### PR DESCRIPTION
When using the `/heresphere` api the media urls are returned with a trailing slash:
```
http://localhost:9999/api/dms/file/1/
http://localhost:9999/api/dms/file/1/?dnt=true
```

This PR fixes it to:
```
http://localhost:9999/api/dms/file/1
http://localhost:9999/api/dms/file/1?dnt=true
```

Which also matches the `/deovr` api:
https://github.com/xbapps/xbvr/blob/9f253fea5ca21fdfb4fd109769fbf72b55ec090d/pkg/api/deovr.go#L402

Blame #969 