### PR TITLE
fix: error when building due to unclosed tag in vue file

### DIFF
--- a/ui/src/views/options/sections/InterfaceAdvanced.vue
+++ b/ui/src/views/options/sections/InterfaceAdvanced.vue
@@ -170,15 +170,18 @@
       <div class="columns" v-if="activeTab == 4">
         <div class="column">
           <section>
-
             <b-field :label="$t('Proxy')" label-position="on-border">
               <b-input v-model="scraperProxy" :placeholder="$t('Optional: http proxy')"></b-input>
             </b-field>
             <b-field>
               <b-button type="is-primary" @click="save">Save</b-button>
             </b-field>
-      <!-- Heaaders/Cookies tab -->
-      <div class="columns" v-if="activeTab == 4">
+          </section>
+        </div>
+      </div>
+
+      <!-- Headers/Cookies tab -->
+      <div class="columns" v-if="activeTab == 5">
         <div class="column">
           <section>            
             <b-field>


### PR DESCRIPTION
Fix the following error when building locally:

```
[dev:ui]  ERROR  Failed to compile with 1 error5:57:32 PM
[dev:ui] 
[dev:ui]  error  in ./src/views/options/sections/InterfaceAdvanced.vue?vue&type=template&id=bebdc236&scoped=true&
[dev:ui] 
[dev:ui] Module Error (from ../node_modules/@vue/cli-service/node_modules/@vue/vue-loader-v15/lib/loaders/templateLoader.js):
[dev:ui] (Emitted value instead of an instance of Error) 
[dev:ui] 
[dev:ui]   Errors compiling template:
[dev:ui] 
[dev:ui]   tag <section> has no matching end tag.
[dev:ui] 
[dev:ui]   170|      <div class="columns" v-if="activeTab == 4">
[dev:ui]   171|        <div class="column">
[dev:ui]   172|          <section>
[dev:ui]      |          ^^^^^^^^^
[dev:ui]   173|  
[dev:ui]   174|            <b-field :label="$t('Proxy')" label-position="on-border">
[dev:ui] 
[dev:ui]   tag <div> has no matching end tag.
[dev:ui] 
[dev:ui]   2  |  <div class="container">
[dev:ui]   3  |    <b-loading :is-full-page="false" :active.sync="isLoading" />
[dev:ui]   4  |    <div class="content">
[dev:ui]      |    ^^^^^^^^^^^^^^^^^^^^^
[dev:ui]   5  |      <h3>{{ $t('Advanced') }}</h3>
[dev:ui]   6  |      <hr />
[dev:ui] 
[dev:ui]   tag <div> has no matching end tag.
[dev:ui] 
[dev:ui]   1  |  
[dev:ui]      |   
[dev:ui]   2  |  <div class="container">
[dev:ui]      |  ^^^^^^^^^^^^^^^^^^^^^^^
[dev:ui]   3  |    <b-loading :is-full-page="false" :active.sync="isLoading" />
[dev:ui] 
[dev:ui] 
[dev:ui]  ERROR  Error: Build failed with errors.
```

This was caused by: https://github.com/xbapps/xbvr/pull/1952