### PR TITLE
Update VRSpy scraper

### DIFF
--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -3,10 +3,12 @@ package scrape
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/nleeper/goment"
@@ -19,15 +21,37 @@ const (
 	scraperID = "vrspy"
 	siteID    = "VRSpy"
 	domain    = "vrspy.com"
-	baseURL   = "https://" + domain
+	baseURL   = "https://www." + domain
 )
 
 func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<- models.ScrapedScene, singleSceneURL string, singleScrapeAdditionalInfo string, limitScraping bool) error {
 	defer wg.Done()
 	logScrapeStart(scraperID, siteID)
 
-	sceneCollector := createCollector(domain)
-	siteCollector := createCollector(domain)
+	allowedDomains := []string{domain, "www." + domain}
+	sceneCollector := createCollector(allowedDomains...)
+	siteCollector := createCollector(allowedDomains...)
+
+	cookies := []*http.Cookie{
+		{
+			Name:    "age",
+			Value:   "true",
+			Path:    "/",
+			Expires: time.Now().Add(365 * 24 * time.Hour),
+		},
+	}
+
+	sceneCollector.OnRequest(func(r *colly.Request) {
+		for _, c := range cookies {
+			r.Headers.Set("Cookie", c.Name+"="+c.Value)
+		}
+	})
+
+	siteCollector.OnRequest(func(r *colly.Request) {
+		for _, c := range cookies {
+			r.Headers.Set("Cookie", c.Name+"="+c.Value)
+		}
+	})
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}
@@ -37,23 +61,36 @@ func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<
 		sc.Site = siteID
 		sc.HomepageURL = e.Request.URL.String()
 
-		e.ForEach(`meta[property="og:image"][content*="vrspy.com/videos"]`, func(id int, e *colly.HTMLElement) {
-			if sc.SiteID == "" {
-				ogimage := e.Attr("content")
-				if ogimage != "" {
-					ogimageURL, err := url.Parse(ogimage)
-					if err == nil {
-						parts := strings.Split(ogimageURL.Path, "/")
-						if len(parts) > 2 {
-							_, err := strconv.Atoi(parts[2])
-							if err == nil {
-								sc.SiteID = parts[2]
+		// Extract scene ID using the most reliable method first
+		pageHTML, _ := e.DOM.Html()
+
+		// 1. Try image URLs with pattern cdn.vrspy.com/videos/{id}/
+		imageRegex := regexp.MustCompile(`cdn\.vrspy\.com/videos/(\d+)/`)
+		imageMatches := imageRegex.FindStringSubmatch(pageHTML)
+		if len(imageMatches) > 1 {
+			sc.SiteID = imageMatches[1]
+		}
+
+		// 2. Try og:image extraction if ID not found
+		if sc.SiteID == "" {
+			e.ForEach(`meta[property="og:image"][content*="vrspy.com/videos"]`, func(id int, e *colly.HTMLElement) {
+				if sc.SiteID == "" {
+					ogimage := e.Attr("content")
+					if ogimage != "" {
+						ogimageURL, err := url.Parse(ogimage)
+						if err == nil {
+							parts := strings.Split(ogimageURL.Path, "/")
+							if len(parts) > 2 {
+								_, err := strconv.Atoi(parts[2])
+								if err == nil {
+									sc.SiteID = parts[2]
+								}
 							}
 						}
 					}
 				}
-			}
-		})
+			})
+		}
 
 		if sc.SiteID == "" {
 			log.Infof("Unable to determine a Scene Id for %s", e.Request.URL)
@@ -62,77 +99,243 @@ func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<
 
 		sc.SceneID = scraperID + "-" + sc.SiteID
 
-		sc.Title = strings.TrimSuffix(strings.TrimSuffix(e.ChildText(`div.video-title .section-header-container`), " Scene"), " - VR Porn")
+		// Updated title selector based on reference scrapers
+		title := e.ChildText(`h1.section-header-container`)
+		if title == "" {
+			title = e.ChildText(`div.video-title .section-header-container`)
+		}
+		// Clean up the title
+		title = strings.TrimSpace(title)
+		title = strings.TrimSuffix(title, " Scene")
+		title = strings.TrimSuffix(title, " - VR Porn")
+		title = strings.TrimSuffix(title, " - Vr Porn")
+		sc.Title = title
 
-		sc.Synopsis = e.ChildText(`.video-description-container`)
-		sc.Tags = e.ChildTexts(`.video-categories .chip`)
+		// Updated synopsis selector
+		synopsis := e.ChildText(`.show-more-text p`)
+		if synopsis == "" {
+			synopsis = e.ChildText(`.video-description-container`)
+		}
+		sc.Synopsis = synopsis
 
+		// Updated tags selector
+		tags := e.ChildTexts(`.video-categories a`)
+		if len(tags) == 0 {
+			tags = e.ChildTexts(`.video-categories .chip`)
+		}
+		sc.Tags = tags
+
+		// Updated cast selector
 		sc.ActorDetails = make(map[string]models.ActorDetails)
 		e.ForEach(`.video-actor-item`, func(id int, e *colly.HTMLElement) {
-			sc.Cast = append(sc.Cast, e.Text)
-			e.ForEach(`a`, func(id int, a *colly.HTMLElement) {
-				sc.ActorDetails[e.Text] = models.ActorDetails{
-					Source:     scraperID + " scrape",
-					ProfileUrl: e.Request.AbsoluteURL(a.Attr(`href`)),
-				}
-
-			})
+			actorName := strings.TrimSpace(e.Text)
+			if actorName != "" {
+				sc.Cast = append(sc.Cast, actorName)
+				e.ForEach(`a`, func(id int, a *colly.HTMLElement) {
+					sc.ActorDetails[actorName] = models.ActorDetails{
+						Source:     scraperID + " scrape",
+						ProfileUrl: e.Request.AbsoluteURL(a.Attr(`href`)),
+					}
+				})
+			}
 		})
 
-		var durationParts []string
-		// Date & Duration
+		// Updated date and duration extraction
 		e.ForEach(`.video-details-info-item`, func(id int, e *colly.HTMLElement) {
-			parts := strings.Split(e.Text, ":")
-			if len(parts) > 1 {
-				switch strings.TrimSpace(parts[0]) {
-				case "Release date":
-					tmpDate, _ := goment.New(strings.TrimSpace(parts[1]), "DD MMMM YYYY")
-					sc.Released = tmpDate.Format("YYYY-MM-DD")
-				case "Duration":
-					durationParts = strings.Split(strings.TrimSpace(parts[1]), " ")
-					tmpDuration, err := strconv.Atoi(durationParts[0])
-					mins := tmpDuration * 60
-					tmpDuration, err = strconv.Atoi(parts[2])
-					mins = mins + tmpDuration
+			infoText := e.Text
+
+			// Check for release date
+			if strings.Contains(infoText, "Release date") {
+				dateText := e.ChildText("span")
+				if dateText == "" && strings.Contains(infoText, ":") {
+					dateText = strings.TrimSpace(strings.Split(infoText, ":")[1])
+				}
+
+				if dateText != "" {
+					// Try most common date format first
+					tmpDate, err := goment.New(dateText, "DD MMMM YYYY")
 					if err == nil {
-						sc.Duration = mins
+						sc.Released = tmpDate.Format("YYYY-MM-DD")
 					}
+				}
+			}
+
+			// Check for duration
+			if strings.Contains(infoText, "Duration") {
+				durationText := e.ChildText("span")
+				if durationText == "" && strings.Contains(infoText, ":") {
+					durationText = strings.TrimSpace(strings.Split(infoText, ":")[1])
+				}
+
+				if durationText != "" {
+					// Simplified duration extraction
+					parts := strings.Split(durationText, ":")
+					var hours, mins, secs int
+					if len(parts) == 3 {
+						hours, _ = strconv.Atoi(parts[0])
+						mins, _ = strconv.Atoi(parts[1])
+						secs, _ = strconv.Atoi(parts[2])
+					} else if len(parts) == 2 {
+						mins, _ = strconv.Atoi(parts[0])
+						secs, _ = strconv.Atoi(parts[1])
+					}
+					sc.Duration = (hours*3600 + mins*60 + secs) / 60
 				}
 			}
 		})
 
+		// Set up CDN URL for covers and images
 		cdnSceneURL := e.Request.URL
 		cdnSceneURL.Host = "cdn." + domain
 		cdnSceneURL.Path = "/videos/" + sc.SiteID
 
-		sc.Covers = []string{
-			cdnSceneURL.JoinPath("images", "cover.jpg").String(),
-			cdnSceneURL.JoinPath("images", "poster.jpg").String(),
+		// Look for gallery images in page HTML
+		pageHTMLStr := string(e.Response.Body)
+
+		// Extract cover images
+		cover := cdnSceneURL.JoinPath("images", "cover.jpg").String()
+
+		// Find cover images directly in HTML to get the correct URLs
+		coverRegex := regexp.MustCompile(`https://cdn\.vrspy\.com/videos/\d+/images/cover\.jpg`)
+
+		coverMatches := coverRegex.FindAllString(pageHTMLStr, -1)
+
+		// Use found URLs if available, otherwise fall back to constructed URLs
+		if len(coverMatches) > 0 {
+			// Clean up URL - extract just the base URL without any parameters or fragments
+			parsedURL, err := url.Parse(coverMatches[0])
+			if err == nil {
+				parsedURL.Fragment = ""
+				parsedURL.RawQuery = ""
+				cover = parsedURL.String()
+			}
 		}
 
-		nuxtData := e.ChildText(`#__NUXT_DATA__`)
-		imageRegex := regexp.MustCompile(regexp.QuoteMeta(cdnSceneURL.String()) + `(/photos/[^?"]*\.jpg)`)
-		sc.Gallery = imageRegex.FindAllString(nuxtData, -1)
+		sc.Covers = []string{cover}
 
-		// trailer details
-		sc.TrailerType = "scrape_html"
-		paramsdata := models.TrailerScrape{SceneUrl: sc.HomepageURL, HtmlElement: "script[id=\"__NUXT_DATA__\"]", ExtractRegex: `(https:\/\/cdn.vrspy.com\/videos\/\d*\/trailers\/\dk\.mp4\?token.*?)"`}
-		jsonStr, _ := json.Marshal(paramsdata)
-		sc.TrailerSrc = string(jsonStr)
+		// Try to find gallery images with the CDN image processing format and direct CDN URLs
+		cdnImageRegex := regexp.MustCompile(`https://vrspy\.com/cdn-cgi/image/w=\d+/https://cdn\.vrspy\.com/videos/\d+/photos/([^"\s]+\.jpg)`)
+		directImageRegex := regexp.MustCompile(`https://cdn\.vrspy\.com/videos/\d+/photos/([^"\s]+\.jpg)`)
+
+		// Extract all image filenames and their source URLs
+		type imageSource struct {
+			filename string
+			fullURL  string
+			isdirect bool
+		}
+
+		images := make([]imageSource, 0)
+
+		// Find CDN processed images
+		cdnMatches := cdnImageRegex.FindAllStringSubmatch(pageHTMLStr, -1)
+		for _, match := range cdnMatches {
+			if len(match) >= 2 {
+				images = append(images, imageSource{
+					filename: match[1],
+					fullURL:  match[0],
+					isdirect: false,
+				})
+			}
+		}
+
+		// Find direct CDN images
+		directMatches := directImageRegex.FindAllStringSubmatch(pageHTMLStr, -1)
+		for _, match := range directMatches {
+			if len(match) >= 2 {
+				images = append(images, imageSource{
+					filename: match[1],
+					fullURL:  match[0],
+					isdirect: true,
+				})
+			}
+		}
+
+		// Deduplicate images by filename and standardize to w=960
+		cleanGallery := make([]string, 0)
+		seenFilenames := make(map[string]bool)
+
+		// Process all images with a single loop
+		for _, img := range images {
+			if !seenFilenames[img.filename] {
+				seenFilenames[img.filename] = true
+
+				var directURL string
+				if !img.isdirect {
+					// Extract the direct URL part from CDN URL
+					parts := strings.Split(img.fullURL, "/https://")
+					if len(parts) < 2 {
+						continue
+					}
+					directURL = "https://" + parts[1]
+				} else {
+					directURL = img.fullURL
+				}
+
+				// Remove any fragments
+				directURL = strings.Split(directURL, "#")[0]
+
+				// Add both direct URL and CDN-transformed URL as fallback if CDN transformation fails
+				cleanGallery = append(cleanGallery, directURL)
+			}
+		}
+
+		sc.Gallery = cleanGallery
+
+		// Extract trailer URLs, 		// First try to find trailer URLs directly in the HTML
+		trailerRegex := regexp.MustCompile(`https://cdn\.vrspy\.com/videos/\d+/trailers/\w+\.mp4\?token=[^"&]+`)
+		trailerMatches := trailerRegex.FindAllString(pageHTMLStr, -1)
+
+		if len(trailerMatches) > 0 {
+			// If we found trailer URLs directly, use the first one
+			sc.TrailerType = "url"
+			sc.TrailerSrc = trailerMatches[0]
+		} else {
+			// Fallback to the scrape_html method
+			sc.TrailerType = "scrape_html"
+			paramsdata := models.TrailerScrape{
+				SceneUrl:     sc.HomepageURL,
+				HtmlElement:  "body", // Search the entire body since NUXT_DATA might be in different locations
+				ExtractRegex: `(https://cdn\.vrspy\.com/videos/\d+/trailers/\w+\.mp4\?token=[^"&]+)`,
+			}
+			jsonStr, _ := json.Marshal(paramsdata)
+			sc.TrailerSrc = string(jsonStr)
+		}
 
 		out <- sc
 	})
 
+	// Handle pagination
 	siteCollector.OnHTML(`body`, func(e *colly.HTMLElement) {
-		e.ForEachWithBreak(`.video-section a.photo-preview`, func(id int, e *colly.HTMLElement) bool {
-			currentPage, _ := strconv.Atoi(e.Request.URL.Query().Get("page"))
-			if !limitScraping {
-				siteCollector.Visit(fmt.Sprintf("%s/videos?sort=new&page=%d", baseURL, currentPage+1))
+		// Check if we need to go to the next page
+		currentPage, _ := strconv.Atoi(e.Request.URL.Query().Get("page"))
+		if currentPage == 0 {
+			currentPage = 1
+		}
+
+		if !limitScraping {
+			// Check if there are videos on this page before going to the next page
+			hasVideos := false
+			e.ForEach(`.item-wrapper .photo a`, func(id int, e *colly.HTMLElement) {
+				hasVideos = true
+			})
+
+			if hasVideos {
+				// Visit the next page
+				nextPage := currentPage + 1
+				siteCollector.Visit(fmt.Sprintf("%s/videos?sort=all&page=%d", baseURL, nextPage))
 			}
-			return false
-		})
+		}
 	})
 
+	// Find and visit scene pages
+	siteCollector.OnHTML(`.item-wrapper .photo a`, func(e *colly.HTMLElement) {
+		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
+		if !funk.ContainsString(knownScenes, sceneURL) {
+			sceneCollector.Visit(sceneURL)
+		}
+	})
+
+	// Fallback selector for scene links
 	siteCollector.OnHTML(`.video-section a.photo-preview`, func(e *colly.HTMLElement) {
 		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
 		if !funk.ContainsString(knownScenes, sceneURL) {
@@ -141,9 +344,19 @@ func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<
 	})
 
 	if singleSceneURL != "" {
+		// Ensure single scene URL uses www subdomain
+		if !strings.Contains(singleSceneURL, "www.") && strings.Contains(singleSceneURL, "://") {
+			parts := strings.Split(singleSceneURL, "://")
+			if len(parts) > 1 {
+				singleSceneURL = parts[0] + "://www." + strings.TrimPrefix(parts[1], "www.")
+			}
+		}
+		log.Infof("visiting %s", singleSceneURL)
 		sceneCollector.Visit(singleSceneURL)
 	} else {
-		siteCollector.Visit(baseURL + "/videos?sort=new&page=1")
+		listingURL := baseURL + "/videos?sort=all&page=1"
+		log.Infof("visiting %s", listingURL)
+		siteCollector.Visit(listingURL)
 	}
 
 	if updateSite {


### PR DESCRIPTION
VRSpy scraper rewritten to be more robust, accommodate new site changes, and transform scraped gallery images to 480px width since untransformed site images would cause unnecessary image cache bloat as they are very large