### PR TITLE
FIX: webUI video player did not work for some users when using the 'Player' tab

### DIFF
--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -644,6 +644,17 @@ watch:{
     }
     this.activeTab = newVal
     this.$store.commit('overlay/changeDetailsTab', { tab: -1 })
+  },
+  activeMedia(newVal, oldVal) {
+    // Auto-load first video when Player tab is opened (without auto-playing)
+    // The webUI video player doesn't work for some users without autoloading
+    if (newVal === 1 && !this.displayingAlternateSource) {
+      const videoFiles = this.filesByType.filter(f => f.type === 'video')
+      if (videoFiles.length > 0) {
+        this.activeMedia = 1
+        this.updatePlayer('/api/dms/file/' + videoFiles[0].id + '?dnt=true', (videoFiles[0].projection == 'flat' ? 'NONE' : '180'))
+      }
+    }
   }
 },
   methods: {
@@ -1224,6 +1235,12 @@ watch:{
 
 .video-js {
   margin: 0 auto;
+}
+
+:deep(.video-js .vjs-big-play-button) {
+  left: 50% !important;
+  top: 50% !important;
+  transform: translate(-50%, -50%) !important;
 }
 
 .modal-card {


### PR DESCRIPTION
- Chromium-based browsers introduced a security change preventing local files from being called from the front end. This is now fixed by adding autoload to the backend. This will not autplay the video, but it will allow users to click play and have the video start.