### PR TITLE
Changed VRSpy Scene Id logic

### DIFF
--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -38,18 +38,26 @@ func VRSpy(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out chan<-
 		sc.Site = siteID
 		sc.HomepageURL = e.Request.URL.String()
 
-		ogimage := e.ChildAttr(`meta[property="og:image"][content*="cover.jpg"]`, "content")
-		if ogimage != "" {
-			ogimageURL, err := url.Parse(ogimage)
-			if err == nil {
-				parts := strings.Split(ogimageURL.Path, "/")
-				if len(parts) > 2 {
-					sc.SiteID = parts[2]
+		e.ForEach(`meta[property="og:image"][content*="vrspy.com/videos"]`, func(id int, e *colly.HTMLElement) {
+			if sc.SiteID == "" {
+				ogimage := e.Attr("content")
+				if ogimage != "" {
+					ogimageURL, err := url.Parse(ogimage)
+					if err == nil {
+						parts := strings.Split(ogimageURL.Path, "/")
+						if len(parts) > 2 {
+							_, err := strconv.Atoi(parts[2])
+							if err == nil {
+								sc.SiteID = parts[2]
+							}
+						}
+					}
 				}
 			}
-		}
+		})
 
 		if sc.SiteID == "" {
+			log.Infof("Unable to determine a Scene Id for %s", e.Request.URL)
 			return
 		}
 


### PR DESCRIPTION
Changed Scene Id logic. Previously used the cover.jpg image to extract the scene id, but some covers do not use this name, make logic a bit more generic and added an additional check the id found is numeric, givem the selector is a more generic match.