### PR TITLE
Fix StashDB DB locked errors

### DIFF
--- a/pkg/scrape/stashdb.go
+++ b/pkg/scrape/stashdb.go
@@ -79,7 +79,7 @@ func StashDb() {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
 		defer models.RemoveLock("scrape")
-		
+
 		t0 := time.Now()
 		tlog := log.WithField("task", "scrape")
 		tlog.Infof("StashDB Scraping started at %s", t0.Format("Mon Jan _2 15:04:05 2006"))


### PR DESCRIPTION
Since the stashDB scraper is called directly via `scrape.StashDb()` through `api.StashDB()` and not though `tasks.Scrape()` All the locked code that is associated with `tasks.Scrape()` is not used. So DB acitions in `stashDB()` are being blocked. I believe this is causing errors when multiple process attempt to run as other processes lock the DB but stashDB does not and doesn't check either.

Also updated the start code to bring it more in line with how `tasks.Scrape()` starts as `scrapeID` and `siteID` are only used in this one instance.

Testing required to confirm squash