### PR TITLE
Fix For SexbabesVR Scraper

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2020,7 +2020,7 @@ func Migrate() {
 				}
 				for _, scene := range scenes {
 
-					if scene.Site == "sexbabesvr" {
+					if scene.Site == "SexBabesVR" {
 						sceneID, err := newSceneId(scene.Site, scene.SceneURL)
 						if err != nil {
 							return err

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -41,7 +41,6 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 
 		// Cover Url
 		coverURL := e.Request.Ctx.GetAny("coverURL").(string)
-		log.Infoln(coverURL)
 		sc.Covers = append(sc.Covers, coverURL)
 
 		// Title
@@ -115,7 +114,6 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 			sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 			if !funk.ContainsString(knownScenes, sceneURL) {
 				coverURL := e.ChildAttr("a.video-container__image img", "data-src")
-				log.Infoln("Scraped Cover", coverURL)
 				ctx := colly.NewContext()
 				ctx.Put("coverURL", coverURL)
 				sceneCollector.Request("GET", sceneURL, nil, ctx, nil)

--- a/pkg/scrape/sexbabesvr.go
+++ b/pkg/scrape/sexbabesvr.go
@@ -54,10 +54,22 @@ func SexBabesVR(wg *sync.WaitGroup, updateSite bool, knownScenes []string, out c
 		})
 
 		// Synopsis
-		e.ForEach(`div.video-detail>div.container>p`, func(id int, e *colly.HTMLElement) {
-			// Handle blank <p></p> surrounding the synopsis
-			if strings.TrimSpace(e.Text) != "" {
-				sc.Synopsis = strings.TrimSpace(e.Text)
+		e.ForEach(`div.list-of-categories__p`, func(id int, e *colly.HTMLElement) {
+			synopsis := e.Text
+
+			if synopsis == "" {
+				synopsis = e.ChildText(`p.ql-align-justify`)
+
+				if synopsis == "" {
+					e.ForEach(`div`, func(id int, e *colly.HTMLElement) {
+						synopsis = synopsis + " " + strings.TrimSpace(e.Text)
+					})
+
+				}
+			}
+
+			if strings.TrimSpace(synopsis) != "" {
+				sc.Synopsis = strings.TrimSpace(synopsis)
 			}
 		})
 


### PR DESCRIPTION
The scene id in on the scene webpage now seems to be 614 for all scenes. Causing all scenes to be rescraped and never adding new scenes.

This pulls the poster url which appears to have a unique identifier in the last directory.

Also updated the cover URL to pull the image used for the thumbnail on the index page. As the latest scene has a SBS image for the cover where the thumbnail contains a more useful image

All appears functional. ~Might require deleting all scraped SexbabesVR scenes due to a shift in scene-id causing file mismatch and scene preview generation hiccups~ Added Migration Code