### PR TITLE
Fix for KinkVR

### DIFF
--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -710,8 +710,6 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 	scrapeRules.GenericActorScrapingConfig["vrcosplayx scrape"] = siteDetails
 	siteDetails.Domain = "18vr.com"
 	scrapeRules.GenericActorScrapingConfig["18vr scrape"] = siteDetails
-	siteDetails.Domain = "kinkvr.com"
-	scrapeRules.GenericActorScrapingConfig["kinkvr scrape"] = siteDetails
 
 	siteDetails = GenericScraperRuleSet{}
 	siteDetails.Domain = "darkroomvr.com"

--- a/pkg/scrape/badoink.go
+++ b/pkg/scrape/badoink.go
@@ -26,8 +26,8 @@ func BadoinkSite(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
-	sceneCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com", "kinkvr.com")
-	siteCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com", "kinkvr.com")
+	sceneCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com")
+	siteCollector := createCollector("badoinkvr.com", "babevr.com", "vrcosplayx.com", "18vr.com")
 	trailerCollector := cloneCollector(sceneCollector)
 
 	commonDb, _ := models.GetCommonDB()
@@ -283,14 +283,9 @@ func BabeVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan
 	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "babevr", "BabeVR", "https://babevr.com/vrpornvideos?order=newest", singeScrapeAdditionalInfo, limitScraping)
 }
 
-func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
-	return BadoinkSite(wg, updateSite, knownScenes, out, singleSceneURL, "kinkvr", "KinkVR", "https://kinkvr.com/bdsm-vr-videos?order=newest", singeScrapeAdditionalInfo, limitScraping)
-}
-
 func init() {
 	registerScraper("badoinkvr", "BadoinkVR", "https://pbs.twimg.com/profile_images/618071358933610497/QaMV81nF_200x200.png", "badoinkvr.com", BadoinkVR)
 	registerScraper("18vr", "18VR", "https://pbs.twimg.com/profile_images/989481761783545856/w-iKqgqV_200x200.jpg", "18vr.com", B18VR)
 	registerScraper("vrcosplayx", "VRCosplayX", "https://pbs.twimg.com/profile_images/900675974039298049/ofMytpkQ_200x200.jpg", "vrcosplayx.com", VRCosplayX)
 	registerScraper("babevr", "BabeVR", "https://babevr.com/icons/babevr/apple-touch-icon.png", "babevr.com", BabeVR)
-	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/icons/kinkvr/apple-touch-icon.png", "kinkvr.com", KinkVR)
 }

--- a/pkg/scrape/badoinkv2.go
+++ b/pkg/scrape/badoinkv2.go
@@ -1,0 +1,127 @@
+package scrape
+
+import (
+	"strings"
+
+	"github.com/gocolly/colly/v2"
+	"github.com/mozillazg/go-slugify"
+	"github.com/nleeper/goment"
+	"github.com/thoas/go-funk"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, domain string, singeScrapeAdditionalInfo string, limitScraping bool) error {
+	defer wg.Done()
+	logScrapeStart(scraperID, siteID)
+
+	sceneCollector := createCollector(domain)
+	siteCollector := createCollector(domain)
+
+	// These cookies are needed for age verification.
+	siteCollector.OnRequest(func(r *colly.Request) {
+		r.Headers.Set("Cookie", "agreedToDisclaimer=true")
+	})
+
+	sceneCollector.OnRequest(func(r *colly.Request) {
+		r.Headers.Set("Cookie", "agreedToDisclaimer=true")
+	})
+
+	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+		sc := models.ScrapedScene{}
+		sc.ScraperID = scraperID
+		sc.SceneType = "VR"
+		sc.Studio = "Badoink"
+		sc.Site = siteID
+		sc.SiteID = ""
+		sc.HomepageURL, _ = strings.CutSuffix(e.Request.URL.String(), "/")
+
+		// Cover Url
+		coverURL := e.ChildAttr("div#povVideoContainer dl8-video", "poster")
+		sc.Covers = append(sc.Covers, coverURL)
+
+		// Gallery
+		e.ForEach(`div.owl-carousel div.item`, func(id int, e *colly.HTMLElement) {
+			sc.Gallery = append(sc.Gallery, e.ChildAttr("img", "src"))
+		})
+
+		// Incase we scrape a single scene use one of the gallery images for the cover
+		if singleSceneURL != "" {
+			sc.Covers = append(sc.Covers, sc.Gallery[0])
+		}
+
+		// Cast
+		sc.ActorDetails = make(map[string]models.ActorDetails)
+		e.ForEach(`table.video-description-list tbody`, func(id int, e *colly.HTMLElement) {
+			// Cast
+			e.ForEach(`tr:nth-child(1) a`, func(id int, e *colly.HTMLElement) {
+				if strings.TrimSpace(e.Text) != "" {
+					sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
+					sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
+				}
+			})
+
+			// Tags
+			e.ForEach(`tr:nth-child(2) a`, func(id int, e *colly.HTMLElement) {
+				tag := strings.TrimSpace(e.Text)
+				sc.Tags = append(sc.Tags, tag)
+			})
+
+			// Date
+			tmpDate, _ := goment.New(strings.TrimSpace(e.ChildText(`tr:nth-child(3) td:last-child`)), "MMMM DD, YYYY")
+			sc.Released = tmpDate.Format("YYYY-MM-DD")
+		})
+
+		// Synposis
+		sc.Synopsis = strings.TrimSpace(e.ChildText("div.accordion-body"))
+
+		// Title
+		sc.Title = e.ChildText("h1.page-title")
+
+		// Scene ID -- Uses the ending number of the video url instead of the ID used for the directory that the video link is stored in(Maintains backwards compatibility with old scenes)
+		tmp := strings.Split(sc.HomepageURL, "/")
+		siteIDstr := strings.Split(tmp[len(tmp)-1], "-")
+		sc.SiteID = siteIDstr[len(siteIDstr)-1]
+
+		if sc.SiteID != "" {
+			sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+
+			// save only if we got a SceneID
+			out <- sc
+		}
+	})
+
+	siteCollector.OnHTML(`a.page-link[aria-label="Next"]:not(.disabled)`, func(e *colly.HTMLElement) {
+		if !limitScraping {
+			pageURL := e.Request.AbsoluteURL(e.Attr("href"))
+			siteCollector.Visit(pageURL)
+		}
+	})
+
+	siteCollector.OnHTML(`div.video-grid-view a`, func(e *colly.HTMLElement) {
+		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
+		// If scene exist in database, there's no need to scrape
+		if !funk.ContainsString(knownScenes, sceneURL) {
+			sceneCollector.Visit(sceneURL)
+		}
+	})
+
+	if singleSceneURL != "" {
+		sceneCollector.Visit(singleSceneURL)
+	} else {
+		siteCollector.Visit("https://" + domain + "/videos/page1")
+	}
+
+	if updateSite {
+		updateSiteLastUpdate(scraperID)
+	}
+	logScrapeFinished(scraperID, siteID)
+	return nil
+}
+
+func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
+	return BadoinkSitev2(wg, updateSite, knownScenes, out, singleSceneURL, "kinkvr", "KinkVR", "kinkvr.com", singeScrapeAdditionalInfo, limitScraping)
+}
+
+func init() {
+	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/icons/kinkvr/apple-touch-icon.png", "kinkvr.com", KinkVR)
+}

--- a/pkg/scrape/badoinkv2.go
+++ b/pkg/scrape/badoinkv2.go
@@ -98,7 +98,7 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 	})
 
 	siteCollector.OnHTML(`div.video-grid-view a`, func(e *colly.HTMLElement) {
-		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
+		sceneURL, _ := strings.CutSuffix(e.Request.AbsoluteURL(e.Attr("href")), "/")
 		// If scene exist in database, there's no need to scrape
 		if !funk.ContainsString(knownScenes, sceneURL) {
 			sceneCollector.Visit(sceneURL)

--- a/pkg/scrape/kinkvr.go
+++ b/pkg/scrape/kinkvr.go
@@ -58,7 +58,7 @@ func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan
 			e.ForEach(`tr:nth-child(1) a`, func(id int, e *colly.HTMLElement) {
 				if strings.TrimSpace(e.Text) != "" {
 					sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
-					sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
+					sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
 				}
 			})
 

--- a/pkg/scrape/kinkvr.go
+++ b/pkg/scrape/kinkvr.go
@@ -122,5 +122,5 @@ func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan
 }
 
 func init() {
-	registerScraper("kinkvr", "KinkVR", "https://kinkvr.com/icons/kinkvr/apple-touch-icon.png", "kinkvr.com", KinkVR)
+	registerScraper("kinkvr", "KinkVR", "https://static.rlcontent.com/shared/KINK/skins/web-10/branding/favicon.png", "kinkvr.com", KinkVR)
 }

--- a/pkg/scrape/kinkvr.go
+++ b/pkg/scrape/kinkvr.go
@@ -10,12 +10,14 @@ import (
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
-func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, scraperID string, siteID string, domain string, singeScrapeAdditionalInfo string, limitScraping bool) error {
+func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
 	defer wg.Done()
+	scraperID := "kinkvr"
+	siteID := "KinkVR"
 	logScrapeStart(scraperID, siteID)
 
-	sceneCollector := createCollector(domain)
-	siteCollector := createCollector(domain)
+	sceneCollector := createCollector("kinkvr.com")
+	siteCollector := createCollector("kinkvr.com")
 
 	// These cookies are needed for age verification.
 	siteCollector.OnRequest(func(r *colly.Request) {
@@ -33,7 +35,7 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 		sc.Studio = "Badoink"
 		sc.Site = siteID
 		sc.SiteID = ""
-		sc.HomepageURL, _ = strings.CutSuffix(e.Request.URL.String(), "/")
+		sc.HomepageURL = e.Request.URL.String()
 
 		// Cover Url
 		coverURL := e.ChildAttr("div#povVideoContainer dl8-video", "poster")
@@ -78,7 +80,8 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 		sc.Title = e.ChildText("h1.page-title")
 
 		// Scene ID -- Uses the ending number of the video url instead of the ID used for the directory that the video link is stored in(Maintains backwards compatibility with old scenes)
-		tmp := strings.Split(sc.HomepageURL, "/")
+		tmpUrlStr, _ := strings.CutSuffix(e.Request.URL.String(), "/")
+		tmp := strings.Split(tmpUrlStr, "/")
 		siteIDstr := strings.Split(tmp[len(tmp)-1], "-")
 		sc.SiteID = siteIDstr[len(siteIDstr)-1]
 
@@ -98,7 +101,7 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 	})
 
 	siteCollector.OnHTML(`div.video-grid-view a`, func(e *colly.HTMLElement) {
-		sceneURL, _ := strings.CutSuffix(e.Request.AbsoluteURL(e.Attr("href")), "/")
+		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 		// If scene exist in database, there's no need to scrape
 		if !funk.ContainsString(knownScenes, sceneURL) {
 			sceneCollector.Visit(sceneURL)
@@ -108,7 +111,7 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 	if singleSceneURL != "" {
 		sceneCollector.Visit(singleSceneURL)
 	} else {
-		siteCollector.Visit("https://" + domain + "/videos/page1")
+		siteCollector.Visit("https://kinkvr.com/videos/page1")
 	}
 
 	if updateSite {
@@ -116,10 +119,6 @@ func BadoinkSitev2(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 	}
 	logScrapeFinished(scraperID, siteID)
 	return nil
-}
-
-func KinkVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singeScrapeAdditionalInfo string, limitScraping bool) error {
-	return BadoinkSitev2(wg, updateSite, knownScenes, out, singleSceneURL, "kinkvr", "KinkVR", "kinkvr.com", singeScrapeAdditionalInfo, limitScraping)
 }
 
 func init() {


### PR DESCRIPTION
KinkVR now uses bootstrap. ~Sister badoink websites are still using its old front end. I have coded this in such a way that future badoink sites can be added if this bootstrap migration occurs company wide.~ Kink and Badoink collaboration has ended

File names are dropped upon migration. Appears to have no good means for the guessing of filenames for the future as the trailer URL no longer follows a convention or Badoink's convention.

Does not need migration code. Due to the change in the URL to the scenes, all scenes are re-scraped on next scrape and all scraped data is replaced with its new format. 

Funscript scraping has also been abandoned, no longer searchable. 

One scene has two different URLs. This is due to maintaining Badoink's ID for scenes. I may switch scene-id upon input from repo mangers. This would require migration code.