### PR TITLE
Update WetVR scraper

### DIFF
--- a/pkg/scrape/wetvr.go
+++ b/pkg/scrape/wetvr.go
@@ -50,6 +50,10 @@ func fetchJSON(url string, target interface{}) error {
 		return err
 	}
 
+	httpConfig := GetCoreDomain(url) + "-scraper"
+	log.Debugf("Using Header/Cookies from %s", httpConfig)
+	SetupHtmlRequest(httpConfig, req)
+
 	req.Header.Set("x-site", "wetvr.com")
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
[WetVR scraoer] 

* Rewrite scraper for AMA API
*  Reduced full site scrape time from several minutes to two seconds
* Add duration map
         NOTE: the site doesn't provide durations either from page elements or API, so a duration map is hardcoded on line 35. The idea is that it's better than no durations. The downside is that as new scenes are published going forward, they will have blank durations until this hardcoding is updated. If that is undesirable for lack of uniformity then lines 35, 97-99 can be removed.
* Duplicate scene: id 75122 is a streaming-only duplicate scene of 75091. The scraper therefore ignores 75122 (line 181). It's possibly a remnant of the early days of the site which they never cleaned up.