### PR TITLE
Restore bundles from URL

### DIFF
--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -93,6 +95,7 @@ type RequestRestore struct {
 	InclActorActions bool   `json:"inclActorActions"`
 	InclConfig       bool   `json:"inclConfig"`
 	ExtRefSubset     string `json:"extRefSubset"`
+	BundleUrl        string `json:"bundleUrl"`
 }
 
 func CleanTags() {
@@ -812,6 +815,11 @@ func BackupBundle(inclAllSites bool, onlyIncludeOfficalSites bool, inclScenes bo
 }
 
 func RestoreBundle(request RequestRestore) {
+	if request.BundleUrl != "" {
+		data, _ := downloadBundle(request.BundleUrl)
+		request.UploadData = data
+	}
+
 	if strings.Contains(request.UploadData, "\"bundleVersion\":\"1\"") {
 		ImportBundle(request.UploadData)
 		return
@@ -1732,4 +1740,26 @@ func UpdateSceneStatus(db *gorm.DB) {
 			tlog.Infof("Update status of Scenes (%v/%v)", i+1, len(scenes))
 		}
 	}
+}
+
+func downloadBundle(url string) (string, error) {
+	// Get the response
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Check for a successful response
+	if resp.StatusCode != http.StatusOK {
+		return "", err
+	}
+
+	// Read the response body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
 }

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -815,7 +815,9 @@ func BackupBundle(inclAllSites bool, onlyIncludeOfficalSites bool, inclScenes bo
 }
 
 func RestoreBundle(request RequestRestore) {
+	tlog := log.WithField("task", "scrape")
 	if request.BundleUrl != "" {
+		tlog.Infof("Downloading data from %s", request.BundleUrl)
 		data, _ := downloadBundle(request.BundleUrl)
 		request.UploadData = data
 	}
@@ -827,8 +829,6 @@ func RestoreBundle(request RequestRestore) {
 	if !models.CheckLock("scrape") {
 		models.CreateLock("scrape")
 		defer models.RemoveLock("scrape")
-
-		tlog := log.WithField("task", "scrape")
 
 		var json = jsoniter.Config{
 			EscapeHTML:             true,


### PR DESCRIPTION
This change allows the user to specify a URL to download a Restore Bundle from, rather than uploading the file via the browser.  This is to handle Browser memory issues when trying to load large bundle files rather than creating multiple smaller Bundle exports.  

The user can use the XBVR self-hosted myfiles directory to load the files from the last backup.
e.g.
http://xxx.xxx.xxx.xxx:9999/myfiles/xbvr-content-bundle.json
or the last export at http://xxx.xxx.xxx.xxx:9999/download/xbvr-content-bundle.json
or any other accessible URL

The Bundle Import screen now has a toggle button to select between Import from a Url or Import from a file