### PR TITLE
fix: VRSpy scraper updates for site changes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,6 @@ type ObjectConfig struct {
 		SceneCardScaleToFit  bool   `default:"true" json:"sceneCardScaleToFit"`
 		ActorCardAspectRatio string `default:"1:1" json:"actorCardAspectRatio"`
 		ActorCardScaleToFit  bool   `default:"true" json:"actorCardScaleToFit"`
-		ShowAllScrapers      bool   `default:"false" json:"showAllScrapers"`
 	} `json:"web"`
 	Advanced struct {
 		ShowInternalSceneId          bool      `default:"false" json:"showInternalSceneId"`

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -2411,6 +2411,14 @@ func Migrate(migrateTo string) {
 				return nil
 			},
 		},
+		{
+			ID: "0087-add-scraper-id-index",
+			Migrate: func(tx *gorm.DB) error {
+				// Add index on scraper_id to improve scene count query performance
+				// This prevents timeout on Scrapers page for users with large databases
+				return tx.Table("scenes").AddIndex("idx_scenes_scraper_id", "scraper_id").Error
+			},
+		},
 	}
 
 	// Wrap migrations to automatically track progress

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -63,7 +63,7 @@ type Scene struct {
 	SceneID         string    `gorm:"index" json:"scene_id" xbvrbackup:"scene_id"`
 	Title           string    `json:"title" sql:"type:varchar(1024);" xbvrbackup:"title"`
 	SceneType       string    `json:"scene_type" xbvrbackup:"scene_type"`
-	ScraperId       string    `json:"scraper_id" xbvrbackup:"scraper_id"`
+	ScraperId       string    `gorm:"index" json:"scraper_id" xbvrbackup:"scraper_id"`
 	Studio          string    `json:"studio" xbvrbackup:"studio"`
 	Site            string    `json:"site" xbvrbackup:"site"`
 	Tags            []Tag     `gorm:"many2many:scene_tags;" json:"tags" xbvrbackup:"tags"`

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -24,7 +24,6 @@ const state = {
     sceneCardScaleToFit: true,
     actorCardAspectRatio: "1:1",
     actorCardScaleToFit: true,
-    showAllScrapers: false,
     updateCheck: true
   }
 }
@@ -58,7 +57,6 @@ const actions = {
         state.web.sceneCardScaleToFit = data.config.web.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.config.web.actorCardAspectRatio
         state.web.actorCardScaleToFit = data.config.web.actorCardScaleToFit
-        state.web.showAllScrapers = data.config.web.showAllScrapers
         state.loading = false
       })
   },
@@ -88,7 +86,6 @@ const actions = {
         state.web.sceneCardScaleToFit = data.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.actorCardAspectRatio
         state.web.actorCardScaleToFit = data.actorCardScaleToFit
-        state.web.showAllScrapers = data.showAllScrapers
         state.loading = false
       })
   }

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -18,8 +18,8 @@
             </div>
           </b-dropdown-item>
         </b-dropdown>
-        <a class="button" :class="[$store.state.optionsWeb.web.showAllScrapers ? 'is-info' : '']" v-on:click="toggleEnabledFilter">
-          {{$store.state.optionsWeb.web.showAllScrapers ? $t('Show all scrapers') : $t('Show enabled only')}}
+        <a class="button" :class="[showAllScrapers ? '' : 'is-info']" v-on:click="toggleEnabledFilter">
+          {{showAllScrapers ? $t('Show enabled only') : $t('Show all scrapers')}}
         </a>
         <a class="button is-primary" v-on:click="taskScrape('_enabled')">{{$t('Run selected scrapers')}}</a>
       </div>
@@ -178,6 +178,7 @@ export default {
       currentScraper: '',
       scraperwarning: '',
       scraperwarning2: '',
+      showAllScrapers: true,
     }
   },
   mounted () {
@@ -393,8 +394,7 @@ export default {
       })
     },
     toggleEnabledFilter() {
-      this.$store.state.optionsWeb.web.showAllScrapers = !this.$store.state.optionsWeb.web.showAllScrapers
-      this.$store.dispatch('optionsWeb/save')
+      this.showAllScrapers = !this.showAllScrapers
     },
     saveAdvancedSettings() {
       this.$store.dispatch('optionsAdvanced/save')
@@ -425,7 +425,7 @@ export default {
       }
 
       // Filter by enabled status if the filter is active
-      if (this.$store.state.optionsWeb.web.showAllScrapers) {
+      if (!this.showAllScrapers) {
         items = items.filter(item => item.is_enabled === true);
       }
 

--- a/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataScrapers.vue
@@ -45,14 +45,16 @@
       <b-table-column field="source" :label="$t('Source')" sortable searchable v-slot="props">
         {{ props.row.source }}
       </b-table-column>
-      <b-table-column field="last_update" :label="$t('Last scrape')" sortable v-slot="props">
+      <b-table-column field="last_update" :label="$t('Last scrape')" sortable v-slot="props" cell-class="no-wrap">
             <span :class="[runningScrapers.includes(props.row.id) ? 'invisible' : '']">
               <span v-if="props.row.last_update !== '0001-01-01T00:00:00Z'">
-                {{formatCompactTime(props.row.last_update)}}</span>
+                {{formatCompactTimeAgo(props.row.last_update)}}</span>
               <span v-else>-</span>
             </span>
-            <span :class="[runningScrapers.includes(props.row.id) ? '' : 'invisible']">
-              <span class="pulsate is-info">{{$t('Scraping now...')}}</span>
+            <span :class="[runningScrapers.includes(props.row.id) ? 'scraping-container' : 'invisible']">
+              <span class="loading-dots">
+                <span>.</span><span>.</span><span>.</span>
+              </span>
             </span>
       </b-table-column>
       <b-table-column field="limit_scraping" :label="$t('Limit Scraping')" v-slot="props" width="60" sortable>
@@ -406,6 +408,25 @@ export default {
       const year = date.getFullYear()
       return `${month}/${day}/${year}`
     },
+    formatCompactTimeAgo(isoString) {
+      const now = new Date()
+      const date = parseISO(isoString)
+      const seconds = Math.floor((now - date) / 1000)
+
+      if (seconds < 60) return 'just now'
+      const minutes = Math.floor(seconds / 60)
+      if (minutes < 60) return `${minutes}min ago`
+      const hours = Math.floor(minutes / 60)
+      if (hours < 24) return `${hours}h ago`
+      const days = Math.floor(hours / 24)
+      if (days < 7) return `${days}d ago`
+      const weeks = Math.floor(days / 7)
+      if (weeks < 4) return `${weeks}w ago`
+      const months = Math.floor(days / 30)
+      if (months < 12) return `${months}mo ago`
+      const years = Math.floor(days / 365)
+      return `${years}y ago`
+    },
     parseISO,
     formatDistanceToNow
   },
@@ -484,21 +505,43 @@ export default {
   .invisible {
     display: none;
   }
-  .pulsate {
-    -webkit-animation: pulsate 0.8s linear;
-    -webkit-animation-iteration-count: infinite;
-    opacity: 0.5;
+
+  .scraping-container {
+    display: inline-block;
+    vertical-align: middle;
   }
 
-  @-webkit-keyframes pulsate {
-    0% {
-      opacity: 0.5;
+  /* Animated ellipsis for scraping indicator */
+  .loading-dots {
+    display: inline-block;
+    font-size: 1.2em;
+    font-weight: bold;
+    color: #3273dc;
+    line-height: 1;
+    vertical-align: middle;
+    position: relative;
+    top: -0.4em;
+  }
+
+  .loading-dots span {
+    animation: blink 1.4s infinite both;
+    display: inline-block;
+  }
+
+  .loading-dots span:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  .loading-dots span:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes blink {
+    0%, 80%, 100% {
+      opacity: 0;
     }
-    50% {
-      opacity: 1.0;
-    }
-    100% {
-      opacity: 0.5;
+    40% {
+      opacity: 1;
     }
   }
 </style>
@@ -511,5 +554,13 @@ export default {
 
   .content table th .icon {
     display: none;
+  }
+
+  .content table td.no-wrap {
+    white-space: nowrap;
+  }
+
+  .content table td {
+    vertical-align: middle;
   }
 </style>


### PR DESCRIPTION
## Summary
- Update gallery image scraping to use direct CDN URLs without resize parameters, with a fallback to fullsize if resized fails
- Adjust pagination for site changes
- Add Auto Limit Scraping support