### PR TITLE
feat: make scene and actor cards cover aspect ratio configurable

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -44,23 +44,27 @@ type VersionCheckResponse struct {
 }
 
 type RequestSaveOptionsWeb struct {
-	TagSort             string `json:"tagSort"`
-	SceneHidden         bool   `json:"sceneHidden"`
-	SceneWatchlist      bool   `json:"sceneWatchlist"`
-	SceneFavourite      bool   `json:"sceneFavourite"`
-	SceneWishlist       bool   `json:"sceneWishlist"`
-	SceneWatched        bool   `json:"sceneWatched"`
-	SceneEdit           bool   `json:"sceneEdit"`
-	SceneDuration       bool   `json:"sceneDuration"`
-	SceneCuepoint       bool   `json:"sceneCuepoint"`
-	ShowHspFile         bool   `json:"showHspFile"`
-	ShowSubtitlesFile   bool   `json:"showSubtitlesFile"`
-	SceneTrailerlist    bool   `json:"sceneTrailerlist"`
-	ShowScriptHeatmap   bool   `json:"showScriptHeatmap"`
-	ShowAllHeatmaps     bool   `json:"showAllHeatmaps"`
-	ShowOpenInNewWindow bool   `json:"showOpenInNewWindow"`
-	UpdateCheck         bool   `json:"updateCheck"`
-	IsAvailOpacity      int    `json:"isAvailOpacity"`
+	TagSort              string `json:"tagSort"`
+	SceneHidden          bool   `json:"sceneHidden"`
+	SceneWatchlist       bool   `json:"sceneWatchlist"`
+	SceneFavourite       bool   `json:"sceneFavourite"`
+	SceneWishlist        bool   `json:"sceneWishlist"`
+	SceneWatched         bool   `json:"sceneWatched"`
+	SceneEdit            bool   `json:"sceneEdit"`
+	SceneDuration        bool   `json:"sceneDuration"`
+	SceneCuepoint        bool   `json:"sceneCuepoint"`
+	ShowHspFile          bool   `json:"showHspFile"`
+	ShowSubtitlesFile    bool   `json:"showSubtitlesFile"`
+	SceneTrailerlist     bool   `json:"sceneTrailerlist"`
+	ShowScriptHeatmap    bool   `json:"showScriptHeatmap"`
+	ShowAllHeatmaps      bool   `json:"showAllHeatmaps"`
+	ShowOpenInNewWindow  bool   `json:"showOpenInNewWindow"`
+	UpdateCheck          bool   `json:"updateCheck"`
+	IsAvailOpacity       int    `json:"isAvailOpacity"`
+	SceneCardAspectRatio string `json:"sceneCardAspectRatio"`
+	SceneCardScaleToFit  bool   `json:"sceneCardScaleToFit"`
+	ActorCardAspectRatio string `json:"actorCardAspectRatio"`
+	ActorCardScaleToFit  bool   `json:"actorCardScaleToFit"`
 }
 
 type RequestSaveOptionsAdvanced struct {
@@ -502,6 +506,10 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.ShowOpenInNewWindow = r.ShowOpenInNewWindow
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.Config.Web.IsAvailOpacity = r.IsAvailOpacity
+	config.Config.Web.SceneCardAspectRatio = r.SceneCardAspectRatio
+	config.Config.Web.SceneCardScaleToFit = r.SceneCardScaleToFit
+	config.Config.Web.ActorCardAspectRatio = r.ActorCardAspectRatio
+	config.Config.Web.ActorCardScaleToFit = r.ActorCardScaleToFit
 	config.SaveConfig()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, r)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,23 +30,27 @@ type ObjectConfig struct {
 		Password string `default:"" json:"password"`
 	} `json:"security"`
 	Web struct {
-		TagSort             string `default:"by-tag-count" json:"tagSort"`
-		SceneHidden         bool   `default:"true" json:"sceneHidden"`
-		SceneWatchlist      bool   `default:"true" json:"sceneWatchlist"`
-		SceneFavourite      bool   `default:"true" json:"sceneFavourite"`
-		SceneWishlist       bool   `default:"true" json:"sceneWishlist"`
-		SceneWatched        bool   `default:"false" json:"sceneWatched"`
-		SceneEdit           bool   `default:"false" json:"sceneEdit"`
-		SceneDuration       bool   `default:"false" json:"sceneDuration"`
-		SceneCuepoint       bool   `default:"true" json:"sceneCuepoint"`
-		ShowHspFile         bool   `default:"true" json:"showHspFile"`
-		ShowSubtitlesFile   bool   `default:"true" json:"showSubtitlesFile"`
-		SceneTrailerlist    bool   `default:"true" json:"sceneTrailerlist"`
-		ShowScriptHeatmap   bool   `default:"true" json:"showScriptHeatmap"`
-		ShowAllHeatmaps     bool   `default:"false" json:"showAllHeatmaps"`
-		ShowOpenInNewWindow bool   `default:"true" json:"showOpenInNewWindow"`
-		UpdateCheck         bool   `default:"true" json:"updateCheck"`
-		IsAvailOpacity      int    `default:"40" json:"isAvailOpacity"`
+		TagSort              string `default:"by-tag-count" json:"tagSort"`
+		SceneHidden          bool   `default:"true" json:"sceneHidden"`
+		SceneWatchlist       bool   `default:"true" json:"sceneWatchlist"`
+		SceneFavourite       bool   `default:"true" json:"sceneFavourite"`
+		SceneWishlist        bool   `default:"true" json:"sceneWishlist"`
+		SceneWatched         bool   `default:"false" json:"sceneWatched"`
+		SceneEdit            bool   `default:"false" json:"sceneEdit"`
+		SceneDuration        bool   `default:"false" json:"sceneDuration"`
+		SceneCuepoint        bool   `default:"true" json:"sceneCuepoint"`
+		ShowHspFile          bool   `default:"true" json:"showHspFile"`
+		ShowSubtitlesFile    bool   `default:"true" json:"showSubtitlesFile"`
+		SceneTrailerlist     bool   `default:"true" json:"sceneTrailerlist"`
+		ShowScriptHeatmap    bool   `default:"true" json:"showScriptHeatmap"`
+		ShowAllHeatmaps      bool   `default:"false" json:"showAllHeatmaps"`
+		ShowOpenInNewWindow  bool   `default:"true" json:"showOpenInNewWindow"`
+		UpdateCheck          bool   `default:"true" json:"updateCheck"`
+		IsAvailOpacity       int    `default:"40" json:"isAvailOpacity"`
+		SceneCardAspectRatio string `default:"1:1" json:"sceneCardAspectRatio"`
+		SceneCardScaleToFit  bool   `default:"true" json:"sceneCardScaleToFit"`
+		ActorCardAspectRatio string `default:"1:1" json:"actorCardAspectRatio"`
+		ActorCardScaleToFit  bool   `default:"true" json:"actorCardScaleToFit"`
 	} `json:"web"`
 	Advanced struct {
 		ShowInternalSceneId          bool      `default:"false" json:"showInternalSceneId"`

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -12,23 +12,27 @@ type ObjectState struct {
 		BoundIP []string `json:"bound_ip"`
 	} `json:"server"`
 	Web struct {
-		TagSort             string `json:"tagSort"`
-		SceneHidden         bool   `json:"sceneHidden"`
-		SceneWatchlist      bool   `json:"sceneWatchlist"`
-		SceneFavourite      bool   `json:"sceneFavourite"`
-		SceneWishlist       bool   `json:"sceneWishlist"`
-		SceneWatched        bool   `json:"sceneWatched"`
-		SceneEdit           bool   `json:"sceneEdit"`
-		SceneDuration       bool   `json:"sceneDuration"`
-		SceneCuepoint       bool   `json:"sceneCuepoint"`
-		ShowHspFile         bool   `json:"showHspFile"`
-		ShowSubtitlesFile   bool   `json:"showSubtitlesFile"`
-		SceneTrailerlist    bool   `json:"sceneTrailerlist"`
-		ShowScriptHeatmap   bool   `json:"showScriptHeatmap"`
-		ShowAllHeatmaps     bool   `json:"showAllHeatmaps"`
-		ShowOpenInNewWindow bool   `json:"showOpenInNewWindow"`
-		UpdateCheck         bool   `json:"updateCheck"`
-		IsAvailOpacity      int    `json:"isAvailOpacity"`
+		TagSort              string `json:"tagSort"`
+		SceneHidden          bool   `json:"sceneHidden"`
+		SceneWatchlist       bool   `json:"sceneWatchlist"`
+		SceneFavourite       bool   `json:"sceneFavourite"`
+		SceneWishlist        bool   `json:"sceneWishlist"`
+		SceneWatched         bool   `json:"sceneWatched"`
+		SceneEdit            bool   `json:"sceneEdit"`
+		SceneDuration        bool   `json:"sceneDuration"`
+		SceneCuepoint        bool   `json:"sceneCuepoint"`
+		ShowHspFile          bool   `json:"showHspFile"`
+		ShowSubtitlesFile    bool   `json:"showSubtitlesFile"`
+		SceneTrailerlist     bool   `json:"sceneTrailerlist"`
+		ShowScriptHeatmap    bool   `json:"showScriptHeatmap"`
+		ShowAllHeatmaps      bool   `json:"showAllHeatmaps"`
+		ShowOpenInNewWindow  bool   `json:"showOpenInNewWindow"`
+		UpdateCheck          bool   `json:"updateCheck"`
+		IsAvailOpacity       int    `json:"isAvailOpacity"`
+		SceneCardAspectRatio string `json:"sceneCardAspectRatio"`
+		SceneCardScaleToFit  bool   `json:"sceneCardScaleToFit"`
+		ActorCardAspectRatio string `json:"actorCardAspectRatio"`
+		ActorCardScaleToFit  bool   `json:"actorCardScaleToFit"`
 	} `json:"web"`
 	DLNA struct {
 		Running  bool     `json:"running"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -20,6 +20,10 @@ const state = {
     showScriptHeatmap: false,
     showAllHeatmaps: false,
     showOpenInNewWindow: true,
+    sceneCardAspectRatio: "1:1",
+    sceneCardScaleToFit: true,
+    actorCardAspectRatio: "1:1",
+    actorCardScaleToFit: true,
     updateCheck: true
   }
 }
@@ -49,6 +53,10 @@ const actions = {
         state.web.updateCheck = data.config.web.updateCheck
         state.web.isAvailOpacity = data.config.web.isAvailOpacity 
         state.web.showOpenInNewWindow = data.config.web.showOpenInNewWindow
+        state.web.sceneCardAspectRatio = data.config.web.sceneCardAspectRatio
+        state.web.sceneCardScaleToFit = data.config.web.sceneCardScaleToFit
+        state.web.actorCardAspectRatio = data.config.web.actorCardAspectRatio
+        state.web.actorCardScaleToFit = data.config.web.actorCardScaleToFit
         state.loading = false
       })
   },
@@ -72,8 +80,12 @@ const actions = {
         state.web.showScriptHeatmap = data.showScriptHeatmap
         state.web.showAllHeatmaps = data.showAllHeatmaps
         state.web.updateCheck = data.updateCheck
-        state.web.isAvailOpacity = data.isAvailOpacity        
+        state.web.isAvailOpacity = data.isAvailOpacity
         state.web.showOpenInNewWindow = data.showOpenInNewWindow
+        state.web.sceneCardAspectRatio = data.sceneCardAspectRatio
+        state.web.sceneCardScaleToFit = data.sceneCardScaleToFit
+        state.web.actorCardAspectRatio = data.actorCardAspectRatio
+        state.web.actorCardScaleToFit = data.actorCardScaleToFit
         state.loading = false
       })
   }

--- a/ui/src/views/actors/ActorCard.vue
+++ b/ui/src/views/actors/ActorCard.vue
@@ -2,7 +2,7 @@
   <div class="card is-shadowless">
     <div class="card-image">
       <div class="bbox"
-           v-bind:style="{backgroundImage: `url(${getImageURL(actor.image_url)})`, backgroundSize: 'contain', backgroundPosition: 'center', backgroundRepeat: 'no-repeat', opacity:isAvailable(actor) ? 1.0 : isAvailOpactiy}"
+           v-bind:style="{backgroundImage: `url(${getImageURL(actor.image_url)})`, backgroundSize: actorCardScale, backgroundPosition: 'center', backgroundRepeat: 'no-repeat', opacity:isAvailable(actor) ? 1.0 : isAvailOpacity, aspectRatio: actorCardAspectRatio}"
            @click="showDetails(actor)"
            @mouseover="preview = true"
            @mouseleave="preview = false">
@@ -71,11 +71,27 @@ export default {
     }
   },
   computed: {
-      isAvailOpactiy () {      
+    isAvailOpacity () {      
       if (this.$store.state.optionsWeb.web.isAvailOpacity == undefined) {
         return .4
       }
       return this.$store.state.optionsWeb.web.isAvailOpacity / 100
+    },
+    actorCardAspectRatio () {
+      if (this.$store.state.optionsWeb.web.actorCardAspectRatio == "2:3") {
+        return 2 / 3
+      } else if (this.$store.state.optionsWeb.web.actorCardAspectRatio == "9:16") {
+        return 9 / 16
+      } else {
+        return 1
+      }
+    },
+    actorCardScale () {
+      if (this.$store.state.optionsWeb.web.actorCardScaleToFit) {
+        return "contain"
+      } else {
+        return "cover"
+      }
     },
   },
   methods: {

--- a/ui/src/views/actors/SearchStashdbActors.vue
+++ b/ui/src/views/actors/SearchStashdbActors.vue
@@ -143,7 +143,7 @@ export default {
       this.$store.commit('overlay/hideSearchStashdbActors')
     },
     searchStashdb() {
-      this.$buefy.toast.open({message: `Searching Actots`, type: 'is-primary', duration: 5000})
+      this.$buefy.toast.open({message: `Searching Actors`, type: 'is-primary', duration: 5000})
         ky.get('/api/extref/stashdb/searchactor/' + this.actor.id + "?q=" + this.queryString, {timeout: 6e6}).json().then(data => {
             this.searchResults = Object.values(data.Results).sort((a, b) => b.Weight - a.Weight)
             this.isModalActive = true

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -98,6 +98,32 @@
               </div>
             </b-field>
 
+            <b-field label="Scene card aspect ratio">
+              <b-select placeholder="Select aspect ratio" v-model="sceneCardAspectRatio">
+                <option>1:1</option>
+                <option>3:2</option>
+                <option>16:9</option>
+              </b-select>
+            </b-field>
+            <b-field>
+              <b-switch v-model="sceneCardScaleToFit" type="is-dark">
+                Scale cover to fit
+              </b-switch>
+            </b-field>
+
+            <b-field label="Actor card aspect ratio">
+              <b-select placeholder="Select aspect ratio" v-model="actorCardAspectRatio">
+                <option>1:1</option>
+                <option>2:3</option>
+                <option>9:16</option>
+              </b-select>
+            </b-field>
+            <b-field>
+              <b-switch v-model="actorCardScaleToFit" type="is-dark">
+                Scale cover to fit
+              </b-switch>
+            </b-field>
+
             <b-field label="Automatically Check for Updates">
               <b-switch v-model="updateCheck">
                 Enabled
@@ -265,9 +291,41 @@ export default {
         this.$store.state.optionsWeb.web.isAvailOpacity = value
       }
     },
+    sceneCardAspectRatio: {
+      get () {
+        return this.$store.state.optionsWeb.web.sceneCardAspectRatio
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.sceneCardAspectRatio = value
+      }
+    },
+    sceneCardScaleToFit: {
+      get () {
+        return this.$store.state.optionsWeb.web.sceneCardScaleToFit
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.sceneCardScaleToFit = value
+      }
+    },
+    actorCardAspectRatio: {
+      get () {
+        return this.$store.state.optionsWeb.web.actorCardAspectRatio
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.actorCardAspectRatio = value
+      }
+    },
+    actorCardScaleToFit: {
+      get () {
+        return this.$store.state.optionsWeb.web.actorCardScaleToFit
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.actorCardScaleToFit = value
+      }
+    },
     isLoading: function () {
       return this.$store.state.optionsWeb.loading
-    }    
+    }
   }
 }
 </script>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -2,7 +2,7 @@
   <div class="card is-shadowless">
     <div class="card-image">
       <div class="bbox"
-           v-bind:style='{backgroundImage: `url("${getImageURL(item.cover_url)}")`, backgroundSize: "contain", backgroundPosition: "center", backgroundRepeat: "no-repeat", opacity:item.is_available ? 1.0 : this.isAvailOpactiy}'
+           v-bind:style='{backgroundImage: `url("${getImageURL(item.cover_url)}")`, backgroundSize: this.sceneCardScale, backgroundPosition: "center", backgroundRepeat: "no-repeat", opacity:item.is_available ? 1.0 : this.isAvailOpactiy, aspectRatio: this.sceneCardAspectRatio}'
            @click="showDetails(item)"
            @mouseover="preview = true"
            @mouseleave="preview = false">
@@ -157,6 +157,22 @@ export default {
         return .4
       }
       return this.$store.state.optionsWeb.web.isAvailOpacity / 100
+    },
+    sceneCardAspectRatio () {
+      if (this.$store.state.optionsWeb.web.sceneCardAspectRatio == "3:2") {
+        return 3 / 2
+      } else if (this.$store.state.optionsWeb.web.sceneCardAspectRatio == "16:9") {
+        return 16 / 9
+      } else {
+        return 1
+      }
+    },
+    sceneCardScale () {
+      if (this.$store.state.optionsWeb.web.sceneCardScaleToFit) {
+        return "contain"
+      } else {
+        return "cover"
+      }
     },
     async getAlternateSceneSourcesWithTitles() {
       this.stashLinkExists = false


### PR DESCRIPTION
Add option under INTERFACES > Web UI to configure the aspect ratio of the cover images for scenes and actors. And to configure whether the image should fill or fit in the available space:

<img width="236" height="258" alt="image" src="https://github.com/user-attachments/assets/cd46b1c2-9e65-4e9c-939c-a1c96b516b37" />
