### PR TITLE
Refresh Actor Data After Manually Linking to Stashdb

### DIFF
--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -11,6 +11,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/xbapps/xbvr/pkg/models"
+	"github.com/xbapps/xbvr/pkg/scrape"
 )
 
 type ResponseGetActors struct {
@@ -746,6 +747,9 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 				ExternalReferenceID: extref.ID, ExternalSource: extref.ExternalSource, ExternalId: extref.ExternalId, MatchType: 0})
 			extref.Save()
 			models.AddActionActor(actor.ID, "edit_actor", "add", "external_reference_link", url)
+			if extref.ExternalSource == "stashdb performer" {
+				scrape.RefreshPerformer(extref.ExternalId)
+			}
 		} else {
 			// external reference exists, but check it is linked to this actor
 			found := false
@@ -761,6 +765,9 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 					ExternalReferenceID: extref.ID, ExternalSource: extref.ExternalSource, ExternalId: extref.ExternalId, MatchType: 0}
 				newLink.Save()
 				models.AddActionActor(actor.ID, "edit_actor", "add", "external_reference_link", url)
+				if extref.ExternalSource == "stashdb performer" {
+					scrape.RefreshPerformer(extref.ExternalId)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently you can edit an Actors details and manually specify the Url to the Actors Page on stashdb.  You can then go to the Scrapers Tab for the Actor and manually refresh the Stashdb Performer data.

This is a minor change to also automatically update the Actors data from Stashdb when you manually enter the Url.