### PR TITLE
scraper: VRPorn - include AR/passthrough scenes (fixes empty ARPorn results)

### DIFF
--- a/pkg/scrape/vrporn.go
+++ b/pkg/scrape/vrporn.go
@@ -143,7 +143,7 @@ func VRPorn(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan
 			if page < int(pages) && !limitScraping {
 				page++
 				slug := strings.TrimSuffix(strings.ReplaceAll(siteURL, "https://vrporn.com/studio/", ""), "/")
-				url := "https://vrporn.com/proxy/api/content/v1/videos/studio/" + slug + "?page=" + strconv.Itoa(page) + "&limit=32&sort=new"
+				url := "https://vrporn.com/proxy/api/content/v1/videos/studio/" + slug + "?page=" + strconv.Itoa(page) + "&limit=32&sort=new&is-ar=true"
 				WaitBeforeVisit("vrporn.com", apiCollector.Visit, url)
 			}
 		}
@@ -155,7 +155,7 @@ func VRPorn(wg *models.ScrapeWG, updateSite bool, knownScenes []string, out chan
 	} else {
 		slug := strings.TrimSuffix(strings.ReplaceAll(siteURL, "https://vrporn.com/studio/", ""), "/")
 		//url:="https://vrporn.com/proxy/api/content/v1/videos/studio/"+slug+"?page=1&limit=32&sort=new&is-toys=true&is-ar=true"
-		url := "https://vrporn.com/proxy/api/content/v1/videos/studio/" + slug + "?page=" + strconv.Itoa(page) + "&limit=32&sort=new"
+		url := "https://vrporn.com/proxy/api/content/v1/videos/studio/" + slug + "?page=" + strconv.Itoa(page) + "&limit=32&sort=new&is-ar=true"
 		WaitBeforeVisit("vrporn.com", apiCollector.Visit, url)
 	}
 


### PR DESCRIPTION
### Problem

The VRPorn studio-listing API silently excludes AR (passthrough) scenes unless the request carries `&is-ar=true`. Studios whose entire catalog is passthrough — e.g. **ARPorn**, which is hosted on VRPorn — return **zero scenes** as a result. The flag existed in this scraper at one point but only as a commented-out line.

### Fix

Append `&is-ar=true` to the two VRPorn studio-listing requests (the first-page request and the pagination request). The flag returns a **superset**: every scene that came back before still comes back, plus the AR/passthrough scenes that were previously dropped. Verified against the live API.

### Why both lines

The scraper builds the studio URL in two places — the initial fetch and the page-2+ pagination fetch. Patching only one would include AR scenes on page 1 but drop them again from page 2 onward for any studio with more than 32 scenes.

### Scope

This affects all VRPorn-based scrapers, since `VRPorn()` is the shared function. Because the flag returns a strict superset, existing studios are unaffected apart from now also capturing any AR/passthrough scenes they publish.
