### PR TITLE
Implement Heresphere needsMediaSource flag

### DIFF
--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -102,13 +102,14 @@ type HereSphereAlphaPackedSettings struct {
 }
 
 type HereSphereAuthRequest struct {
-	Username    string           `json:"username"`
-	Password    string           `json:"password"`
-	Rating      *float64         `json:"rating"`
-	IsFavorite  *bool            `json:"isFavorite"`
-	Hsp         *string          `json:"hsp"`
-	Tags        *[]HeresphereTag `json:"tags"`
-	DeleteFiles *bool            `json:"deleteFile"`
+	Username         string           `json:"username"`
+	Password         string           `json:"password"`
+	Rating           *float64         `json:"rating"`
+	IsFavorite       *bool            `json:"isFavorite"`
+	Hsp              *string          `json:"hsp"`
+	Tags             *[]HeresphereTag `json:"tags"`
+	DeleteFiles      *bool            `json:"deleteFile"`
+	NeedsMediaSource optional.Bool    `json:"needsMediaSource"`
 }
 
 var RequestBody []byte
@@ -353,7 +354,8 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 		videoLength = file.VideoDuration
 	}
 
-	if len(videoFiles) == 0 && config.Config.Web.SceneTrailerlist {
+	if len(videoFiles) == 0 && config.Config.Web.SceneTrailerlist && requestData.NeedsMediaSource.OrElse(true) {
+		log.Infof("Get Trailer details for %s scene %s", scene.TrailerType, scene.SceneID)
 		switch scene.TrailerType {
 		case "heresphere":
 			heresphereScene := LoadHeresphereScene(scene.TrailerSource)

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -355,7 +355,6 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 	}
 
 	if len(videoFiles) == 0 && config.Config.Web.SceneTrailerlist && requestData.NeedsMediaSource.OrElse(true) {
-		log.Infof("Get Trailer details for %s scene %s", scene.TrailerType, scene.SceneID)
 		switch scene.TrailerType {
 		case "heresphere":
 			heresphereScene := LoadHeresphereScene(scene.TrailerSource)


### PR DESCRIPTION
Minor change to implement the needsMediaSource flag in the Heresphere request body.

Heresphere sets this flag if it needs media source details, i.e. which is only when it wants to play the media.  The advantage of checking the flag is for trailers, some of which may require a scene page to be scraped to get the current trailer URL (i.e. to get the latest tokens, expiry times, etc).  When Heresphere is started it will request a library list and then each scene in the list, triggering a scrape for those trailers.  These requests have needsMediaSource set to false as Heresphere is not playing the video and only needs the other metadata, e.g. title, actors, tags, etc.

This is just a minor performance change, reducing or spreading the scrapes required by Trailers until the Trailer is requested to be played.