### PR TITLE
VRSpy Fix - Title

### DIFF
--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -62,7 +62,8 @@ func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<
 
 		sc.SceneID = scraperID + "-" + sc.SiteID
 
-		sc.Title = e.ChildText(`.video-content .header-container .video-title .section-header-container`)
+		sc.Title = strings.TrimSuffix(strings.TrimSuffix(e.ChildText(`div.video-title .section-header-container`), " Scene"), " - VR Porn")
+
 		sc.Synopsis = e.ChildText(`.video-description-container`)
 		sc.Tags = e.ChildTexts(`.video-categories .chip`)
 


### PR DESCRIPTION
Title was no longer being found. Also removed the VR Porn Scene suffix being applied to recent scenes