### PR TITLE
Configurable video extensions, Auto-load more scene cards. New: Gallery Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,57 @@
-/.idea
-.DS_Store
-.vscode/
-
+# Binaries and build artifacts
+xbvr.exe
+.lock
+go.mod
+go.sum
+main.db
 test.db
 /test_cache
 
-/dist/
-
+# Dependencies
 node_modules/
-/ui/dist/
+/dist
+/ui/dist
 /ui/public/static/bundle.*
-npm-debug.log
-yarn-error.log
 
+# IDE and editor files
+/.idea
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Logs and databases
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files
+.env
+.env.local
+.env.*.local
 .release-env
 .docker-creds
+
+# Package files
+package-lock.json
+yarn.lock
+
+# Go specific
+/vendor/
+*.test
+/coverage
+*.out
+
+# Cache directories
+.npm/
+.eslintcache
+.cache/
+
+# Local development
+*.local
+
+# Test files and Automation
+*.py
+*.ipynb

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -581,7 +581,6 @@ func (i ConfigResource) listStorage(req *restful.Request, resp *restful.Response
 	db, _ := models.GetDB()
 	defer db.Close()
 
-
 	var vol []models.Volume
 	db.Raw(`select id, path, last_scan,is_available, is_enabled, type,
        	(select count(*) from files where files.volume_id = volumes.id) as file_count,
@@ -1121,9 +1120,6 @@ func (i ConfigResource) saveOptionsStorage(req *restful.Request, resp *restful.R
 }
 
 func (i ConfigResource) getCollectorConfigs(req *restful.Request, resp *restful.Response) {
-	db, _ := models.GetDB()
-	defer db.Close()
-
 	list := scrape.GetAllScrapeHttpConfigs()
 	resp.WriteHeaderAndEntity(http.StatusOK, &list)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,6 +171,7 @@ type ObjectConfig struct {
 	} `json:"cron"`
 	Storage struct {
 		MatchOhash bool `default:"false" json:"match_ohash"`
+		VideoExt   []string `json:"video_ext"`
 	} `json:"storage"`
 	ScraperSettings struct {
 		TMWVRNet struct {
@@ -185,6 +186,8 @@ type ObjectConfig struct {
 var (
 	Config            ObjectConfig
 	RecentIPAddresses []string
+	ForbiddenVideoExtensions = []string{".funscript", ".cmscript", ".hsp", ".srt", ".ssa", ".ass"}
+	DefaultVideoExtensions   = []string{".mp4", ".avi", ".wmv", ".mpeg4", ".mov", ".mkv"}
 )
 
 func LoadConfig() {

--- a/pkg/scrape/littlecaprice.go
+++ b/pkg/scrape/littlecaprice.go
@@ -125,5 +125,5 @@ func LittleCaprice(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 }
 
 func init() {
-	registerScraper("littlecaprice", "Little Caprice Dreams", "https://www.littlecaprice-dreams.com/wp-content/uploads/2019/03/cropped-lcd-heart-192x192.png", "littlecaprice-dreams.com", LittleCaprice)
+	registerScraper("littlecaprice", "Little Caprice Dreams", "https://www.littlecaprice-dreams.com/favicon.ico", "littlecaprice-dreams.com", LittleCaprice)
 }

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -25,6 +25,9 @@ import (
 	"github.com/xbapps/xbvr/pkg/scrape"
 )
 
+// List of video extension has been moved to config.go as it is now used in multiple places, and user configurable (with fallback list)
+var allowedVideoExt = config.Config.Storage.VideoExt
+
 func RescanVolumes(id int) {
 	if !models.CheckLock("rescan") {
 		models.CreateLock("rescan")
@@ -217,7 +220,7 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			if !f.Mode().IsDir() {
 				// Make sure the filename should be considered
 				// Video file extensions are defined in the config.Storage.VideoExt array with error correction and fallback list
-				if !strings.HasPrefix(filepath.Base(path), ".") && funk.Contains(config.Config.Storage.VideoExt, strings.ToLower(filepath.Ext(path))) {
+				if !strings.HasPrefix(filepath.Base(path), ".") && funk.Contains(allowedVideoExt, strings.ToLower(filepath.Ext(path))) {
 					var fl models.File
 					err = db.Where(&models.File{Path: filepath.Dir(path), Filename: filepath.Base(path)}).First(&fl).Error
 
@@ -414,7 +417,7 @@ func scanPutIO(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 	// Walk
 	var currentFileID []string
 	for i := range files {
-		if !files[i].IsDir() && funk.Contains(config.Config.Storage.VideoExt, strings.ToLower(filepath.Ext(files[i].Name))) {
+		if !files[i].IsDir() && funk.Contains(allowedVideoExt, strings.ToLower(filepath.Ext(files[i].Name))) {
 			var fl models.File
 			err = db.Where(&models.File{Path: strconv.FormatInt(files[i].ID, 10), Filename: files[i].Name}).First(&fl).Error
 

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -25,8 +25,6 @@ import (
 	"github.com/xbapps/xbvr/pkg/scrape"
 )
 
-var allowedVideoExt = []string{".mp4", ".avi", ".wmv", ".mpeg4", ".mov", ".mkv"}
-
 func RescanVolumes(id int) {
 	if !models.CheckLock("rescan") {
 		models.CreateLock("rescan")
@@ -218,7 +216,8 @@ func scanLocalVolume(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 			}
 			if !f.Mode().IsDir() {
 				// Make sure the filename should be considered
-				if !strings.HasPrefix(filepath.Base(path), ".") && funk.Contains(allowedVideoExt, strings.ToLower(filepath.Ext(path))) {
+				// Video file extensions are defined in the config.Storage.VideoExt array with error correction and fallback list
+				if !strings.HasPrefix(filepath.Base(path), ".") && funk.Contains(config.Config.Storage.VideoExt, strings.ToLower(filepath.Ext(path))) {
 					var fl models.File
 					err = db.Where(&models.File{Path: filepath.Dir(path), Filename: filepath.Base(path)}).First(&fl).Error
 
@@ -415,7 +414,7 @@ func scanPutIO(vol models.Volume, db *gorm.DB, tlog *logrus.Entry) {
 	// Walk
 	var currentFileID []string
 	for i := range files {
-		if !files[i].IsDir() && funk.Contains(allowedVideoExt, strings.ToLower(filepath.Ext(files[i].Name))) {
+		if !files[i].IsDir() && funk.Contains(config.Config.Storage.VideoExt, strings.ToLower(filepath.Ext(files[i].Name))) {
 			var fl models.File
 			err = db.Where(&models.File{Path: strconv.FormatInt(files[i].ID, 10), Filename: files[i].Name}).First(&fl).Error
 

--- a/ui/src/components/GalleryEditor.vue
+++ b/ui/src/components/GalleryEditor.vue
@@ -1,0 +1,210 @@
+<template>
+  <div>
+    <div class="field">
+      <div class="control">
+        <input class="input" type="text" v-model="newItem" :placeholder="$t('Add new item')" @keyup.enter="addItem">
+      </div>
+    </div>
+
+    <!-- Lock Control -->
+    <div style="margin-bottom: 0.25rem; padding: 0;">
+      <div style="display: flex; justify-content: space-between; align-items: center; line-height: 1; padding: 0;">
+        <span style="font-size: 0.6rem; color: #b5b5b5; line-height: 1; margin: 0;">
+          Drag-and-drop images to reorder
+        </span>
+        <b-button 
+          type="is-light" 
+          size="is-small" 
+          @click="toggleLock"
+          :class="{ 'is-info': !isLocked, 'is-warning': isLocked }"
+          icon-left="lock"
+          style="font-size: 0.6rem; padding: 0.25rem 0.5rem; line-height: 1; margin: 0;">
+          {{ isLocked ? 'Unlock' : 'Lock' }} Delete
+        </b-button>
+      </div>
+    </div>
+
+    <draggable :list="internalList" @end="onDragEnd" class="image-grid">
+      <div v-for="(item, index) in internalList" :key="index" class="image-item">
+        <img :src="getImageURL(item)" alt="Gallery image" class="gallery-image"/>
+        <div class="image-controls">
+          <b-tooltip :label="$t('Delete Image')" type="is-dark" position="is-top" :delay="500" append-to-body>
+            <b-button 
+              type="is-danger" 
+              size="is-small" 
+              @click="removeItem(index)" 
+              icon-left="delete"
+              :disabled="isLocked"
+              :class="{ 'is-light': isLocked }">
+            </b-button>
+          </b-tooltip>
+          <b-tooltip :label="$t('Set as Cover')" type="is-dark" position="is-top" :delay="500" append-to-body>
+            <b-button
+              type="is-primary"
+              size="is-small"
+              :class="{ 'is-light': item !== coverUrl }"
+              @click="setCover(item)"
+              icon-left="image">
+            </b-button>
+          </b-tooltip>
+        </div>
+      </div>
+    </draggable>
+  </div>
+</template>
+
+<script>
+import draggable from 'vuedraggable'
+
+export default {
+  name: 'GalleryEditor',
+  components: {
+    draggable
+  },
+  props: {
+    list: {
+      type: Array,
+      required: true
+    },
+    coverUrl: {
+      type: String,
+      default: ''
+    },
+    blurFn: {
+      type: Function,
+      default: () => {}
+    }
+  },
+  data () {
+    return {
+      internalList: [...this.list],
+      newItem: '',
+      isLocked: true // Default to locked
+    }
+  },
+  watch: {
+    list(newList) {
+      this.internalList = [...newList];
+    }
+  },
+  methods: {
+    toggleLock() {
+      this.isLocked = !this.isLocked;
+    },
+    addItem () {
+      if (this.newItem.trim() !== '') {
+        this.internalList.push(this.newItem.trim())
+        this.newItem = ''
+        this.updateList()
+      }
+    },
+    removeItem (index) {
+      if (!this.isLocked) {
+        const itemToDelete = this.internalList[index]
+        
+        // Check if this is the cover image
+        if (itemToDelete === this.coverUrl) {
+          // Show confirmation dialog for deleting cover image
+          this.$buefy.dialog.confirm({
+            title: 'Delete Cover Image',
+            message: 'You are about to delete the current cover image. This will clear the cover selection. Are you sure you want to continue?',
+            confirmText: 'Delete',
+            cancelText: 'Cancel',
+            type: 'is-warning',
+            hasIcon: true,
+            onConfirm: () => {
+              // Remove the image
+              this.internalList.splice(index, 1)
+              // Clear the cover_url since we're deleting the cover image
+              this.$emit('setCover', '')
+              this.updateList()
+            }
+          })
+        } else {
+          // Regular image deletion - just remove it without affecting cover_url
+          this.internalList.splice(index, 1)
+          this.updateList()
+        }
+      }
+    },
+    updateList () {
+      this.$emit('update:list', this.internalList)
+      this.blurFn()
+    },
+    onDragEnd (evt) {
+      // 'draggable' updates the list automatically, so we just need to emit the update
+      this.updateList()
+    },
+    setCover (url) {
+      this.$emit('setCover', url)
+    },
+    getImageURL (url) {
+      if (!url) return url
+      try {
+        if (url.startsWith('http')) {
+          if (url.indexOf('%') === -1) {
+            return '/img/200x/' + encodeURI(url)
+          } else {
+            return '/img/200x/' + encodeURI(decodeURI(url))
+          }
+        }
+      } catch {
+        // fall through
+      }
+      // For local images or already proxied paths just return as-is
+      return url
+    }
+  }
+}
+</script>
+
+<style scoped>
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 178px));
+  grid-auto-rows: 120px;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.image-item {
+  position: relative;
+  overflow: hidden;
+  word-break: break-all;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  min-height: 120px;
+  max-height: 120px;
+  min-width: 120px;
+  max-width: 178px;
+  aspect-ratio: 16/9;
+}
+
+.gallery-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.image-controls {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.image-item:hover .image-controls {
+  opacity: 1;
+}
+
+.image-controls .button {
+  height: 2rem;
+  width: 2rem;
+  padding: 0;
+}
+</style>

--- a/ui/src/store/actorList.js
+++ b/ui/src/store/actorList.js
@@ -10,7 +10,7 @@ function defaultValue (v, d) {
 
 const defaultFilterState = {
   dlState: 'available',
-  cardSize: '1',
+  cardSize: '2',
 
   lists: [],
   cast: [],

--- a/ui/src/store/actorList.js
+++ b/ui/src/store/actorList.js
@@ -10,7 +10,7 @@ function defaultValue (v, d) {
 
 const defaultFilterState = {
   dlState: 'available',
-  cardSize: '2',
+  cardSize: '2', // cardSize 'S' is now #2, because of the new 'XS' size
 
   lists: [],
   cast: [],

--- a/ui/src/store/optionsStorage.js
+++ b/ui/src/store/optionsStorage.js
@@ -5,7 +5,6 @@ const state = {
   options: {
     match_ohash: false,
     video_ext: [],
-    forbidden_video_ext: []
   },  
 }
 
@@ -19,7 +18,6 @@ const actions = {
       state.items = data.volumes
       state.options.match_ohash = data.match_ohash
       state.options.video_ext = data.video_ext
-      state.options.forbidden_video_ext = data.forbidden_video_ext
     })
   },
   async save ({ state }, enabled) { 

--- a/ui/src/store/optionsStorage.js
+++ b/ui/src/store/optionsStorage.js
@@ -4,6 +4,8 @@ const state = {
   items: [],
   options: {
     match_ohash: false,
+    video_ext: [],
+    forbidden_video_ext: []
   },  
 }
 
@@ -16,6 +18,8 @@ const actions = {
     .then(data => {
       state.items = data.volumes
       state.options.match_ohash = data.match_ohash
+      state.options.video_ext = data.video_ext
+      state.options.forbidden_video_ext = data.forbidden_video_ext
     })
   },
   async save ({ state }, enabled) { 

--- a/ui/src/views/actors/ActorCard.vue
+++ b/ui/src/views/actors/ActorCard.vue
@@ -130,6 +130,9 @@ export default {
     overflow: hidden;
     padding: 0;
     line-height: 0;
+    position: relative;
+    width: 100%;
+    min-height: 100px; /* Ensure minimum height for XS cards */
   }
 
   .bbox:not(:hover) > video {
@@ -173,5 +176,23 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    margin-bottom: 0.25rem; /* Add some spacing below title */
+  }
+
+  .card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.5rem; /* Add some spacing between cards */
+  }
+
+  .card-image {
+    flex: 1;
+    min-height: 100px; /* Ensure minimum height for XS cards */
+  }
+
+  /* Adjust text size for XS cards */
+  .is-1 .scene_title {
+    font-size: 11px;
   }
 </style>

--- a/ui/src/views/actors/ActorCard.vue
+++ b/ui/src/views/actors/ActorCard.vue
@@ -130,9 +130,6 @@ export default {
     overflow: hidden;
     padding: 0;
     line-height: 0;
-    position: relative;
-    width: 100%;
-    min-height: 100px; /* Ensure minimum height for XS cards */
   }
 
   .bbox:not(:hover) > video {
@@ -176,23 +173,5 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    margin-bottom: 0.25rem; /* Add some spacing below title */
-  }
-
-  .card {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 0.5rem; /* Add some spacing between cards */
-  }
-
-  .card-image {
-    flex: 1;
-    min-height: 100px; /* Ensure minimum height for XS cards */
-  }
-
-  /* Adjust text size for XS cards */
-  .is-1 .scene_title {
-    font-size: 11px;
   }
 </style>

--- a/ui/src/views/actors/List.vue
+++ b/ui/src/views/actors/List.vue
@@ -39,12 +39,15 @@
           <b-field>
             <span class="list-header-label">{{$t('Card size')}}</span>
             <b-radio-button v-model="cardSize" native-value="1" size="is-small">
-              S
+              XS
             </b-radio-button>
             <b-radio-button v-model="cardSize" native-value="2" size="is-small">
-              M
+              S
             </b-radio-button>
             <b-radio-button v-model="cardSize" native-value="3" size="is-small">
+              M
+            </b-radio-button>
+            <b-radio-button v-model="cardSize" native-value="4" size="is-small">
               L
             </b-radio-button>
           </b-field>
@@ -153,12 +156,15 @@ export default {
         this.$store.state.actorList.filters.cardSize = value
         switch (value){
           case "1":
-            this.limit=18
+            this.limit=36
             break
           case "2":
-            this.limit=10
+            this.limit=18
             break
           case "3":
+            this.limit=10
+            break
+          case "4":
             this.limit=8
             break
             }            
@@ -193,10 +199,12 @@ export default {
     cardSizeClass () {
       switch (this.$store.state.actorList.filters.cardSize) {
         case '1':
-          return 'is-2'
+          return 'is-1'
         case '2':
-          return 'is-one-fifth'
+          return 'is-2'
         case '3':
+          return 'is-one-fifth'
+        case '4':
           return 'is-one-quarter'
         default:
           return 'is-2'

--- a/ui/src/views/scenes/List.vue
+++ b/ui/src/views/scenes/List.vue
@@ -31,12 +31,15 @@
           <b-field>
             <span class="list-header-label">{{$t('Card size')}}</span>
             <b-radio-button v-model="cardSize" native-value="1" size="is-small">
-              S
+              XS
             </b-radio-button>
             <b-radio-button v-model="cardSize" native-value="2" size="is-small">
-              M
+              S
             </b-radio-button>
             <b-radio-button v-model="cardSize" native-value="3" size="is-small">
+              M
+            </b-radio-button>
+            <b-radio-button v-model="cardSize" native-value="4" size="is-small">
               L
             </b-radio-button>
           </b-field>
@@ -79,10 +82,12 @@ export default {
     cardSizeClass () {
       switch (this.$store.state.sceneList.filters.cardSize) {
         case '1':
-          return 'is-one-fifth'
+          return 'is-one-sixth'
         case '2':
-          return 'is-one-quarter'
+          return 'is-one-fifth'
         case '3':
+          return 'is-one-quarter'
+        case '4':
           return 'is-one-third'
         default:
           return 'is-one-fifth'
@@ -171,5 +176,17 @@ export default {
 <style scoped>
   .list-header-label {
     padding-right: 1em;
+  }
+
+  /* Add Bulma-style one-sixth column */
+  .column.is-one-sixth {
+    flex: none;
+    width: 16.66666%;
+  }
+
+  @media screen and (max-width: 768px) {
+    .column.is-one-sixth {
+      width: 50%;
+    }
   }
 </style>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -246,6 +246,16 @@ export default {
     margin-right: 3px;
   }
 
+  .card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .card-image {
+    flex: 1;
+  }
+
   .bbox {
     flex: 1 0 calc(25%);
     background: #f0f0f0;
@@ -255,6 +265,8 @@ export default {
     overflow: hidden;
     padding: 0;
     line-height: 0;
+    position: relative;
+    width: 100%;
   }
 
   .bbox:not(:hover) > video {
@@ -307,23 +319,41 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    width: 100%;
   }
 
-.heatmapFunscript {
-  width: auto;
-}
+  .image-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 4px;
+  }
 
-.heatmapFunscript img {
-  border: 1px #888 solid;
-  width: 100%;
-  height: 15px;
-  border-radius: 0.25rem;
-}
+  .altsrc-image-wrapper {
+    display: inline-block;
+    margin-right: 5px;
+    margin-top: 3px;
+  }
 
-.altsrc-image-wrapper {
-  display: inline-block;
-  margin-right: 5px;
-  margin-top: 3px;
-}
+  .thumbnail {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
 
+  .heatmapFunscript {
+    width: auto;
+  }
+
+  .heatmapFunscript img {
+    border: 1px #888 solid;
+    width: 100%;
+    height: 15px;
+    border-radius: 0.25rem;
+  }
+
+  /* Fix for XS card width */
+  :deep(.column.is-one-sixth) {
+    flex: 0 0 16.666%;
+  }
 </style>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -246,16 +246,6 @@ export default {
     margin-right: 3px;
   }
 
-  .card {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .card-image {
-    flex: 1;
-  }
-
   .bbox {
     flex: 1 0 calc(25%);
     background: #f0f0f0;
@@ -265,8 +255,6 @@ export default {
     overflow: hidden;
     padding: 0;
     line-height: 0;
-    position: relative;
-    width: 100%;
   }
 
   .bbox:not(:hover) > video {
@@ -319,41 +307,23 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 100%;
   }
 
-  .image-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin-top: 4px;
-  }
+.heatmapFunscript {
+  width: auto;
+}
 
-  .altsrc-image-wrapper {
-    display: inline-block;
-    margin-right: 5px;
-    margin-top: 3px;
-  }
+.heatmapFunscript img {
+  border: 1px #888 solid;
+  width: 100%;
+  height: 15px;
+  border-radius: 0.25rem;
+}
 
-  .thumbnail {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
+.altsrc-image-wrapper {
+  display: inline-block;
+  margin-right: 5px;
+  margin-top: 3px;
+}
 
-  .heatmapFunscript {
-    width: auto;
-  }
-
-  .heatmapFunscript img {
-    border: 1px #888 solid;
-    width: 100%;
-    height: 15px;
-    border-radius: 0.25rem;
-  }
-
-  /* Fix for XS card width */
-  :deep(.column.is-one-sixth) {
-    flex: 0 0 16.666%;
-  }
 </style>

--- a/ui/src/views/scenes/Scenes.vue
+++ b/ui/src/views/scenes/Scenes.vue
@@ -8,6 +8,10 @@
         <a id="toTop">
           <b-icon pack="mdi" icon="navigation" />
         </a>
+
+        <a id="infiniteScrollToggle" @click="toggleInfiniteScroll" :data-tooltip="infiniteScrollTooltip">
+          <b-icon pack="mdi" :icon="infiniteScrollEnabled ? 'refresh' : 'pause'" />
+        </a>
       </div>
 
       <div class="column is-four-fifths">
@@ -25,10 +29,24 @@ import List from './List'
 export default {
   name: 'Scenes',
   components: { Filters, List },
+  data() {
+    return {
+      infiniteScrollEnabled: true,
+    }
+  },
+  computed: {
+    infiniteScrollTooltip() {
+      return this.infiniteScrollEnabled ? 'Disable auto load more' : 'Enable auto load more'
+    }
+  },
   mounted () {
     const toTop = document.getElementById('toTop')
+    const infiniteScrollToggle = document.getElementById('infiniteScrollToggle')
     addEventListener('scroll', function () {
       toTop.style.display = document.body.scrollTop > 20 || document.documentElement.scrollTop > 20
+        ? 'block'
+        : 'none'
+      infiniteScrollToggle.style.display = document.body.scrollTop > 20 || document.documentElement.scrollTop > 20
         ? 'block'
         : 'none'
     })
@@ -61,6 +79,14 @@ export default {
     this.$store.dispatch('sceneList/load', { offset: 0 })
     next()
   },
+  methods: {
+    toggleInfiniteScroll() {
+      this.infiniteScrollEnabled = !this.infiniteScrollEnabled
+      if (this.$refs.listComponent) {
+        this.$refs.listComponent.infiniteScrollEnabled = this.infiniteScrollEnabled
+      }
+    }
+  },
 }
 </script>
 
@@ -79,5 +105,37 @@ export default {
 
   #toTop:hover {
     background-color: #BDBDBD;
+  }
+
+  #infiniteScrollToggle {
+    display: none;
+    position: fixed;
+    bottom: 20px;
+    left: calc(20% - 60px);
+    background-color: #f0f0f0;
+    color: #4a4a4a;
+    padding: 15px;
+    border-radius: 10px;
+    font-size: 18px;
+    cursor: pointer;
+  }
+
+  #infiniteScrollToggle:hover {
+    background-color: #BDBDBD;
+  }
+
+  #infiniteScrollToggle:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    right: 0;
+    background-color: #333;
+    color: white;
+    padding: 5px 10px;
+    border-radius: 5px;
+    font-size: 12px;
+    white-space: nowrap;
+    margin-bottom: 5px;
+    z-index: 1000;
   }
 </style>


### PR DESCRIPTION
There's a couple of updates rolled into one pull request, but they are sepperated by commit. so they can easily be cherry-picked.

- Update LittleCapriceVR logo URL
- User configurable video extensions with error correction and forbidden etensions (ie .funscript .srt to prevent users from adding them as type 'video')
- QoL scene image Gallery update. Now shows thumbnails instead of a list of URL's. drag-and-drop reordering. Single click set cover. Lockable 'delete image' button (prevent accidental deletion). Error correction, UI/UX only change, the database metadata remains untouched.
- Scenes page now has a toggle to auto load more scenes when scrolling down. When disabled will still show the 'Load More' buttom as before.
- Changes are extensively explained with comments, except for the 'Auto load more' implementation as that code is pretty self-explanatory.


My main concern was making sure that no original behaviour of the app was changed. I would personally change some, but I didn't want to do it as part of the new features' commits.

I hope you'll like the updates as they are high on the users' list of "want to have".

---

Windows binaries - Preview: https://github.com/Rakly3/xbvr/releases/tag/Rakly3-Preview