### PR TITLE
VirtualRealPorn Actor scrape - fix missing image

### DIFF
--- a/pkg/models/model_external_reference.go
+++ b/pkg/models/model_external_reference.go
@@ -428,10 +428,9 @@ func (scrapeRules ActorScraperConfig) buildGenericActorScraperRules() {
 		XbvrField: "nationality", Selector: `script[type="application/ld+json"][class!='yoast-schema-graph']`,
 		PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"birthPlace"}}, {Function: "Lookup Country"}},
 	})
-	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{
-		XbvrField: "image_url", Selector: `script[type="application/ld+json"][class!='yoast-schema-graph']`,
-		PostProcessing: []PostProcessing{{Function: "jsonString", Params: []string{"image"}}},
-	})
+
+	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "image_url", Selector: `div.feature_img_model > img`, ResultType: "attr", Attribute: "src"})
+
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "eye_color", Selector: `table[id="table_about"] tr th:contains('Eyes Color')+td`})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "hair_color", Selector: `table[id="table_about"] tr th:contains('Hair Color')+td`})
 	siteDetails.SiteRules = append(siteDetails.SiteRules, GenericActorScraperRule{XbvrField: "band_size", Selector: `table[id="table_about"] tr th:contains('Bust')+td`})


### PR DESCRIPTION
resolves #2049 

scraper fix - actor image was relocated in html code on virtualrealporn so instead of scraping image, the genericactor scraper is scraping json. depending on the size of the json this was (in addition to the image being missing from the Actor's profile) causing xbvr to crash.