### PR TITLE
fix: scene accessibility when only later scenes are inaccessible

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -314,6 +314,8 @@ func (o *Scene) UpdateStatus() {
 	if len(files) > 0 {
 		var newestFileDate time.Time
 		var totalFileSize int64
+		anyVideoAccessible := false
+
 		for j := range files {
 			totalFileSize = totalFileSize + files[j].Size
 
@@ -329,17 +331,10 @@ func (o *Scene) UpdateStatus() {
 				videos = videos + 1
 
 				if files[j].Exists() {
+					anyVideoAccessible = true
+
 					if files[j].CreatedTime.After(newestFileDate) || newestFileDate.IsZero() {
 						newestFileDate = files[j].CreatedTime
-					}
-					if !o.IsAccessible {
-						o.IsAccessible = true
-						changed = true
-					}
-				} else {
-					if o.IsAccessible {
-						o.IsAccessible = false
-						changed = true
 					}
 				}
 			}
@@ -357,6 +352,11 @@ func (o *Scene) UpdateStatus() {
 
 		if scripts == 0 && o.IsScripted {
 			o.IsScripted = false
+			changed = true
+		}
+
+		if anyVideoAccessible != o.IsAccessible {
+			o.IsAccessible = anyVideoAccessible
 			changed = true
 		}
 


### PR DESCRIPTION
There was a bug with this for loop where the order of the video files impacted the final state of the video's accessibility flag. Proper logic should be marking a scene as accessible if any video exists.

**Repro**
* Have 1 scraped scene
* Download 2 video files for it
* Have 1 video file be mounted and accessible and another not be mounted

When the for loop runs, if the non-accessible video file appears later in the files list, it will mark the scene as not accessible even though another video file exists.