### PR TITLE
fix: Concurrent Scraper Waitgroups

### DIFF
--- a/pkg/models/model_scraper.go
+++ b/pkg/models/model_scraper.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"sync/atomic"
+	"time"
 )
 
 var scrapers []Scraper
@@ -111,7 +112,7 @@ func (wg *ScrapeWG) Done() {
 
 func (wg *ScrapeWG) Wait(n int64) {
 	for atomic.LoadInt64(&wg.count) >= n && atomic.LoadInt64(&wg.count) != 0 {
-		continue
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
This fixes issue I noticed during debugging (not sure if also an issue when running normal). My development environment became useless to debug scrapers. Initiating a scrape would send CPU to 100% and lock xbvr until the app was killed. Without this I could not step through code during execution. It would happen 99.5 times out of 100.