### PR TITLE
Fix extra unreferenced tags been created

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -53,6 +53,7 @@ func (i *RequestSceneList) ToJSON() string {
 }
 
 func Migrate() {
+	var retryMigration []string
 	db, _ := models.GetDB()
 
 	m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
@@ -1967,7 +1968,21 @@ func Migrate() {
 			// remove unreferenced tags created due to an error
 			ID: "0079-remove-unreferenced-tags",
 			Migrate: func(tx *gorm.DB) error {
+				// update tag counts
 				tasks.CountTags()
+
+				// check there are no Tags with a count of 0 that are in use, should not happen if CountTags is working properly,
+				//  but don't want to risk a referential integrity issue
+				type tagsInUse struct {
+					Cnt int
+				}
+				var result tagsInUse
+				db.Raw("select count(*) as cnt from scene_tags st join scenes s on s.id=st.scene_id join tags t on t.id=st.tag_id where t.`count` = 0 and s.deleted_at is NULL").Scan(&result)
+				if result.Cnt > 0 {
+					// this should never happen, but not deleting unreferenced tags will not break the system, so don't fail the migration, flag it to retry
+					retryMigration = append(retryMigration, "0079-remove-unreferenced-tags")
+					return nil
+				}
 				return tx.Model(&models.Tag{}).Exec("delete from tags where `count` = 0").Error
 			},
 		},
@@ -1975,6 +1990,15 @@ func Migrate() {
 
 	if err := m.Migrate(); err != nil {
 		common.Log.Fatalf("Could not migrate: %v", err)
+	}
+	if len(retryMigration) > 0 {
+		for _, migration := range retryMigration {
+			common.Log.Warnf("*** MIGRATION WARNING ***: Could not migrate: '%v', this migration will retry the next time XBVR is started", migration)
+			err := db.Exec("DELETE FROM migrations WHERE id = ?", migration).Error
+			if err != nil {
+				common.Log.Fatalf("Failed to remove %v from the miigration table - will not be retried", err)
+			}
+		}
 	}
 	common.Log.Printf("Migration did run successfully")
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -1963,6 +1963,14 @@ func Migrate() {
 				return db.Where("scene_id = ?", "virtualtaboo-").Delete(&models.Scene{}).Error
 			},
 		},
+		{
+			// remove unreferenced tags created due to an error
+			ID: "0079-remove-unreferenced-tags",
+			Migrate: func(tx *gorm.DB) error {
+				tasks.CountTags()
+				return tx.Model(&models.Tag{}).Exec("delete from tags where `count` = 0").Error
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -433,16 +433,17 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 	var site Site
 	db.Where("id = ?", o.ScraperId).FirstOrInit(&site)
 	o.IsSubscribed = site.Subscribed
-	SaveWithRetry(db, &o)
 
 	// Clean & Associate Tags
 	var tags = o.Tags
 	db.Model(&o).Association("Tags").Clear()
-	for _, tag := range tags {
+	for idx, tag := range tags {
 		tmpTag := Tag{}
 		db.Where(&Tag{Name: tag.Name}).FirstOrCreate(&tmpTag)
-		db.Model(&o).Association("Tags").Append(tmpTag)
+		tags[idx] = tmpTag
 	}
+	o.Tags = tags
+	SaveWithRetry(db, &o)
 
 	// Clean & Associate Actors
 	db.Model(&o).Association("Cast").Clear()


### PR DESCRIPTION
Fixes  #1707 

Fixes an issue where duplicate Tags are been created during scene scrapping but are not referenced by any scenes.

Includes a migration to remove unreferenced tags, i.e. where the count column in the tag = 0. If Tag records with the count of 0 exists and should be deleted but is referenced in the scene_tags table, it will not delete the unreferenced tags.  This should not happen but is just a precaution, so a data referential integrity issue is not created.
 
I have updated the migration logic to allow a migration to be flagged to retry.  This is useful where the migration is not required for the new version of Xbvr to run, e.g. the unreferenced tags are not causing an issue other than creating unused entries in the tags table.  Another, example where this could be useful would be adding an index, adding the index would make the system faster but if the migration failed create the index, the new version would still run.  Retriable migrations would not be the norm.  To flag a migration to retry, you can add the Migration Id to the `retryMigration` array and return nil from the migration function.  The Id will be removed from the migrations table so it tries again the next time xbvr runs.