### PR TITLE
Fix  Custom Site Matching Rules not Loading

### DIFF
--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -1077,6 +1077,9 @@ func (scrapeRules ActorScraperConfig) getCustomRules() {
 				scrapeRules.GenericActorScrapingConfig[key] = rule
 			}
 		}
+		for key, matchrule := range customScrapeRules.StashSceneMatching {
+			scrapeRules.StashSceneMatching[key] = matchrule
+		}
 	}
 }
 


### PR DESCRIPTION
Custom rules in actor_scraper_custom_config.json for matching sites between XBVR and Stashdb are not been loaded.

Needed for #1888 and #1886 