### PR TITLE
Add Offical to Custom Scraper Code. Move multiple sites to Custom List

### DIFF
--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -190,10 +190,10 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 
 		// Data taken from offical SLR scraper, updated to fix url change
 		scraper := ScraperConfig{URL: url, Name: name, Company: company, AvatarUrl: avatarUrl}
-		
+
 		// Needed in case the site we are updating was a master site for others
 		updateMasterSite := func(sites []ScraperConfig) {
-			for idx, site := range sites{
+			for idx, site := range sites {
 				if site.MasterSiteId == id {
 					sites[idx].MasterSiteId = newId
 				}
@@ -206,9 +206,9 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 
 		// Add the to the SLR list the new custom PS-Porn site
 		switch customId {
-		case "slr":	
+		case "slr":
 			scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
-		case "povr":			
+		case "povr":
 			scraperConfig.CustomScrapers.PovrScrapers = append(scraperConfig.CustomScrapers.PovrScrapers, scraper)
 		case "vrporn":
 			scraperConfig.CustomScrapers.VrpornScrapers = append(scraperConfig.CustomScrapers.VrpornScrapers, scraper)

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -157,7 +157,7 @@ func SetSiteId(configList *[]ScraperConfig, customId string) {
 
 }
 
-func MigrateFromOfficalToCustom(id string, url string, name string, company string, avatarUrl string) error {
+func MigrateFromOfficalToCustom(id string, url string, name string, company string, avatarUrl string, customId string, suffix string) error {
 	
 	db, _ := models.GetDB()
 	defer db.Close()
@@ -165,31 +165,54 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 	// Check to see if we even have PS-Porn data. Other wise there is no need to add a custom site entry
 	var scenes []models.Scene
 	db.Where("scraper_id = ?", id).Find(&scenes)
-	if len(scenes) < 1 {
-		common.Log.Infoln(`No` + name + ` Scenes found no migration needed`)
-		return db.Delete(&models.Site{ID: id}).Error
+	if len(scenes) != 0 {
+		common.Log.Infoln(name + ` Scenes found migration needed`)
+		
+		// Update scene data to reflect change
+		for _, scene := range scenes {				
+								//Needed due to weried VRPHub scrapers
+			scene.ScraperId = strings.TrimPrefix(id, "vrphub-" + `-` + customId)
+			scene.Site = name + " " + suffix
+			scene.NeedsUpdate = true
+
+			err := db.Save(&scene).Error
+
+			if err != nil {
+				return err
+			}
+		}
+
+		
+
+		// Load the custom scrapers
+		var scraperConfig ScraperList
+		scraperConfig.Load()
+
+		// Data taken from offical SLR scraper, updated to fix url change
+		scraper := ScraperConfig{URL: url, Name: name, Company: company, AvatarUrl: avatarUrl}
+		// Add the to the SLR list the new custom PS-Porn site
+		switch customId{
+		case "slr":
+			scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
+		case "povr":
+			scraperConfig.CustomScrapers.PovrScrapers = append(scraperConfig.CustomScrapers.PovrScrapers, scraper)
+		case "vrporn":
+			scraperConfig.CustomScrapers.VrpornScrapers = append(scraperConfig.CustomScrapers.VrpornScrapers, scraper)
+		case "vrphub":
+			scraperConfig.CustomScrapers.VrphubScrapers = append(scraperConfig.CustomScrapers.VrphubScrapers, scraper)
+		}
+		// Save the new list file
+		fName := filepath.Join(common.AppDir, "scrapers.json")
+		list, _ := json.MarshalIndent(scraperConfig, "", "  ")
+		os.WriteFile(fName, list, 0644)
+
+		common.Log.Infoln(name + ` migration complete. Please restart XBVR and run ` + name + ` scraper to complete migration`)
+
+	} else {
+
+		common.Log.Infoln(`No ` + name + ` Scenes found no migration needed`)
+
 	}
-	common.Log.Infoln(name + `Scenes found migration needed`)
-	
-	err := db.Model(&models.Scene{}).Where("scraper_id = ?", id).Update("needs_update", true).Error
-	if err != nil {
-		return err
-	}
-	// Load the custom scrapers
-	var scraperConfig ScraperList
-	scraperConfig.Load()
 
-	// Data taken from offical SLR scraper, updated to fix url change
-	scraper := ScraperConfig{URL: url, Name: name, Company: company, AvatarUrl: avatarUrl}
-	// Add the to the SLR list the new custom PS-Porn site
-	scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
-
-	// Save the new list file
-	fName := filepath.Join(common.AppDir, "scrapers.json")
-	list, _ := json.MarshalIndent(scraperConfig, "", "  ")
-	os.WriteFile(fName, list, 0644)
-
-	common.Log.Infoln(name + `migration complete. Please restart XBVR and run` + name + `scraper to complete migration`)
-
-	return db.Delete(&models.Site{ID: "ps-porn"}).Error
+	return db.Delete(&models.Site{ID: id}).Error
 }

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -164,7 +164,7 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 
 	var scenes []models.Scene
 	db.Where("scraper_id = ?", id).Find(&scenes)
-	
+
 	if len(scenes) != 0 {
 		common.Log.Infoln(name + ` Scenes found migration needed`)
 

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -162,7 +162,6 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 	db, _ := models.GetDB()
 	defer db.Close()
 
-	// Check to see if we even have PS-Porn data. Other wise there is no need to add a custom site entry
 	var scenes []models.Scene
 	db.Where("scraper_id = ?", id).Find(&scenes)
 	if len(scenes) != 0 {

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -158,20 +158,20 @@ func SetSiteId(configList *[]ScraperConfig, customId string) {
 }
 
 func MigrateFromOfficalToCustom(id string, url string, name string, company string, avatarUrl string, customId string, suffix string) error {
-	
+
 	db, _ := models.GetDB()
 	defer db.Close()
-	
+
 	// Check to see if we even have PS-Porn data. Other wise there is no need to add a custom site entry
 	var scenes []models.Scene
 	db.Where("scraper_id = ?", id).Find(&scenes)
 	if len(scenes) != 0 {
 		common.Log.Infoln(name + ` Scenes found migration needed`)
-		
+
 		// Update scene data to reflect change
-		for _, scene := range scenes {				
-								//Needed due to weried VRPHub scrapers
-			scene.ScraperId = strings.TrimPrefix(id, "vrphub-" + `-` + customId)
+		for _, scene := range scenes {
+			//Needed due to weried VRPHub scrapers
+			scene.ScraperId = strings.TrimPrefix(id, "vrphub-"+`-`+customId)
 			scene.Site = name + " " + suffix
 			scene.NeedsUpdate = true
 
@@ -182,8 +182,6 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 			}
 		}
 
-		
-
 		// Load the custom scrapers
 		var scraperConfig ScraperList
 		scraperConfig.Load()
@@ -191,7 +189,7 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 		// Data taken from offical SLR scraper, updated to fix url change
 		scraper := ScraperConfig{URL: url, Name: name, Company: company, AvatarUrl: avatarUrl}
 		// Add the to the SLR list the new custom PS-Porn site
-		switch customId{
+		switch customId {
 		case "slr":
 			scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
 		case "povr":

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -191,8 +191,6 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 		// Data taken from offical scraper list
 		scraper := ScraperConfig{URL: url, Name: name, Company: company, AvatarUrl: avatarUrl}
 
-		exists := false
-
 		// Update any alt sites that is using the old id to the new id
 		updateMasterSite := func(sites []ScraperConfig) {
 			for idx, site := range sites {
@@ -207,25 +205,23 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 		updateMasterSite(scraperConfig.CustomScrapers.VrpornScrapers)
 		updateMasterSite(scraperConfig.CustomScrapers.VrphubScrapers)
 
-		if exists == false {
-			// Append our scraper to the the Custom Scraper list unless its new id already exists
-			switch customId {
-			case "slr":
-				if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.SlrScrapers) == false {
-					scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
-				}
-			case "povr":
-				if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.PovrScrapers) == false {
-					scraperConfig.CustomScrapers.PovrScrapers = append(scraperConfig.CustomScrapers.PovrScrapers, scraper)
-				}
-			case "vrporn":
-				if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.VrpornScrapers) == false {
-					scraperConfig.CustomScrapers.VrpornScrapers = append(scraperConfig.CustomScrapers.VrpornScrapers, scraper)
-				}
-			case "vrphub":
-				if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.VrphubScrapers) == false {
-					scraperConfig.CustomScrapers.VrphubScrapers = append(scraperConfig.CustomScrapers.VrphubScrapers, scraper)
-				}
+		// Append our scraper to the the Custom Scraper list unless its new id already exists
+		switch customId {
+		case "slr":
+			if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.SlrScrapers) == false {
+				scraperConfig.CustomScrapers.SlrScrapers = append(scraperConfig.CustomScrapers.SlrScrapers, scraper)
+			}
+		case "povr":
+			if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.PovrScrapers) == false {
+				scraperConfig.CustomScrapers.PovrScrapers = append(scraperConfig.CustomScrapers.PovrScrapers, scraper)
+			}
+		case "vrporn":
+			if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.VrpornScrapers) == false {
+				scraperConfig.CustomScrapers.VrpornScrapers = append(scraperConfig.CustomScrapers.VrpornScrapers, scraper)
+			}
+		case "vrphub":
+			if CheckMatchingSite(scraper, scraperConfig.CustomScrapers.VrphubScrapers) == false {
+				scraperConfig.CustomScrapers.VrphubScrapers = append(scraperConfig.CustomScrapers.VrphubScrapers, scraper)
 			}
 		}
 

--- a/pkg/config/scraper_list.go
+++ b/pkg/config/scraper_list.go
@@ -164,25 +164,16 @@ func MigrateFromOfficalToCustom(id string, url string, name string, company stri
 
 	var scenes []models.Scene
 	db.Where("scraper_id = ?", id).Find(&scenes)
+	
 	if len(scenes) != 0 {
 		common.Log.Infoln(name + ` Scenes found migration needed`)
+
+		// Update scene data to reflect change
+		db.Model(&models.Scene{}).Where("scraper_id = ?", id).Update("needs_update", true)
 
 		// Determine the new id from the URL using the same template as the scraper list code
 		tmp := strings.TrimRight(url, "/")
 		newId := strings.ToLower(tmp[strings.LastIndex(tmp, "/")+1:]) + `-` + customId
-
-		// Update scene data to reflect change
-		for _, scene := range scenes {
-			scene.ScraperId = newId
-			scene.Site = name + " " + suffix
-			scene.NeedsUpdate = true
-
-			err := db.Save(&scene).Error
-
-			if err != nil {
-				return err
-			}
-		}
 
 		var scraperConfig ScraperList
 		scraperConfig.Load()

--- a/pkg/config/scrapers.json
+++ b/pkg/config/scrapers.json
@@ -490,7 +490,6 @@
           "avatar_url": "https://mcdn.vrporn.com/files/20200421094123/vrclubz_logo_NEW-400x400_webwhite.png"
         }
       ],
-      "vrphub": [
-      ]
+      "vrphub": []
     }
   }

--- a/pkg/config/scrapers.json
+++ b/pkg/config/scrapers.json
@@ -320,12 +320,6 @@
           "avatar_url": "https://mcdn.vrporn.com/files/20191125091909/POVCentralLogo.jpg"
         },
         {
-          "url": "https://www.sexlikereal.com/studios/ps-porn",
-          "name": "PS-Porn",
-          "company": "Paula Shy",
-          "avatar_url": "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg"
-        },
-        {
           "url": "https://www.sexlikereal.com/studios/realhotvr",
           "name": "RealHotVR",
           "company": "RealHotVR",

--- a/pkg/config/scrapers.json
+++ b/pkg/config/scrapers.json
@@ -176,12 +176,6 @@
           "avatar_url": ""
         },
         {
-          "url": "https://www.sexlikereal.com/studios/fuckpassvr",
-          "name": "FuckPassVR",
-          "company": "FuckPassVR",
-          "avatar_url": "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/352/logo_crop_1635153994.png"          
-        },
-        {
           "url": "https://www.sexlikereal.com/studios/heathering",
           "name": "Heathering",
           "company": "",
@@ -497,20 +491,6 @@
         }
       ],
       "vrphub": [
-        {
-          "id": "vrphub-vrhush",
-          "url": "https://vrphub.com/category/vr-hush",
-          "name": "VRHush",
-          "company": "VRHush",
-          "avatar_url": "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vrh/favicon/apple-touch-icon-180x180.png"
-        },
-        {
-          "id": "vrphub-stripzvr",
-          "url": "https://vrphub.com/category/stripzvr/",
-          "name": "StripzVR - VRP Hub",
-          "company": "StripzVR",
-          "avatar_url": "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg"
-        }
       ]
     }
   }

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2073,7 +2073,7 @@ func Migrate() {
 			},
 		},
 		{
-			ID: "0091-PS-Porn-Offical-Removal",
+			ID: "0092-PS-Porn-Offical-Removal",
 			Migrate: func(tx *gorm.DB) error {
 				
 				return config.MigrateFromOfficalToCustom("ps-porn", "https://www.sexlikereal.com/studios/ps-porn-vr", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg")

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2073,10 +2073,14 @@ func Migrate() {
 			},
 		},
 		{
-			ID: "0092-PS-Porn-Offical-Removal",
+			ID: "0081-Offical-Site-Removals-With-Main-Site-Aviable",
 			Migrate: func(tx *gorm.DB) error {
 				
-				return config.MigrateFromOfficalToCustom("ps-porn", "https://www.sexlikereal.com/studios/ps-porn-vr", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg")
+				err := config.MigrateFromOfficalToCustom("ps-porn", "https://www.sexlikereal.com/studios/ps-porn-vr", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg", "slr", "(SLR)")
+				err = config.MigrateFromOfficalToCustom("fuckpassvr", "https://www.sexlikereal.com/studios/fuckpassvr", "FuckPassVR", "FuckPassVR", "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/352/logo_crop_1635153994.png", "slr", "(SLR)")
+				err = config.MigrateFromOfficalToCustom("vrphub-vrhush", "https://vrphub.com/category/vr-hush", "VRHush", "VRHush", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vrh/favicon/apple-touch-icon-180x180.png", "vrphub", "(VRP Hub)")
+				err = config.MigrateFromOfficalToCustom("vrphub-stripzvr", "https://vrphub.com/category/stripzvr/", "StripzVR - VRP Hub", "StripzVR", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", "vrphub", "(VRP Hub)")
+				return err
 	
 			},
 		},

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2075,13 +2075,13 @@ func Migrate() {
 		{
 			ID: "0081-Offical-Site-Removals-With-Main-Site-Aviable",
 			Migrate: func(tx *gorm.DB) error {
-				
+
 				err := config.MigrateFromOfficalToCustom("ps-porn", "https://www.sexlikereal.com/studios/ps-porn-vr", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg", "slr", "(SLR)")
 				err = config.MigrateFromOfficalToCustom("fuckpassvr", "https://www.sexlikereal.com/studios/fuckpassvr", "FuckPassVR", "FuckPassVR", "https://cdn-vr.sexlikereal.com/images/studio_creatives/logotypes/1/352/logo_crop_1635153994.png", "slr", "(SLR)")
 				err = config.MigrateFromOfficalToCustom("vrphub-vrhush", "https://vrphub.com/category/vr-hush", "VRHush", "VRHush", "https://cdn-nexpectation.secure.yourpornpartner.com/sites/vrh/favicon/apple-touch-icon-180x180.png", "vrphub", "(VRP Hub)")
 				err = config.MigrateFromOfficalToCustom("vrphub-stripzvr", "https://vrphub.com/category/stripzvr/", "StripzVR - VRP Hub", "StripzVR", "https://www.stripzvr.com/wp-content/uploads/2018/09/cropped-favicon-192x192.jpg", "vrphub", "(VRP Hub)")
 				return err
-	
+
 			},
 		},
 	})

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2072,6 +2072,14 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0091-PS-Porn-Offical-Removal",
+			Migrate: func(tx *gorm.DB) error {
+				
+				return config.MigrateFromOfficalToCustom("ps-porn", "https://www.sexlikereal.com/studios/ps-porn-vr", "PS-Porn", "Paula Shy", "https://mcdn.vrporn.com/files/20201221090642/PS-Porn-400x400.jpg")
+	
+			},
+		},
 	})
 
 	if err := m.Migrate(); err != nil {

--- a/pkg/scrape/vrphub.go
+++ b/pkg/scrape/vrphub.go
@@ -273,9 +273,9 @@ func init() {
 	scrapers.Load()
 	for _, scraper := range scrapers.XbvrScrapers.VrphubScrapers {
 		switch scraper.ID {
-		case "vrphub-vrhush":
+		case "vr-hush-vrphub":
 			addVRPHubScraper(scraper.ID, scraper.Name, scraper.Company, scraper.AvatarUrl, false, scraper.URL, vrhushCallback)
-		case "vrphub-stripzvr":
+		case "stripzvr-vrphub":
 			addVRPHubScraper(scraper.ID, scraper.Name, scraper.Company, scraper.AvatarUrl, false, scraper.URL, stripzvrCallback)
 		}
 		addVRPHubScraper(scraper.ID, scraper.Name, scraper.Company, scraper.AvatarUrl, false, scraper.URL, noop)


### PR DESCRIPTION
This code removes some sites from the official list so users may use them as alt sites instead of being forced out of the alt site functionality. The sites that have been moved are as follows. If no scene's are present it just removes the site all together.

- Both the VRPHub sites while mainting their custom handling of these studios in its scraper code. 
- Updated PS-Porn to its new url and move it to custom. 
- Removed FuckPassVR SLR and moved it to a custom site. 
- Also setup the code for future moves from official to custom.

The new function add is `MigrateFromOfficalToCustom(id string, url string, name string, company string, avatarUrl string, customId string, suffix string)` where

- `id` is the filename portion of the url
- `url` is the full url of the studio
- `name`, `company`, `avatarUrl` are pulled from the official list
- `customId` is the internal code used by XBVR to designate which parent site the custom site is associtaed with. The following are the accepted inputs
  - `povr`
  - `slr`
  - `vrphub` 
  - `vrporn`
 - `suffix` Is the portion attached to the site name for users to indentify the parent site. The current suffixes in use are
   -  `(SLR)`
   - `(VRP Hub)`
   - `(POVR)`
   - `(VRPorn)`