### PR TITLE
Allow Stash Scraping via new flag rather than if site is_enabled

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -238,6 +238,9 @@ func (i ConfigResource) WebService() *restful.WebService {
 	ws.Route(ws.PUT("/sites/limit_scraping/{site}").To(i.toggleLimitScraping).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
+	ws.Route(ws.PUT("/sites/scrape_stash/{site}").To(i.toggleScrapeStash).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
 	ws.Route(ws.POST("/scraper/force-site-update").To(i.forceSiteUpdate).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
@@ -355,6 +358,9 @@ func (i ConfigResource) toggleLimitScraping(req *restful.Request, resp *restful.
 	i.toggleSiteField(req, resp, "LimitScraping")
 }
 
+func (i ConfigResource) toggleScrapeStash(req *restful.Request, resp *restful.Response) {
+	i.toggleSiteField(req, resp, "ScrapeStash")
+}
 func (i ConfigResource) toggleSiteField(req *restful.Request, resp *restful.Response, field string) {
 	db, _ := models.GetDB()
 	defer db.Close()
@@ -380,6 +386,9 @@ func (i ConfigResource) toggleSiteField(req *restful.Request, resp *restful.Resp
 	case "LimitScraping":
 		site.LimitScraping = !site.LimitScraping
 		db.Model(&models.Scene{}).Where("scraper_id = ?", site.ID).Update("limit_scraping", site.LimitScraping)
+	case "ScrapeStash":
+		site.ScrapeStash = !site.ScrapeStash
+		db.Model(&models.Scene{}).Where("scrape_stash = ?", site.ID).Update("scrape_stash", site.LimitScraping)
 	}
 	site.Save()
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -820,6 +820,19 @@ func Migrate() {
 				return nil
 			},
 		},
+		{
+			ID: "0082-scrape-stash-flag",
+			Migrate: func(tx *gorm.DB) error {
+				type Site struct {
+					ScrapeStash bool `json:"scrape_stash" xbvrbackup:"scrape_stash"`
+				}
+				err := tx.AutoMigrate(Site{}).Error
+				if err != nil {
+					return err
+				}
+				return tx.Exec("update sites set scrape_stash = is_enabled").Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_site.go
+++ b/pkg/models/model_site.go
@@ -19,6 +19,7 @@ type Site struct {
 	LimitScraping  bool      `json:"limit_scraping" xbvrbackup:"limit_scraping"`
 	MasterSiteID   string    `json:"master_site_id" xbvrbackup:"master_site_id"`
 	MatchingParams string    `json:"matching_params" gorm:"size:1000" xbvrbackup:"matching_params"`
+	ScrapeStash    bool      `json:"scrape_stash" xbvrbackup:"scrape_stash"`
 }
 
 func (i *Site) Save() error {

--- a/pkg/scrape/stashdb.go
+++ b/pkg/scrape/stashdb.go
@@ -86,7 +86,7 @@ func StashDb() {
 	defer db.Close()
 
 	Config = models.BuildActorScraperRules()
-	db.Where(&models.Site{IsEnabled: true}).Order("id").Find(&sites)
+	db.Where(&models.Site{ScrapeStash: true}).Order("id").Find(&sites)
 
 	for _, site := range sites {
 		tlog.Infof("Scraping stash studio %s", site.Name)

--- a/ui/src/store/optionsSites.js
+++ b/ui/src/store/optionsSites.js
@@ -20,6 +20,9 @@ const actions = {
   async toggleLimitScraping ({ state }, params) {
     state.items = await ky.put(`/api/options/sites/limit_scraping/${params.id}`, { json: {} }).json()
   },
+  async toggleScrapeStash ({ state }, params) {
+    state.items = await ky.put(`/api/options/sites/scrape_stash/${params.id}`, { json: {} }).json()
+  },
 }
 
 export default {

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -50,6 +50,11 @@
           <span v-if="props.row.master_site_id==''"><b-switch v-model ="props.row.subscribed" @input="$store.dispatch('optionsSites/toggleSubscribed', {id: props.row.id})"/></span>
         </b-tooltip>
       </b-table-column>
+      <b-table-column field="scrape_stash" :label="$t('Scrape Stash')" v-slot="props" width="60" sortable>
+        <b-tooltip class="is-info" :label="$t('Enables scraping Stashdb for Actors')" :delay="250" >
+          <span v-if="props.row.master_site_id==''"><b-switch v-model ="props.row.scrape_stash" @input="$store.dispatch('optionsSites/toggleScrapeStash', {id: props.row.id})"/></span>
+        </b-tooltip>
+      </b-table-column>
       <b-table-column field="options" v-slot="props" width="30">
         <div class="menu">
           <b-dropdown aria-role="list" class="is-pulled-right" position="is-bottom-left">


### PR DESCRIPTION
Some sites are not suitable for matching scenes with Stashdb.  eg the aggregator site may change all the titles.

This allows the user to turn off/on matching with Stashdb for sites.