### PR TITLE
Add VRAllure Members Link

### DIFF
--- a/pkg/scrape/vrallure.go
+++ b/pkg/scrape/vrallure.go
@@ -37,6 +37,7 @@ func VRAllure(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out cha
 		sc.Studio = "VRAllure"
 		sc.Site = siteID
 		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+		sc.MembersUrl = strings.Replace(sc.HomepageURL, "https://vrallure.com/scenes/", "https://ma.vrallure.com/scene/", 1)
 
 		// Scene ID - get from URL
 		tmp := strings.Split(sc.HomepageURL, "/")


### PR DESCRIPTION
Confirmed works. The members link is located here `https://ma.vrallure.com/scene` the preview link is here `https://vrallure.com/scenes` Both the Members and Preview link send the user to the correct location. 