### PR TITLE
Consider StashdbPerformer.As field when match Actors with Stashdb

### DIFF
--- a/pkg/externalreference/stashdb.go
+++ b/pkg/externalreference/stashdb.go
@@ -249,7 +249,8 @@ func checkMatchedScenes() {
 
 					// if len(ref.XbvrLinks) == 0 {
 					for _, xbvrActor := range xbvrScene.Cast {
-						if strings.EqualFold(strings.TrimSpace(simplifyName(xbvrActor.Name)), strings.TrimSpace(simplifyName(performer.Performer.Name))) {
+						if strings.EqualFold(strings.TrimSpace(simplifyName(xbvrActor.Name)), strings.TrimSpace(simplifyName(performer.Performer.Name))) ||
+							strings.EqualFold(strings.TrimSpace(simplifyName(xbvrActor.Name)), strings.TrimSpace(simplifyName(performer.As))) {
 							// check if actor already matched
 							exists := false
 							for _, link := range ref.XbvrLinks {


### PR DESCRIPTION
This is a minor enhancement to consider the As field on the Stashdb Scene when matching Actors with XBVR.  If the As field matches the XBVR Actor's name, they will now be linked.