### PR TITLE
Fix NaughtyAmerica Cast been returned as undefined

### DIFF
--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -139,6 +139,7 @@ func NaughtyAmericaVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string,
 				vm := otto.New()
 
 				script := e.Text
+				script = strings.ReplaceAll(script, "nanalytics.trackExperiment('scene_page_viewed', 'streaming_option_join_button');", "")
 				script = strings.Replace(script, "window.dataLayer", "dataLayer", -1)
 				script = strings.Replace(script, "dataLayer = dataLayer || []", "dataLayer = []", -1)
 				script = script + "\nout = []; dataLayer.forEach(function(v) { if (v.femaleStar) { out.push(v.femaleStar); } });"


### PR DESCRIPTION
A change on NaughtyAmerica is causing Cast members to be returned as undefined.

This related to the nanalytics object in scripts now returning undefined?? Removed the refence to it as we don't need it to get the cast.