### PR TITLE
Fix VRSpy scene id

### DIFF
--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -38,7 +38,7 @@ func VRSpy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		sc.Site = siteID
 		sc.HomepageURL = e.Request.URL.String()
 
-		ogimage := e.ChildAttr(`meta[property="og:image"]`, "content")
+		ogimage := e.ChildAttr(`meta[property="og:image"][content*="cover.jpg"]`, "content")
 		if ogimage != "" {
 			ogimageURL, err := url.Parse(ogimage)
 			if err == nil {


### PR DESCRIPTION
The Scene Id is now wrong due to VRspy pages having a new tag that matches the selector used for the Scene Id.  Updated the select to be more specific.