### PR TITLE
Fix scene scraper logic deleting all cuepoints for a scene

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -488,8 +488,9 @@ func SceneCreateUpdateFromExternal(db *gorm.DB, ext ScrapedScene) error {
 		// Parse timestamps JSON array
 		var timestamps []map[string]interface{}
 		if err := json.Unmarshal([]byte(ext.Timestamps), &timestamps); err == nil {
-			// Clear existing cuepoints for this scene
-			db.Where("scene_id = ?", o.ID).Delete(&SceneCuepoint{})
+			// Clear existing cuepoints for this scene where the track is null
+			// 	cuepoints where there is a non-null track have probably come from manual entry in heresphere
+			db.Where("scene_id = ? and track is null", o.ID).Delete(&SceneCuepoint{})
 
 			// Process each timestamp and create cuepoint
 			for _, ts := range timestamps {


### PR DESCRIPTION
The scraper logic to update Cuepoints, deletes all existing cuepoints for a scene, which it should not do.  This causes the lose of Cuepoints manually made by a user, particularly from Heresphere.

It should only delete records where the Track Number is Null.  Updates from Heresphere to Cuepoints are lost if a scene is re-scraped.  To support full Heresphere functionality, these have a track number, where simple used by Deovr and SLR do not.

