### PR TITLE
Update RescrapeButton.vue/.gitpod.yml/.gitpod.dockerfile

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -11,7 +11,7 @@ RUN export PATH=$(echo "$PATH" | sed -e 's|:/workspace/go/bin||' -e 's|:/home/gi
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
 
 RUN go install -v \
-  github.com/cosmtrek/air@latest && \
+  github.com/air-verse/air@latest && \
   sudo rm -rf $GOPATH/src && \
   sudo rm -rf $GOPATH/pkg
 # user Go packages

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.dockerfile
 tasks:
   - name: Continuous Build
-    command: yarn config set ignore-engines true && yarn global add concurrently && go install github.com/cosmtrek/air@latest && cd /workspace/xbvr && go generate && go get && yarn && yarn dev
+    command: yarn config set ignore-engines true && yarn global add concurrently && go install github.com/air-verse/air@latest && cd /workspace/xbvr && go generate && go get && yarn && yarn dev
 ports:
   - port: 9999
     onOpen: open-preview

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -884,6 +884,8 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 			where = `scenes.scene_id like "povr-%"`
 		case "SLR Scraper":
 			where = `scenes.scene_id like "slr-%"`
+		case "Has Image":
+			where = "cover_url not in ('','http://localhost/dont_cause_errors')"
 		case "VRPHub Scraper":
 			where = `scenes.scene_id like "vrphub-%"`
 		case "VRPorn Scraper":

--- a/ui/src/components/RescrapeButton.vue
+++ b/ui/src/components/RescrapeButton.vue
@@ -1,7 +1,7 @@
 <template>
   <a class="button is-dark is-outlined is-small"
-    @click="rescrapeSingleScene()"
-    :title="'Rescrape scene'">
+    @click="rescrapeScene()"
+    :title="'Rescrape Scene'">
     <b-icon pack="mdi" icon="web-refresh" size="is-small"/>
   </a>
 </template>
@@ -12,42 +12,51 @@ export default {
   name: 'RescrapeButton',
   props: { item: Object },
   methods: {
-    async rescrapeSingleScene () {
+    delay(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    },
+    async rescrapeScene () {
       let site = ""
 
-      if (this.item.scene_url.toLowerCase().includes("dmm.co.jp")) {
-        ky.post('/api/task/scrape-javr', { json: { s: "r18d", q: this.item.scene_id } })
+      this.$store.commit('sceneList/toggleSceneList', {scene_id: this.item.scene_id, list: 'needs_update'})
+      if (this.item.scraper_id && this.item.needs_update) {
+        await this.delay(200);
+        ky.get(`/api/task/scrape?site=${this.item.scraper_id}`)
       } else {
+        if (this.item.scene_url.toLowerCase().includes("dmm.co.jp")) {
+          ky.post('/api/task/scrape-javr', { json: { s: "r18d", q: this.item.scene_id } })
+        } else {
 
-        const sites = await ky.get('/api/options/sites').json()
-        console.info(sites)
+          const sites = await ky.get('/api/options/sites').json()
+          console.info(sites)
 
-        for (const element of sites) {
-          if (this.item.scene_url.toLowerCase().includes(element.id)) {
-            site = element.id
+          for (const element of sites) {
+            if (this.item.scene_url.toLowerCase().includes(element.id)) {
+              site = element.id
+            }
           }
-        }
 
-        if (this.item.scene_url.toLowerCase().includes("sexlikereal.com")) {
-          site = "slr-single_scene"
+          if (this.item.scene_url.toLowerCase().includes("sexlikereal.com")) {
+            site = "slr-single_scene"
+          }
+          if (this.item.scene_url.toLowerCase().includes("czechvrnetwork.com")) {
+            site = "czechvr-single_scene"
+          }
+          if (this.item.scene_url.toLowerCase().includes("povr.com")) {
+            site = "povr-single_scene"
+          }
+          if (this.item.scene_url.toLowerCase().includes("vrporn.com")) {
+            site = "vrporn-single_scene"
+          }
+          if (this.item.scene_url.toLowerCase().includes("vrphub.com")) {
+            site = "vrphub-single_scene"
+          }
+          if (site == "") {
+            this.$buefy.toast.open({message: `No scrapers exist for this domain`, type: 'is-danger', duration: 5000})      
+            return
+          }    
+          ky.post(`/api/task/singlescrape`, {timeout: false, json: { site: site, sceneurl: this.item.scene_url, additionalinfo:[] }})
         }
-        if (this.item.scene_url.toLowerCase().includes("czechvrnetwork.com")) {
-          site = "czechvr-single_scene"
-        }
-        if (this.item.scene_url.toLowerCase().includes("povr.com")) {
-          site = "povr-single_scene"
-        }
-        if (this.item.scene_url.toLowerCase().includes("vrporn.com")) {
-          site = "vrporn-single_scene"
-        }
-        if (this.item.scene_url.toLowerCase().includes("vrphub.com")) {
-          site = "vrphub-single_scene"
-        }
-        if (site == "") {
-          this.$buefy.toast.open({message: `No scrapers exist for this domain`, type: 'is-danger', duration: 5000})      
-          return
-        }    
-        ky.post(`/api/task/singlescrape`, {timeout: false, json: { site: site, sceneurl: this.item.scene_url, additionalinfo:[] }})
       }
     }
   }


### PR DESCRIPTION
### RescrapeButton.vue
Updated the Rescrape Scene function to work with scenes that have scrape_id and belong to a configured scraper. By toggling it's needs_update and running that scraper.
It can be useful in case of single scenes without images.
I've had to add a small delay (200ms) as it was not triggering the forceUpdate when making the API call, even when checking if this.item.needs_update was true.

### .gitpod.yml/.gitpod.dockerfile

The repo github.com/cosmtrek/air doesn't exist anymore. When running Gitpod, it suggests using github.com/air-verse/air instead.

## Edit
### Has Image Filter
I added a "Has Image" filter at model_scene.go file. It was present in pkg/api/scenes.go but absent from pkg/models/model_scene.go

PS: I'm sorry that the PR got merged, I'm not versed on git, it's my second try to submit more than one PR in a single version, and I failed both times in submitting two separate PRs. But I think it's easier to submit the PRs than just open an issue with what's going on.
