### PR TITLE
stasyqvr_dupe_filenames

### DIFF
--- a/pkg/scrape/stasyqvr.go
+++ b/pkg/scrape/stasyqvr.go
@@ -101,7 +101,6 @@ func StasyQVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 			base = strings.Replace(base, "\"", "", -1)
 			if !funk.ContainsString(sc.Filenames, base) {
 				sc.Filenames = append(sc.Filenames, base)
-				sc.Filenames = append(sc.Filenames, strings.Replace(base, "original_", "original_"+sc.SiteID, -1))
 			}
 		})
 


### PR DESCRIPTION
scraper: fix duplicating filenames. filenames have been duplicated since day one of the scraper. this will reduce future filenames_arr to single filename listings. force update to remove already duped filenames.