### PR TITLE
[URGENT] POVR Scrape Fix

### DIFF
--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -124,8 +124,8 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 	siteCollector.OnHTML(`div.thumbnail-wrap div.thumbnail a.thumbnail__link`, func(e *colly.HTMLElement) {
 		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 
-		// If scene exists in database, or the slternate source exists, there's no need to scrape
-		if !funk.ContainsString(knownScenes, sceneURL) && !strings.Contains(sceneURL, "/join") {
+		// If scene exists in database, or the slternate source exists, there's no need to scrape. Also make sure we only grab valid scene links in the vr-porn directory
+		if !funk.ContainsString(knownScenes, sceneURL) && strings.Contains(sceneURL, "/vr-porn") and !strings.Contains(sceneURL, "/join") {
 			WaitBeforeVisit("povr.com", sceneCollector.Visit, sceneURL)
 		}
 	})

--- a/pkg/scrape/povr.go
+++ b/pkg/scrape/povr.go
@@ -125,7 +125,7 @@ func POVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<- 
 		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 
 		// If scene exists in database, or the slternate source exists, there's no need to scrape. Also make sure we only grab valid scene links in the vr-porn directory
-		if !funk.ContainsString(knownScenes, sceneURL) && strings.Contains(sceneURL, "/vr-porn") and !strings.Contains(sceneURL, "/join") {
+		if !funk.ContainsString(knownScenes, sceneURL) && strings.Contains(sceneURL, "/vr-porn") && !strings.Contains(sceneURL, "/join") {
 			WaitBeforeVisit("povr.com", sceneCollector.Visit, sceneURL)
 		}
 	})


### PR DESCRIPTION
They are now putting porn star suggestions on the same page as scenes. This has the same search parameters as the scenes. The easiest way is to make sure that links only in the `/vr-porn` directory are scraped. As there really isn't any identifiable way to target only the scene links through Query Selectors