### PR TITLE
Fix NaughtyAmerica VR actor scrape

### DIFF
--- a/pkg/scrape/navr.go
+++ b/pkg/scrape/navr.go
@@ -139,6 +139,7 @@ func NaughtyAmericaVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string
 
 				script := e.Text
 				script = strings.ReplaceAll(script, "nanalytics.trackExperiment('scene_page_viewed', 'streaming_option_join_button');", "")
+				script = strings.ReplaceAll(script, "nanalytics.trackExperiment('scene_page_viewed', 'yearly_option_first');", "")
 				script = strings.Replace(script, "window.dataLayer", "dataLayer", -1)
 				script = strings.Replace(script, "dataLayer = dataLayer || []", "dataLayer = []", -1)
 				script = script + "\nout = []; dataLayer.forEach(function(v) { if (v.femaleStar) { out.push(v.femaleStar); } });"


### PR DESCRIPTION
Fix the bug that when scrapping a NaughtyAmerica VR scene the actor's name is always 'undefined'.