### PR TITLE
Fix HSP not displaying thumbnails from myfiles

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	auth "github.com/abbot/go-http-auth"
@@ -141,6 +142,8 @@ func StartServer(version, commit, branch, date string) {
 	// If the client request has a cache-control header (such as 'no-cache'), pass them
 	// onto the imageproxy so that this can be respected.
 	p.PassRequestHeaders = append(p.PassRequestHeaders, "Cache-Control")
+	u, _ := url.Parse("http://127.0.0.1:" + strconv.Itoa(config.Config.Server.Port))
+	p.DefaultBaseURL = u
 	r.PathPrefix("/img/").Handler(ForceShortCacheHandler(http.StripPrefix("/img", p)))
 	hmp := NewHeatmapThumbnailProxy(p, diskCache(filepath.Join(common.AppDir, "heatmapthumbnailproxy")))
 	r.PathPrefix("/imghm/").Handler(http.StripPrefix("/imghm", hmp))

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -872,6 +872,7 @@ watch:{
       } catch {
         return u
       }
+      return u
     },
     getIndicatorURL (idx) {
       if (this.images[idx] !== undefined) {


### PR DESCRIPTION
If the gallery image is saved in myfiles, it is not served to Hereshpere.  Heresphere will be passed a URL such as http://192.168.1.1:9999/img/700x//myfiles/image.jpg.  This fails as the imageproxy package, by default, expects an absolute Url.

I have changed the imageproxy setup to use a default base Url that points back to XBVR so something http://192.168.1.1:9999/img/700x//myfiles/image.jpg will be treated as http://192.168.1.1:9999/img/700x/http://127.0.0.1:9999/myfiles/image.jpg (or whatever port you have configured)

I have also updated the GetImageUrl in details.vue, some it always returns a url, if the image url did not start with "http", then no url is returned from the functioon