### PR TITLE
Change Startup Migrations

### DIFF
--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -59,7 +59,7 @@ func getVRPornSlugToIDMap() (map[string]string, error) {
 	return getVRPornSlugToID(), nil
 }
 
-func Migrate() {
+func Migrate(migrateTo string) {
 	tlog := common.Log.WithField("task", "migration")
 	tlog.Info("Starting database migrations...")
 	config.State.Migration.IsRunning = true
@@ -2435,8 +2435,14 @@ func Migrate() {
 
 	m := gormigrate.New(db, gormigrate.DefaultOptions, wrappedMigrations)
 
-	if err := m.Migrate(); err != nil {
-		tlog.Fatalf("Could not migrate: %v", err)
+	if migrateTo != "" {
+		if err := m.MigrateTo(migrateTo); err != nil {
+			tlog.Fatalf("Could not migrate: %v", err)
+		}
+	} else {
+		if err := m.Migrate(); err != nil {
+			tlog.Fatalf("Could not migrate: %v", err)
+		}
 	}
 	if len(retryMigration) > 0 {
 		for _, migration := range retryMigration {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -56,10 +56,12 @@ func StartServer(version, commit, branch, date string) {
 	// Remove old locks
 	models.RemoveAllLocks()
 
+	migrations.Migrate("0024-drop-actions-old")
+
 	// Run migrations in background
 	go func() {
 		config.State.Migration.IsRunning = true
-		migrations.Migrate()
+		migrations.Migrate("")
 		config.CompleteMigration()
 	}()
 


### PR DESCRIPTION
This changes the running of migrations, to run all schema migrations before starting the UI.  The migrations were changed to 0.4.23 to run in the background, allowing in progress messages to be displayed.  However, this allows UI code to run with no guarantee of the state of the database or if it is even created yet.  This currently can result in a site for BaberoticaVR to be created with a blank key and no guarantee new issues wouldn't arise in the future.

This change will run all migrations up to the first data migration "0024-drop-actions-old", before the UI is started. All schema migrations are meant to be placed before this one.  Schema migrations usually run fairly fast, so delaying the start of the UI should not be a big issue.

Technically, the "0024-drop-actions-old" migration will also run before the UI starts, but it is quick and creates a consistent initial migration point that doesn't need to be updated when new schema migrations are added.