### PR TITLE
Fix RealJamVR & PornCorn SceneIDs & RJ actors

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2251,7 +2251,7 @@ func Migrate() {
 		},
 		{
 			// Had to switch to a differnt sceneID source that's consistent through every scene. so all scenes have to be renumbered.
-			ID: "0085-fix-realjam-ids",
+			ID: "0085-update-realjamvr-ids",
 			Migrate: func(tx *gorm.DB) error {
 				newSceneId := func(site string, url string) (string, int) {
 					sceneID := ""
@@ -2282,6 +2282,7 @@ func Migrate() {
 				if err != nil {
 					return err
 				}
+				scene_renum := 0
 				for _, scene := range scenes {
 
 					// Need both the siteID string and the sceneID has interger for logic
@@ -2317,13 +2318,16 @@ func Migrate() {
 							if err != nil {
 								return err
 							}
+							scene_renum++
 						}
 
 					}
 				}
 
-				// since scenes have new IDs, we need to re-index them
-				tasks.SearchIndex()
+				// since scenes have new IDs, we need to re-index them (only if we actually changed any)
+				if scene_renum != 0 {
+					tasks.SearchIndex()
+				}
 
 				return nil
 			},

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2248,7 +2248,87 @@ func Migrate() {
 				}
 				return nil
 			},
-		}})
+		},
+		{
+			// Had to switch to a differnt sceneID source that's consistent through every scene. so all scenes have to be renumbered.
+			ID: "0085-fix-realjam-ids",
+			Migrate: func(tx *gorm.DB) error {
+				newSceneId := func(site string, url string) (string, int) {
+					sceneID := ""
+					statusCode := 200
+
+					sceneCollector := colly.NewCollector(
+						colly.AllowedDomains("realjamvr.com"),
+					)
+
+					sceneCollector.OnError(func(r *colly.Response, err error) {
+						common.Log.Errorf("Error visiting %s %s", r.Request.URL, err)
+						statusCode = r.StatusCode
+					})
+
+					sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+
+						// Scene ID. filename & scene URL not consistent through entire site so use data-id
+						sceneID = slugify.Slugify(site) + "-" + e.ChildAttr(`div.ms-5`, "data-id")
+					})
+
+					sceneCollector.Visit(url)
+
+					return sceneID, statusCode
+				}
+
+				var scenes []models.Scene
+				err := tx.Where("studio = ?", "Real Jam Network").Find(&scenes).Error
+				if err != nil {
+					return err
+				}
+				for _, scene := range scenes {
+
+					// Need both the siteID string and the sceneID has interger for logic
+					tmp := strings.Split(scene.SceneID, "-")
+					//sceneIDint, _ := strconv.Atoi(tmp[2])
+
+					// Don't change PornCorn. It is using scene URL.
+					if tmp[0] == "realjam" {
+
+						common.Log.Infoln("Checking sceneid:", scene.SceneID)
+						sceneID, statusCode := newSceneId(scene.Site, scene.SceneURL)
+
+						if statusCode != 200 {
+							return err
+						}
+
+						if sceneID == "" {
+							common.Log.Warnf("Could not update scene %s", scene.SceneID)
+							continue
+						}
+
+						if scene.SceneID != sceneID {
+							// update all actions referring to this scene by its scene_id
+							err = tx.Model(&models.Action{}).Where("scene_id = ?", scene.SceneID).Update("scene_id", sceneID).Error
+							if err != nil {
+								return err
+							}
+
+							// update the scene itself
+							common.Log.Infoln("Updating sceneid:", scene.SceneID, "to", sceneID)
+							scene.SceneID = sceneID
+							err = tx.Save(&scene).Error
+							if err != nil {
+								return err
+							}
+						}
+
+					}
+				}
+
+				// since scenes have new IDs, we need to re-index them
+				tasks.SearchIndex()
+
+				return nil
+			},
+		},
+	})
 
 	if err := m.Migrate(); err != nil {
 		common.Log.Fatalf("Could not migrate: %v", err)

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -37,6 +37,7 @@ func RealJamSite(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out
 		sc.Site = siteID
 		sc.HomepageURL = strings.TrimSuffix(strings.Split(e.Request.URL.String(), "?")[0], "/")
 
+		// web code split
 		// PornCorn sources the scene_id from the trailer URL. RealJam sources the scene_id from the trailer data-id
 		trailerId := ""
 		if scraperID == "realjamvr" {
@@ -69,12 +70,20 @@ func RealJamSite(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out
 		sc.TrailerSrc = string(strParams)
 
 		// Cast
+		// RealJamVR & PornCorn web code split
 		sc.ActorDetails = make(map[string]models.ActorDetails)
-		e.ForEach(`div.scene-view > a[href^='/actor/']`, func(id int, e *colly.HTMLElement) {
-			sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
-			sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
-		})
 
+		if scraperID == "realjamvr" {
+			e.ForEach(`div.mb-1 > a[href^='/actor/']`, func(id int, e *colly.HTMLElement) {
+				sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
+				sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
+			})
+		} else {
+			e.ForEach(`div.scene-view > a[href^='/actor/']`, func(id int, e *colly.HTMLElement) {
+				sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
+				sc.ActorDetails[strings.TrimSpace(e.Text)] = models.ActorDetails{Source: sc.ScraperID + " scrape", ProfileUrl: e.Request.AbsoluteURL(e.Attr("href"))}
+			})
+		}
 		// Released
 		e.ForEach(`.bi-calendar3`, func(id int, e *colly.HTMLElement) {
 			p := e.DOM.Parent().Next()


### PR DESCRIPTION
Resolves #1980 

- PorncornVR is grabbing sceneid from trailer URL (not filename)
- RealJamVR is grabbing sceneid from trailer "data-id". Necessary to do differently than PorncornVR because there are at least 3 different URL schemes in use. Also, a migration is needed to update all scenes. Startup will be slow. Reindex should only happen if sceneids were actually updated. 
- RealJamVR missing actors fixed
