### PR TITLE
Fix: Studio_Code matching logic

### DIFF
--- a/pkg/externalreference/stashdb.go
+++ b/pkg/externalreference/stashdb.go
@@ -248,7 +248,7 @@ func matchSceneOnRules(sitename string, config models.StashSiteConfig) {
 			case "studio_code":
 				matchCnt := 0
 				for _, scene := range xbrScenes {
-					if data.Code != "" && strings.Contains(scene.SceneID, data.Code) {
+					if data.Code != "" && strings.HasSuffix(scene.SceneID, "-"+data.Code) {
 						xbvrScene = scene
 						matchCnt += 1
 					}
@@ -296,6 +296,7 @@ func simplystring(str string) string {
 	str = strings.ReplaceAll(str, "'", "")
 	str = strings.ReplaceAll(str, `""`, "")
 	str = strings.ReplaceAll(str, "`", "")
+	str = strings.ReplaceAll(str, "’", "")
 	return strings.ToLower(str)
 }
 


### PR DESCRIPTION
Fixes an issue when matching scenes to stashdb using the studio_code. It use to match where it contains the xbvr code, this could result in 123 matching to 1234