### PR TITLE
Open Tags In A New Window 

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -43,22 +43,23 @@ type VersionCheckResponse struct {
 }
 
 type RequestSaveOptionsWeb struct {
-	TagSort           string `json:"tagSort"`
-	SceneHidden       bool   `json:"sceneHidden"`
-	SceneWatchlist    bool   `json:"sceneWatchlist"`
-	SceneFavourite    bool   `json:"sceneFavourite"`
-	SceneWishlist     bool   `json:"sceneWishlist"`
-	SceneWatched      bool   `json:"sceneWatched"`
-	SceneEdit         bool   `json:"sceneEdit"`
-	SceneDuration     bool   `json:"sceneDuration"`
-	SceneCuepoint     bool   `json:"sceneCuepoint"`
-	ShowHspFile       bool   `json:"showHspFile"`
-	ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
-	SceneTrailerlist  bool   `json:"sceneTrailerlist"`
-	ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
-	ShowAllHeatmaps   bool   `json:"showAllHeatmaps"`
-	UpdateCheck       bool   `json:"updateCheck"`
-	IsAvailOpacity    int    `json:"isAvailOpacity"`
+	TagSort             string `json:"tagSort"`
+	SceneHidden         bool   `json:"sceneHidden"`
+	SceneWatchlist      bool   `json:"sceneWatchlist"`
+	SceneFavourite      bool   `json:"sceneFavourite"`
+	SceneWishlist       bool   `json:"sceneWishlist"`
+	SceneWatched        bool   `json:"sceneWatched"`
+	SceneEdit           bool   `json:"sceneEdit"`
+	SceneDuration       bool   `json:"sceneDuration"`
+	SceneCuepoint       bool   `json:"sceneCuepoint"`
+	ShowHspFile         bool   `json:"showHspFile"`
+	ShowSubtitlesFile   bool   `json:"showSubtitlesFile"`
+	SceneTrailerlist    bool   `json:"sceneTrailerlist"`
+	ShowScriptHeatmap   bool   `json:"showScriptHeatmap"`
+	ShowAllHeatmaps     bool   `json:"showAllHeatmaps"`
+	ShowOpenInNewWindow bool   `json:"showOpenInNewWindow"`
+	UpdateCheck         bool   `json:"updateCheck"`
+	IsAvailOpacity      int    `json:"isAvailOpacity"`
 }
 
 type RequestSaveOptionsAdvanced struct {
@@ -470,6 +471,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.SceneTrailerlist = r.SceneTrailerlist
 	config.Config.Web.ShowScriptHeatmap = r.ShowScriptHeatmap
 	config.Config.Web.ShowAllHeatmaps = r.ShowAllHeatmaps
+	config.Config.Web.ShowOpenInNewWindow = r.ShowOpenInNewWindow
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.Config.Web.IsAvailOpacity = r.IsAvailOpacity
 	config.SaveConfig()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,22 +30,23 @@ type ObjectConfig struct {
 		Password string `default:"" json:"password"`
 	} `json:"security"`
 	Web struct {
-		TagSort           string `default:"by-tag-count" json:"tagSort"`
-		SceneHidden       bool   `default:"true" json:"sceneHidden"`
-		SceneWatchlist    bool   `default:"true" json:"sceneWatchlist"`
-		SceneFavourite    bool   `default:"true" json:"sceneFavourite"`
-		SceneWishlist     bool   `default:"true" json:"sceneWishlist"`
-		SceneWatched      bool   `default:"false" json:"sceneWatched"`
-		SceneEdit         bool   `default:"false" json:"sceneEdit"`
-		SceneDuration     bool   `default:"false" json:"sceneDuration"`
-		SceneCuepoint     bool   `default:"true" json:"sceneCuepoint"`
-		ShowHspFile       bool   `default:"true" json:"showHspFile"`
-		ShowSubtitlesFile bool   `default:"true" json:"showSubtitlesFile"`
-		SceneTrailerlist  bool   `default:"true" json:"sceneTrailerlist"`
-		ShowScriptHeatmap bool   `default:"true" json:"showScriptHeatmap"`
-		ShowAllHeatmaps   bool   `default:"false" json:"showAllHeatmaps"`
-		UpdateCheck       bool   `default:"true" json:"updateCheck"`
-		IsAvailOpacity    int    `default:"40" json:"isAvailOpacity"`
+		TagSort             string `default:"by-tag-count" json:"tagSort"`
+		SceneHidden         bool   `default:"true" json:"sceneHidden"`
+		SceneWatchlist      bool   `default:"true" json:"sceneWatchlist"`
+		SceneFavourite      bool   `default:"true" json:"sceneFavourite"`
+		SceneWishlist       bool   `default:"true" json:"sceneWishlist"`
+		SceneWatched        bool   `default:"false" json:"sceneWatched"`
+		SceneEdit           bool   `default:"false" json:"sceneEdit"`
+		SceneDuration       bool   `default:"false" json:"sceneDuration"`
+		SceneCuepoint       bool   `default:"true" json:"sceneCuepoint"`
+		ShowHspFile         bool   `default:"true" json:"showHspFile"`
+		ShowSubtitlesFile   bool   `default:"true" json:"showSubtitlesFile"`
+		SceneTrailerlist    bool   `default:"true" json:"sceneTrailerlist"`
+		ShowScriptHeatmap   bool   `default:"true" json:"showScriptHeatmap"`
+		ShowAllHeatmaps     bool   `default:"false" json:"showAllHeatmaps"`
+		ShowOpenInNewWindow bool   `default:"true" json:"showOpenInNewWindow"`
+		UpdateCheck         bool   `default:"true" json:"updateCheck"`
+		IsAvailOpacity      int    `default:"40" json:"isAvailOpacity"`
 	} `json:"web"`
 	Advanced struct {
 		ShowInternalSceneId          bool      `default:"false" json:"showInternalSceneId"`

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -12,22 +12,23 @@ type ObjectState struct {
 		BoundIP []string `json:"bound_ip"`
 	} `json:"server"`
 	Web struct {
-		TagSort           string `json:"tagSort"`
-		SceneHidden       bool   `json:"sceneHidden"`
-		SceneWatchlist    bool   `json:"sceneWatchlist"`
-		SceneFavourite    bool   `json:"sceneFavourite"`
-		SceneWishlist     bool   `json:"sceneWishlist"`
-		SceneWatched      bool   `json:"sceneWatched"`
-		SceneEdit         bool   `json:"sceneEdit"`
-		SceneDuration     bool   `json:"sceneDuration"`
-		SceneCuepoint     bool   `json:"sceneCuepoint"`
-		ShowHspFile       bool   `json:"showHspFile"`
-		ShowSubtitlesFile bool   `json:"showSubtitlesFile"`
-		SceneTrailerlist  bool   `json:"sceneTrailerlist"`
-		ShowScriptHeatmap bool   `json:"showScriptHeatmap"`
-		ShowAllHeatmaps   bool   `json:"showAllHeatmaps"`
-		UpdateCheck       bool   `json:"updateCheck"`
-		IsAvailOpacity    int    `json:"isAvailOpacity"`
+		TagSort             string `json:"tagSort"`
+		SceneHidden         bool   `json:"sceneHidden"`
+		SceneWatchlist      bool   `json:"sceneWatchlist"`
+		SceneFavourite      bool   `json:"sceneFavourite"`
+		SceneWishlist       bool   `json:"sceneWishlist"`
+		SceneWatched        bool   `json:"sceneWatched"`
+		SceneEdit           bool   `json:"sceneEdit"`
+		SceneDuration       bool   `json:"sceneDuration"`
+		SceneCuepoint       bool   `json:"sceneCuepoint"`
+		ShowHspFile         bool   `json:"showHspFile"`
+		ShowSubtitlesFile   bool   `json:"showSubtitlesFile"`
+		SceneTrailerlist    bool   `json:"sceneTrailerlist"`
+		ShowScriptHeatmap   bool   `json:"showScriptHeatmap"`
+		ShowAllHeatmaps     bool   `json:"showAllHeatmaps"`
+		ShowOpenInNewWindow bool   `json:"showOpenInNewWindow"`
+		UpdateCheck         bool   `json:"updateCheck"`
+		IsAvailOpacity      int    `json:"isAvailOpacity"`
 	} `json:"web"`
 	DLNA struct {
 		Running  bool     `json:"running"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -19,6 +19,7 @@ const state = {
     isAvailOpacity: 40,
     showScriptHeatmap: false,
     showAllHeatmaps: false,
+    showOpenInNewWindow: true,
     updateCheck: true
   }
 }
@@ -46,7 +47,8 @@ const actions = {
         state.web.showScriptHeatmap = data.config.web.showScriptHeatmap
         state.web.showAllHeatmaps = data.config.web.showAllHeatmaps
         state.web.updateCheck = data.config.web.updateCheck
-        state.web.isAvailOpacity = data.config.web.isAvailOpacity        
+        state.web.isAvailOpacity = data.config.web.isAvailOpacity 
+        state.web.showOpenInNewWindow = data.config.web.showOpenInNewWindow
         state.loading = false
       })
   },
@@ -71,6 +73,7 @@ const actions = {
         state.web.showAllHeatmaps = data.showAllHeatmaps
         state.web.updateCheck = data.updateCheck
         state.web.isAvailOpacity = data.isAvailOpacity        
+        state.web.showOpenInNewWindow = data.showOpenInNewWindow
         state.loading = false
       })
   }

--- a/ui/src/views/actors/ActorDetails.vue
+++ b/ui/src/views/actors/ActorDetails.vue
@@ -151,7 +151,10 @@
                       {{ actor.biography }}
                     </b-message>
                 </b-tab-item>
-                <b-tab-item :label="`Scenes (${actor.scenes.length})`">
+                <b-tab-item>
+                  <template #header>                    
+                    Scenes ({{ actor.scenes.length }}) <a v-if="showOpenInNewWindow" :href='getCastScenesUrl([actor.name])' target="_blank" style="padding-left: 0.1em; border-bottom-style: none;"><b-icon pack="mdi" icon="open-in-new" size="is-small" style="background-color: hsl(0, 0%, 100%);"></b-icon></a>
+                  </template>
                   <div v-show="activeTab == 1" :class="['columns', 'is-multiline', actor.scenes.length > 6 ? 'scroll' : '']">
                     <div :class="['column', 'is-multiline', 'is-one-third']"
                       v-for="(scene, idx) in actor.scenes" :key="idx" class="image-wrapper">
@@ -311,6 +314,9 @@ export default {
     },
     showEdit () {
       return this.$store.state.overlay.actoredit.show
+    },
+    showOpenInNewWindow () {
+      return this.$store.state.optionsWeb.web.showOpenInNewWindow
     },
   },
   mounted () {    
@@ -594,6 +600,19 @@ export default {
         }
       }      
       return true
+    },
+    getCastScenesUrl(actor) {
+      let newfilters = Object.assign({}, this.$store.state.sceneList.filters);
+      console.log(newfilters)
+      newfilters.cast = actor;
+      newfilters.dlState = "any"
+      newfilters.isAvailable=null
+      newfilters.isAccessible=null
+      console.log(newfilters)
+      return this.$router.resolve({
+        name: 'scenes',
+        query: { q: Buffer.from(JSON.stringify(newfilters)).toString('base64') }
+      }).href
     },
     refreshScraper(url){
       if (url.includes('stashdb')) {

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -85,6 +85,11 @@
                 show All Heatmaps
               </b-switch>
             </b-field>
+            <b-field>
+              <b-switch v-model="openInNewWindow" type="is-dark">
+                show Open Tag in New Window
+              </b-switch>
+            </b-field>
             <b-field label="Opacity of unavailable scenes">
               <div class="columns">
                 <div class="column is-two-thirds">
@@ -239,6 +244,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.showSubtitlesFile = value
+      }
+    },
+    openInNewWindow: {
+      get () {
+        return this.$store.state.optionsWeb.web.showOpenInNewWindow
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showOpenInNewWindow = value
       }
     },
     isAvailOpacity: {

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -160,13 +160,19 @@
 
             <div class="block-tags block" v-if="activeTab != 1">
               <b-taglist>
-                <a v-for="(c, idx) in item.cast" :key="'cast' + idx" @click='showCastScenes([c.name])'
-                   class="tag is-warning is-small">{{ c.name }} ({{ c.avail_count }}/{{ c.count }})</a>
-                <a @click='showSiteScenes([item.site])'
-                   class="tag is-primary is-small">{{ item.site }}</a>
-                <a v-for="(tag, idx) in item.tags" :key="'tag' + idx" @click='showTagScenes([tag.name])'
-                   class="tag is-info is-small">{{ tag.name }} ({{ tag.count }})</a>
-              </b-taglist>
+                <span v-for="(c, idx) in item.cast" :key="'cast' + idx" >
+                  <a class="tag is-warning is-small" @click='showCastScenes([c.name])' :style="showOpenInNewWindow ? 'margin-right: 0;': 'margin-right: .5em;'" >{{ c.name }} ({{ c.avail_count }}/{{ c.count }})</a>
+                  <a v-if="showOpenInNewWindow" class="tag is-warning is-small" :href='getCastScenesUrl([c.name])' target="_blank" style="margin-right: 0.5em;"><b-icon pack="mdi" icon="open-in-new" size="is-small"></b-icon></a>
+                </span>
+                <span>
+                  <a @click='showSiteScenes([item.site])' class="tag is-primary is-small" :style="showOpenInNewWindow ? 'margin-right: 0;': 'margin-right: .5em;'">{{ item.site }}</a>
+                  <a v-if="showOpenInNewWindow" class="tag is-primary is-small" :href='getSiteScenesUrl([item.site])' target="_blank" style="margin-right: 0.5em;"><b-icon pack="mdi" icon="open-in-new" size="is-small"></b-icon></a>
+                </span>
+                <span v-for="(tag, idx) in item.tags" :key="'tag' + idx">
+                  <a  @click='showTagScenes([tag.name])' class="tag is-info is-small" :style="showOpenInNewWindow ? 'margin-right: 0;': 'margin-right: .5em;'">{{ tag.name }} ({{ tag.count }})</a>
+                  <a v-if="showOpenInNewWindow" class="tag is-info is-small" :href='getTagScenesUrl([tag.name])' target="_blank" style="margin-right: 0.5em;"><b-icon pack="mdi" icon="open-in-new" size="is-small"></b-icon></a>
+                </span>
+              </b-taglist>              
             </div>
 
             <div class="block-tags block" v-if="activeTab == 1">
@@ -581,6 +587,9 @@ export default {
     quickFindOverlayState() {
       return this.$store.state.overlay.quickFind.show
     },
+    showOpenInNewWindow () {
+      return this.$store.state.optionsWeb.web.showOpenInNewWindow
+    },
     alternateSourcesWithTitles() {
       return this.alternateSources.map(altsrc => {
         const extdata = JSON.parse(altsrc.external_data);
@@ -714,6 +723,17 @@ watch:{
       })
       this.close()
     },
+    getCastScenesUrl(actor) {
+      let newfilters = Object.assign({}, this.$store.state.sceneList.filters);
+      newfilters.cast = actor;       
+      newfilters.sites = []
+      newfilters.tags = []
+      newfilters.attributes = []
+      return this.$router.resolve({
+        name: 'scenes',
+        query: { q: Buffer.from(JSON.stringify(newfilters)).toString('base64') }
+      }).href
+    },
     showTagScenes (tag) {
       this.$store.state.sceneList.filters.cast = []
       this.$store.state.sceneList.filters.sites = []
@@ -725,6 +745,17 @@ watch:{
       })
       this.close()
     },
+    getTagScenesUrl(tag) {
+      let newfilters = Object.assign({}, this.$store.state.sceneList.filters);      
+      newfilters.tags = tag;       
+      newfilters.cast = []       
+      newfilters.sites = []
+      newfilters.attributes = []
+      return this.$router.resolve({
+        name: 'scenes',
+        query: { q: Buffer.from(JSON.stringify(newfilters)).toString('base64') }
+      }).href
+    },
     showSiteScenes (site) {
       this.$store.state.sceneList.filters.cast = []
       this.$store.state.sceneList.filters.sites = site
@@ -735,6 +766,17 @@ watch:{
         query: { q: this.$store.getters['sceneList/filterQueryParams'] }
       })
       this.close()
+    },
+    getSiteScenesUrl(site) {
+      let newfilters = Object.assign({}, this.$store.state.sceneList.filters);
+      newfilters.sites = site;       
+      newfilters.cast = []       
+      newfilters.tags = []
+      newfilters.attributes = []
+      return this.$router.resolve({
+        name: 'scenes',
+        query: { q: Buffer.from(JSON.stringify(newfilters)).toString('base64') }
+      }).href
     },
     showActorDetail (actor_id) {
       ky.get('/api/actor/'+actor_id).json().then(data => {


### PR DESCRIPTION
In the Scene Detail, the Tag Lists for Cast, Site and Tags can be clicked to take you to the scene list, filtered by the Tag you clicked.

This change allows you the option to open the filtered Scene list in a new tab/window rather than the current browser tab.

In the Actor Details, from the Scene tab header, you can also open a filtered list of scenes for the actor in a new tab/window.

If a user will not use this feature, they can hide the Open-In-New-Window icons from "Options/Web UI/show Open Tag in New Window"