### PR TITLE
Fix Duplicate Actor Scraper Entries

### DIFF
--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -731,7 +731,7 @@ func (i ActorResource) editActorExtRefs(req *restful.Request, resp *restful.Resp
 	// add new links
 	for _, url := range urls {
 		var extref models.ExternalReference
-		extref.FindExternalUrl(extref.DetermineActorScraperByUrl(url), url)
+		commonDb.Preload("XbvrLinks").Where(&models.ExternalReference{ExternalURL: url}).First(&extref)
 		if extref.ID == 0 {
 			// create new extref + link
 			extref.ExternalSource = extref.DetermineActorScraperByUrl(url)


### PR DESCRIPTION
This fixes a issue when editing the Urls in the Actors Scraper List, duplicate entries may be created.