### PR TITLE
fix: set user-agent for r18.dev scraper

### DIFF
--- a/pkg/scrape/r18d.go
+++ b/pkg/scrape/r18d.go
@@ -18,6 +18,7 @@ func ScrapeR18D(out *[]models.ScrapedScene, queryString string) error {
 		sc.SceneType = "VR"
 
 		req := resty.New().R()
+		req.SetHeader("User-Agent", UserAgent)
 		res := getByContentId(req, v)
 
 		if res.StatusCode() == 404 {


### PR DESCRIPTION
The r18.dev JAV scraper is now failing with 403 Forbidden errors if we do not set a valid user agent.