### PR TITLE
Add configurable User Agent option in Advanced settings

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -72,6 +72,7 @@ type RequestSaveOptionsAdvanced struct {
 	ShowHSPApiLink               bool      `json:"showHSPApiLink"`
 	ShowSceneSearchField         bool      `json:"showSceneSearchField"`
 	ScraperProxy                 string    `json:"scraperProxy"`
+	ScraperUserAgent             string    `json:"scraperUserAgent"`
 	StashApiKey                  string    `json:"stashApiKey"`
 	ScrapeActorAfterScene        bool      `json:"scrapeActorAfterScene"`
 	UseImperialEntry             bool      `json:"useImperialEntry"`
@@ -528,6 +529,7 @@ func (i ConfigResource) saveOptionsAdvanced(req *restful.Request, resp *restful.
 	config.Config.Advanced.ShowSceneSearchField = r.ShowSceneSearchField
 	config.Config.Advanced.StashApiKey = r.StashApiKey
 	config.Config.Advanced.ScraperProxy = r.ScraperProxy
+	config.Config.Advanced.ScraperUserAgent = r.ScraperUserAgent
 	config.Config.Advanced.ScrapeActorAfterScene = r.ScrapeActorAfterScene
 	config.Config.Advanced.UseImperialEntry = r.UseImperialEntry
 	config.Config.Advanced.LinkScenesAfterSceneScraping = r.LinkScenesAfterSceneScraping

--- a/pkg/api/trailers.go
+++ b/pkg/api/trailers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/tidwall/gjson"
 
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/scrape"
 )
@@ -98,7 +99,7 @@ func LoadDeovrScene(scrapeParams string) DeoScene {
 }
 
 func ScrapeHtml(scrapeParams string) models.VideoSourceResponse {
-	c := colly.NewCollector(colly.UserAgent(scrape.UserAgent))
+	c := colly.NewCollector(colly.UserAgent(config.Config.Advanced.ScraperUserAgent))
 	var params models.TrailerScrape
 	json.Unmarshal([]byte(scrapeParams), &params)
 	if params.KVHttpConfig == "" {
@@ -141,7 +142,7 @@ func ScrapeHtml(scrapeParams string) models.VideoSourceResponse {
 }
 
 func ScrapeJson(scrapeParams string) models.VideoSourceResponse {
-	c := colly.NewCollector(colly.UserAgent(scrape.UserAgent))
+	c := colly.NewCollector(colly.UserAgent(config.Config.Advanced.ScraperUserAgent))
 	var params models.TrailerScrape
 	json.Unmarshal([]byte(scrapeParams), &params)
 	if params.KVHttpConfig == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ type ObjectConfig struct {
 		ShowSceneSearchField         bool      `default:"false" json:"showSceneSearchField"`
 		StashApiKey                  string    `default:"" json:"stashApiKey"`
 		ScraperProxy                 string    `default:"" json:"scraperProxy"`
+		ScraperUserAgent             string    `default:"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36" json:"scraperUserAgent"`
 		ScrapeActorAfterScene        bool      `default:"true" json:"scrapeActorAfterScene"`
 		UseImperialEntry             bool      `default:"false" json:"useImperialEntry"`
 		ProgressTimeInterval         int       `default:"15" json:"progressTimeInterval"`

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -928,7 +928,7 @@ func Migrate() {
 						queryParams := "page=1&type=videos&sort=latest&show_custom_video=1&bonus-video=1&limit=1000"
 						url := fmt.Sprintf("https://content.%s.com/api/content/v1/videos?%s", strings.ToLower(site), queryParams)
 
-						r, err := resty.New().R().SetHeader("User-Agent", scrape.UserAgent).Get(url)
+						r, err := resty.New().R().SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).Get(url)
 						if err != nil {
 							return "", err
 						}
@@ -1031,7 +1031,7 @@ func Migrate() {
 						mapping = map[string]string{}
 						queryParams := "page=1&type=videos&sort=latest&show_custom_video=1&bonus-video=1&limit=1000"
 						url := fmt.Sprintf("https://content.%s.com/api/content/v1/videos?%s", strings.ToLower(site), queryParams)
-						r, err := resty.New().R().SetHeader("User-Agent", scrape.UserAgent).Get(url)
+						r, err := resty.New().R().SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).Get(url)
 						if err != nil {
 							return "", err
 						}

--- a/pkg/scrape/baberoticavr.go
+++ b/pkg/scrape/baberoticavr.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/gosimple/slug"
 	"github.com/thoas/go-funk"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -31,7 +32,7 @@ func BaberoticaVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, ou
 	})
 
 	resp, err := resty.New().R().
-		SetHeader("User-Agent", UserAgent).
+		SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).
 		SetDoNotParseResponse(true).
 		Get("https://baberoticavr.com/feed/csv/")
 

--- a/pkg/scrape/fuckpassvr.go
+++ b/pkg/scrape/fuckpassvr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gocolly/colly/v2"
 	"github.com/nleeper/goment"
 	"github.com/thoas/go-funk"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -23,7 +24,7 @@ func FuckPassVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out 
 	siteCollector := createCollector("www.fuckpassvr.com")
 
 	client := resty.New()
-	client.SetHeader("User-Agent", UserAgent)
+	client.SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent)
 
 	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
 		sc := models.ScrapedScene{}

--- a/pkg/scrape/r18d.go
+++ b/pkg/scrape/r18d.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/tidwall/gjson"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -18,7 +19,7 @@ func ScrapeR18D(out *[]models.ScrapedScene, queryString string) error {
 		sc.SceneType = "VR"
 
 		req := resty.New().R()
-		req.SetHeader("User-Agent", UserAgent)
+		req.SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent)
 		res := getByContentId(req, v)
 
 		if res.StatusCode() == 404 {

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -20,13 +20,11 @@ import (
 
 var log = &common.Log
 
-var UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36"
-
 func createCollector(domains ...string) *colly.Collector {
 	c := colly.NewCollector(
 		colly.AllowedDomains(domains...),
 		colly.CacheDir(getScrapeCacheDir()),
-		colly.UserAgent(UserAgent),
+		colly.UserAgent(config.Config.Advanced.ScraperUserAgent),
 	)
 	// use proxy if configured
 	if config.Config.Advanced.ScraperProxy != "" {

--- a/pkg/scrape/slrstudios.go
+++ b/pkg/scrape/slrstudios.go
@@ -109,7 +109,7 @@ func SexLikeReal(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out
 
 		// Fetch scene data from API
 		req := resty.New().R().
-			SetHeader("User-Agent", UserAgent).
+			SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).
 			SetHeader("Client-Type", "web")
 
 		reqconfig := GetCoreDomain(apiURL) + "-scraper"
@@ -407,7 +407,7 @@ func SexLikeReal(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out
 			apiURL := "https://api.sexlikereal.com/v3/scenes?studios=" + studioCode + "&perPage=" + strconv.Itoa(perPage) + "&sort=mostRecent&page=" + strconv.Itoa(page)
 
 			req := resty.New().R().
-				SetHeader("User-Agent", UserAgent).
+				SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).
 				SetHeader("Client-Type", "web")
 
 			reqconfig := GetCoreDomain(apiURL) + "-scraper"

--- a/pkg/scrape/upclosevr.go
+++ b/pkg/scrape/upclosevr.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nleeper/goment"
 	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -48,7 +49,7 @@ func UpCloseVR(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out c
 				resp, err := client.R().
 					SetHeader("Origin", "https://www.upclosevr.com").
 					SetHeader("Referer", "https://www.upclosevr.com/").
-					SetHeader("User-Agent", UserAgent).
+					SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).
 					SetHeader("x-algolia-api-key", apiKey[1]).
 					SetHeader("x-algolia-application-id", applicationID[1]).
 					SetBody(payload).

--- a/pkg/scrape/vrbangers.go
+++ b/pkg/scrape/vrbangers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nleeper/goment"
 	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -40,7 +41,7 @@ func VRBangersSite(wg *models.ScrapeWG, updateSite bool, knownScenes []string, o
 		contentURL := strings.Replace(URL, "//", "//content.", 1)
 
 		r, _ := resty.New().R().
-			SetHeader("User-Agent", UserAgent).
+			SetHeader("User-Agent", config.Config.Advanced.ScraperUserAgent).
 			Get("https://content." + sc.Site + ".com/api/content/v1/videos/" + content_id)
 
 		JsonMetadata := r.String()

--- a/pkg/scrape/vrspy.go
+++ b/pkg/scrape/vrspy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nleeper/goment"
 	"github.com/thoas/go-funk"
 
+	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -42,14 +43,14 @@ func VRSpy(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan<
 	}
 
 	sceneCollector.OnRequest(func(r *colly.Request) {
-		r.Headers.Set("User-Agent", UserAgent)
+		r.Headers.Set("User-Agent", config.Config.Advanced.ScraperUserAgent)
 		for _, c := range cookies {
 			r.Headers.Set("Cookie", c.Name+"="+c.Value)
 		}
 	})
 
 	siteCollector.OnRequest(func(r *colly.Request) {
-		r.Headers.Set("User-Agent", UserAgent)
+		r.Headers.Set("User-Agent", config.Config.Advanced.ScraperUserAgent)
 		for _, c := range cookies {
 			r.Headers.Set("Cookie", c.Name+"="+c.Value)
 		}

--- a/ui/src/store/optionsAdvanced.js
+++ b/ui/src/store/optionsAdvanced.js
@@ -7,6 +7,7 @@ const state = {
     showHSPApiLink: false,
     showSceneSearchField: false,
     stashApiKey: '',
+    scraperUserAgent: '',
     scrapeActorAfterScene: 'true',
     useImperialEntry: 'false',
     linkScenesAfterSceneScraping: true,
@@ -35,6 +36,7 @@ const actions = {
         state.advanced.showSceneSearchField = data.config.advanced.showSceneSearchField
         state.advanced.stashApiKey = data.config.advanced.stashApiKey
         state.advanced.scraperProxy = data.config.advanced.scraperProxy
+        state.advanced.scraperUserAgent = data.config.advanced.scraperUserAgent
         state.advanced.scrapeActorAfterScene = data.config.advanced.scrapeActorAfterScene
         state.advanced.useImperialEntry = data.config.advanced.useImperialEntry
         state.advanced.linkScenesAfterSceneScraping = data.config.advanced.linkScenesAfterSceneScraping
@@ -54,6 +56,7 @@ const actions = {
         state.advanced.showSceneSearchField = data.showSceneSearchField
         state.advanced.stashApiKey = data.stashApiKey
         state.advanced.scraperProxy = data.scraperProxy
+        state.advanced.scraperUserAgent = data.scraperUserAgent
         state.advanced.scrapeActorAfterScene = data.scrapeActorAfterScene
         state.advanced.useImperialEntry = data.useImperialEntry
         state.advanced.linkScenesAfterSceneScraping = data.linkScenesAfterSceneScraping

--- a/ui/src/views/options/sections/InterfaceAdvanced.vue
+++ b/ui/src/views/options/sections/InterfaceAdvanced.vue
@@ -11,6 +11,7 @@
             <b-tab-item :label="$t('Alternate Sites')"/>
             <b-tab-item :label="$t('Proxy')"/>
             <b-tab-item :label="$t('Cookies/Headers')"/>
+            <b-tab-item :label="$t('Scrapers')"/>
       </b-tabs>
 
       <!-- Screen Details Tab -->
@@ -264,6 +265,20 @@
         </div>
       </div>
 
+      <!-- Scrapers tab -->
+      <div class="columns" v-if="activeTab == 6">
+        <div class="column">
+          <section>
+            <b-field :label="$t('User Agent')" label-position="on-border">
+              <b-input v-model="scraperUserAgent" :placeholder="$t('Custom User Agent for scrapers (default: Mozilla/5.0 (X11; Linux x86_64; rv:144.0) Gecko/20100101 Firefox/144.0)')"></b-input>
+            </b-field>
+            <b-field>
+              <b-button type="is-primary" @click="save">Save</b-button>
+            </b-field>
+          </section>
+        </div>
+      </div>
+
     </div>
   </div>
 </template>
@@ -482,6 +497,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsAdvanced.advanced.scraperProxy = value
+      }
+    },
+    scraperUserAgent: {
+      get () {
+        return this.$store.state.optionsAdvanced.advanced.scraperUserAgent
+      },
+      set (value) {
+        this.$store.state.optionsAdvanced.advanced.scraperUserAgent = value
       }
     },
     stashApiKey: {


### PR DESCRIPTION
 - Adds a new "Scrapers" tab in Advanced settings that allows users to configure a custom User Agent string
 - Replaces the hardcoded User Agent value throughout the codebase with the configurable option from settings
 - Sets a sensible default User Agent that matches the previously hardcoded value

 ## Changes

   ### Backend
   - **pkg/config/config.go**: Added `ScraperUserAgent` field to Advanced config with default value
   - **pkg/api/options.go**: Added API endpoint support for saving/loading the new User Agent setting
   - **pkg/scrape/scrape.go**: Removed hardcoded `UserAgent` constant
   - **Multiple scraper files**: Updated all scrapers to use `config.Config.Advanced.ScraperUserAgent` instead of the hardcoded value:
     - baberoticavr.go
     - fuckpassvr.go
     - r18d.go
     - slrstudios.go
     - upclosevr.go
     - vrbangers.go
     - vrspy.go
   - **pkg/api/trailers.go**: Updated trailer scraping functions to use configurable User Agent
   - **pkg/migrations/migrations.go**: Updated migration scripts to use configurable User Agent

   ### Frontend
   - **ui/src/views/options/sections/InterfaceAdvanced.vue**: Added new "Scrapers" tab with User Agent input field
   - **ui/src/store/optionsAdvanced.js**: Added state management for the new `scraperUserAgent` setting

   ## Motivation

   This change allows users to customize the User Agent string used by XBVR scrapers, which can be useful for:
   - Working around site-specific User Agent restrictions
   - Testing different User Agent strings without code changes
   - Matching specific browser versions required by certain sites
