### PR TITLE
feat(preview,ui,covers): optimize preview generation, add dark/light …

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,48 @@
+name: build-windows
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Setup MSYS2 GCC
+        uses: msys2/setup-msys2@v2
+        with:
+          path-type: inherit
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build UI
+        run: |
+          cd ui
+          yarn install --ignore-engines
+          yarn build
+
+      - name: Build Windows binary
+        shell: msys2 {0}
+        run: |
+          export CGO_ENABLED=1
+          export CC=/mingw64/bin/gcc
+          go build -tags=json1 -ldflags "-s -w -H windowsgui" -o xbvr.exe ./pkg/tray
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xbvr-windows
+          path: xbvr.exe

--- a/.github/workflows/clear-workflow-history.yml
+++ b/.github/workflows/clear-workflow-history.yml
@@ -1,0 +1,21 @@
+name: Clear Workflow History
+
+on:
+  workflow_dispatch: # Чтобы запускать вручную из вкладки Actions
+  schedule:
+    - cron: '0 0 * * 0' # Каждое воскресенье в полночь
+
+permissions:
+  actions: write
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          retain_days: 0 # 0 — удалить абсолютно всё
+          keep_minimum_runs: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.idea
+.idea/
 .DS_Store
 .vscode/
 

--- a/pkg/api/actors.go
+++ b/pkg/api/actors.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,6 +13,7 @@ import (
 
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
+	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/scrape"
 )
@@ -59,6 +63,9 @@ func (i ActorResource) WebService() *restful.WebService {
 		Writes(models.Actor{}))
 
 	ws.Route(ws.POST("/setimage").To(i.setActorImage).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Actor{}))
+	ws.Route(ws.POST("/setmainimage").To(i.setMainImage).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(models.Actor{}))
 	ws.Route(ws.DELETE("/delimage").To(i.deleteActorImage).
@@ -525,6 +532,157 @@ func (i ActorResource) setActorImage(req *restful.Request, resp *restful.Respons
 
 	aa := models.ActionActor{ActorID: actor.ID, ActionType: "setimage", Source: "edit_actor", ChangedColumn: "image_url", NewValue: actor.ImageUrl}
 	aa.Save()
+	resp.WriteHeaderAndEntity(http.StatusOK, actor)
+}
+
+func (i ActorResource) setMainImage(req *restful.Request, resp *restful.Response) {
+	var r RequestSetActorImage
+	err := req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if r.ActorID == 0 || r.Url == "" {
+		return
+	}
+
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var actor models.Actor
+	err = actor.GetIfExistByPKWithSceneAvg(r.ActorID)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	actorsDir := filepath.Join(common.MyFilesDir, "actors")
+	_ = os.MkdirAll(actorsDir, os.ModePerm)
+
+	// Sanitize actor name for use as filename
+	safeName := strings.ReplaceAll(actor.Name, string(os.PathSeparator), "_")
+	safeName = strings.ReplaceAll(safeName, "/", "_")
+	safeName = strings.ReplaceAll(safeName, "\\", "_")
+
+	// Determine file extension from source
+	ext := ".jpg"
+	ctToExt := map[string]string{
+		"image/webp": ".webp",
+		"image/png":  ".png",
+		"image/gif":  ".gif",
+		"image/jpeg": ".jpg",
+	}
+
+	var srcReader io.ReadCloser
+	if strings.HasPrefix(r.Url, "http://") || strings.HasPrefix(r.Url, "https://") {
+		// Download from external URL with browser-like headers to avoid hotlink blocks
+		client := &http.Client{}
+		httpReq, err := http.NewRequest("GET", r.Url, nil)
+		if err != nil {
+			log.Errorf("setMainImage: failed to build request for %s: %v", r.Url, err)
+			resp.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		httpReq.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
+		httpReq.Header.Set("Accept", "image/avif,image/webp,image/apng,image/*,*/*;q=0.8")
+		// Use the origin of the image URL as Referer (find slash after scheme+host)
+		if schemeEnd := strings.Index(r.Url, "://"); schemeEnd != -1 {
+			if pathStart := strings.Index(r.Url[schemeEnd+3:], "/"); pathStart != -1 {
+				httpReq.Header.Set("Referer", r.Url[:schemeEnd+3+pathStart]+"/")
+			} else {
+				httpReq.Header.Set("Referer", r.Url+"/")
+			}
+		}
+		httpResp, err := client.Do(httpReq)
+		if err != nil {
+			log.Errorf("setMainImage: failed to download %s: %v", r.Url, err)
+			resp.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		ct := httpResp.Header.Get("Content-Type")
+		if strings.Contains(ct, "text/html") {
+			httpResp.Body.Close()
+			log.Errorf("setMainImage: server returned HTML instead of image for %s (hotlink blocked?)", r.Url)
+			resp.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		// Determine extension from Content-Type
+		for mime, e := range ctToExt {
+			if strings.Contains(ct, mime) {
+				ext = e
+				break
+			}
+		}
+		srcReader = httpResp.Body
+	} else if strings.HasPrefix(r.Url, "/myfiles/") {
+		// Serve from local myfiles directory
+		localPath := filepath.Join(common.MyFilesDir, strings.TrimPrefix(r.Url, "/myfiles/"))
+		if e := filepath.Ext(localPath); e != "" {
+			ext = e
+		}
+		f, err := os.Open(localPath)
+		if err != nil {
+			log.Errorf("setMainImage: failed to open local %s: %v", localPath, err)
+			resp.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		srcReader = f
+	} else {
+		// Absolute local file path
+		if e := filepath.Ext(r.Url); e != "" {
+			ext = e
+		}
+		f, err := os.Open(r.Url)
+		if err != nil {
+			log.Errorf("setMainImage: failed to open %s: %v", r.Url, err)
+			resp.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		srcReader = f
+	}
+	defer srcReader.Close()
+
+	destPath := filepath.Join(actorsDir, safeName+ext)
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		log.Errorf("setMainImage: failed to create %s: %v", destPath, err)
+		resp.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer destFile.Close()
+
+	if _, err := io.Copy(destFile, srcReader); err != nil {
+		log.Errorf("setMainImage: failed to write %s: %v", destPath, err)
+		resp.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	localURL := "/myfiles/actors/" + safeName + ext
+
+	// Remove any stale /myfiles/actors/<safeName>.* entries (different extension) from image_arr
+	if actor.ImageArr != "" && actor.ImageArr != "[]" {
+		var arr []string
+		if json.Unmarshal([]byte(actor.ImageArr), &arr) == nil {
+			prefix := "/myfiles/actors/" + safeName + "."
+			filtered := arr[:0]
+			for _, item := range arr {
+				if !strings.HasPrefix(item, prefix) {
+					filtered = append(filtered, item)
+				}
+			}
+			b, _ := json.Marshal(filtered)
+			actor.ImageArr = string(b)
+		}
+	}
+
+	actor.ImageUrl = localURL
+	actor.AddToImageArray(localURL)
+	actor.Save()
+
+	aa := models.ActionActor{ActorID: actor.ID, ActionType: "setmainimage", Source: "edit_actor", ChangedColumn: "image_url", NewValue: localURL}
+	aa.Save()
+
 	resp.WriteHeaderAndEntity(http.StatusOK, actor)
 }
 

--- a/pkg/api/deovr.go
+++ b/pkg/api/deovr.go
@@ -176,6 +176,16 @@ func getProto(req *restful.Request) string {
 	return proto
 }
 
+// deoAbsoluteURL converts a relative URL (e.g. "/myfiles/covers/xxx.jpg")
+// to an absolute one using the host the DeoVR client connected through.
+// Absolute URLs (starting with http) are returned unchanged.
+func deoAbsoluteURL(u string) string {
+	if strings.HasPrefix(u, "/") {
+		return session.DeoRequestHost + u
+	}
+	return u
+}
+
 func setDeoPlayerHost(req *restful.Request) {
 	deoIP := req.Request.RemoteAddr
 	lastColon := strings.LastIndex(deoIP, ":")
@@ -551,7 +561,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 		RatingAvg:        scene.StarRating,
 		FullVideoReady:   true,
 		FullAccess:       true,
-		ThumbnailURL:     scene.CoverURL,
+		ThumbnailURL:     deoAbsoluteURL(scene.CoverURL),
 		StereoMode:       stereoMode,
 		Is3D:             true,
 		ScreenType:       screenType,
@@ -583,7 +593,7 @@ func (i DeoVRResource) getDeoScene(req *restful.Request, resp *restful.Response)
 			RatingAvg:        scene.StarRating,
 			FullVideoReady:   true,
 			FullAccess:       true,
-			ThumbnailURL:     scene.CoverURL,
+			ThumbnailURL:     deoAbsoluteURL(scene.CoverURL),
 			StereoMode:       stereoMode,
 			Is3D:             true,
 			ScreenType:       screenType,
@@ -670,7 +680,7 @@ func scenesToDeoList(req *restful.Request, scenes []models.SceneSummary) []DeoLi
 		item := DeoListItem{
 			Title:        scenes[i].Title,
 			VideoLength:  scenes[i].Duration * 60,
-			ThumbnailURL: scenes[i].CoverURL,
+			ThumbnailURL: deoAbsoluteURL(scenes[i].CoverURL),
 			VideoURL:     fmt.Sprintf("%v/deovr/%v", session.DeoRequestHost, scenes[i].ID),
 		}
 		list = append(list, item)

--- a/pkg/api/files.go
+++ b/pkg/api/files.go
@@ -15,6 +15,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
 	"github.com/markphelps/optional"
+	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
@@ -241,6 +242,10 @@ func (i FilesResource) matchFile(req *restful.Request, resp *restful.Response) {
 	if err == nil {
 		f.SceneID = scene.ID
 		f.Save()
+		if f.HasAlpha {
+			scene.SetAlphaChromaKey()
+			scene.Save()
+		}
 	}
 
 	// Add File to the list of Scene filenames so it will be discovered when file is moved
@@ -261,6 +266,7 @@ func (i FilesResource) matchFile(req *restful.Request, resp *restful.Response) {
 
 	// Finally, update scene available/accessible status
 	scene.UpdateStatus()
+	deleteSceneMedia(scene)
 
 	resp.WriteHeaderAndEntity(http.StatusOK, nil)
 }
@@ -321,6 +327,7 @@ func (i FilesResource) unmatchFile(req *restful.Request, resp *restful.Response)
 
 		// Finally, update scene available/accessible status
 		scene.UpdateStatus()
+		deleteSceneMedia(scene)
 	}
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)
@@ -373,10 +380,38 @@ func removeFileByFileId(fileId uint) models.Scene {
 			if file.SceneID != 0 {
 				scene.GetIfExistByPK(file.SceneID)
 				scene.UpdateStatus()
+				deleteSceneMedia(scene)
 			}
 		}
 	} else {
 		log.Errorf("error deleting file %v", err)
 	}
 	return scene
+}
+
+func deleteSceneMedia(scene models.Scene) {
+	files, err := scene.GetFiles()
+	if err != nil {
+		return
+	}
+	videos := 0
+	for _, f := range files {
+		if f.Type == "video" {
+			videos++
+		}
+	}
+	if videos > 0 {
+		return
+	}
+
+	previewPath := filepath.Join(common.VideoPreviewDir, scene.SceneID+".mp4")
+	if err := os.Remove(previewPath); err == nil {
+		log.Infof("Deleted preview %s", previewPath)
+	}
+	for _, ext := range []string{".jpg", ".jpeg"} {
+		coverPath := filepath.Join(common.MyFilesDir, "covers", scene.SceneID+ext)
+		if err := os.Remove(coverPath); err == nil {
+			log.Infof("Deleted cover %s", coverPath)
+		}
+	}
 }

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -44,6 +44,7 @@ type VersionCheckResponse struct {
 }
 
 type RequestSaveOptionsWeb struct {
+	Theme                string `json:"theme"`
 	TagSort              string `json:"tagSort"`
 	SceneHidden          bool   `json:"sceneHidden"`
 	SceneWatchlist       bool   `json:"sceneWatchlist"`
@@ -52,6 +53,7 @@ type RequestSaveOptionsWeb struct {
 	SceneWatched         bool   `json:"sceneWatched"`
 	SceneEdit            bool   `json:"sceneEdit"`
 	SceneDuration        bool   `json:"sceneDuration"`
+	SceneDate            bool   `json:"sceneDate"`
 	SceneCuepoint        bool   `json:"sceneCuepoint"`
 	ShowHspFile          bool   `json:"showHspFile"`
 	ShowSubtitlesFile    bool   `json:"showSubtitlesFile"`
@@ -59,6 +61,7 @@ type RequestSaveOptionsWeb struct {
 	ShowScriptHeatmap    bool   `json:"showScriptHeatmap"`
 	ShowAllHeatmaps      bool   `json:"showAllHeatmaps"`
 	ShowOpenInNewWindow  bool   `json:"showOpenInNewWindow"`
+	ShowStashdbLink      bool   `json:"showStashdbLink"`
 	UpdateCheck          bool   `json:"updateCheck"`
 	IsAvailOpacity       int    `json:"isAvailOpacity"`
 	SceneCardAspectRatio string `json:"sceneCardAspectRatio"`
@@ -117,11 +120,12 @@ type RequestSaveOptionsDeoVR struct {
 
 type RequestSaveOptionsPreviews struct {
 	Enabled       bool    `json:"enabled"`
-	StartTime     int     `json:"startTime"`
 	SnippetLength float64 `json:"snippetLength"`
 	SnippetAmount int     `json:"snippetAmount"`
 	Resolution    int     `json:"resolution"`
 	ExtraSnippet  bool    `json:"extraSnippet"`
+	UseCUDA       bool    `json:"useCUDA"`
+	Pitch         int     `json:"pitch"`
 }
 
 type GetStateResponse struct {
@@ -317,6 +321,9 @@ func (i ConfigResource) WebService() *restful.WebService {
 	ws.Route(ws.POST("/previews/test").To(i.generateTestPreview).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
+	ws.Route(ws.DELETE("/previews/test").To(i.clearTestPreview).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
 	// "Funscripts" section endpoints
 	ws.Route(ws.GET("/funscripts/count").To(i.getFunscriptsCount).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
@@ -507,6 +514,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 		return
 	}
 
+	config.Config.Web.Theme = r.Theme
 	config.Config.Web.TagSort = r.TagSort
 	config.Config.Web.SceneHidden = r.SceneHidden
 	config.Config.Web.SceneWatchlist = r.SceneWatchlist
@@ -515,6 +523,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.SceneWatched = r.SceneWatched
 	config.Config.Web.SceneEdit = r.SceneEdit
 	config.Config.Web.SceneDuration = r.SceneDuration
+	config.Config.Web.SceneDate = r.SceneDate
 	config.Config.Web.SceneCuepoint = r.SceneCuepoint
 	config.Config.Web.ShowHspFile = r.ShowHspFile
 	config.Config.Web.ShowSubtitlesFile = r.ShowSubtitlesFile
@@ -522,6 +531,7 @@ func (i ConfigResource) saveOptionsWeb(req *restful.Request, resp *restful.Respo
 	config.Config.Web.ShowScriptHeatmap = r.ShowScriptHeatmap
 	config.Config.Web.ShowAllHeatmaps = r.ShowAllHeatmaps
 	config.Config.Web.ShowOpenInNewWindow = r.ShowOpenInNewWindow
+	config.Config.Web.ShowStashdbLink = r.ShowStashdbLink
 	config.Config.Web.UpdateCheck = r.UpdateCheck
 	config.Config.Web.IsAvailOpacity = r.IsAvailOpacity
 	config.Config.Web.SceneCardAspectRatio = r.SceneCardAspectRatio
@@ -891,9 +901,10 @@ func (i ConfigResource) saveOptionsPreviews(req *restful.Request, resp *restful.
 
 	config.Config.Library.Preview.Resolution = r.Resolution
 	config.Config.Library.Preview.SnippetAmount = r.SnippetAmount
-	config.Config.Library.Preview.StartTime = r.StartTime
 	config.Config.Library.Preview.SnippetLength = r.SnippetLength
 	config.Config.Library.Preview.ExtraSnippet = r.ExtraSnippet
+	config.Config.Library.Preview.UseCUDA = r.UseCUDA
+	config.Config.Library.Preview.Pitch = r.Pitch
 	config.SaveConfig()
 
 	resp.WriteHeaderAndEntity(http.StatusOK, r)
@@ -907,10 +918,14 @@ func (i ConfigResource) generateTestPreview(req *restful.Request, resp *restful.
 		return
 	}
 
-	// Get first available scene for test preview
+	// Get an available scene without a video preview if possible,
+	// otherwise fall back to the most recently released scene.
 	var scene models.Scene
 	db, _ := models.GetDB()
-	db.Model(&models.Scene{}).Where("is_available = ?", true).Order("release_date desc").First(&scene)
+	err = db.Model(&models.Scene{}).Where("is_available = ? and has_video_preview = ?", true, false).Order("release_date desc").First(&scene).Error
+	if err != nil {
+		err = db.Model(&models.Scene{}).Where("is_available = ?", true).Order("release_date desc").First(&scene).Error
+	}
 	db.Close()
 
 	files, err := scene.GetFiles()
@@ -919,9 +934,24 @@ func (i ConfigResource) generateTestPreview(req *restful.Request, resp *restful.
 		return
 	}
 
+	// Pick the first existing video file (GetFiles also returns scripts etc.)
+	var videoFile *models.File
+	for idx := range files {
+		if files[idx].Type == "video" && files[idx].Exists() {
+			videoFile = &files[idx]
+			break
+		}
+	}
+	if videoFile == nil {
+		log.Errorf("test preview: no available video file for scene %v", scene.SceneID)
+		common.PublishWS("options.previews.previewError", map[string]interface{}{"message": "no available video file found"})
+		resp.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// Generate hash for given parameters
 	hash := sha1.New()
-	hash.Write([]byte(fmt.Sprintf("test-%v-%v-%v-%v-%v-%v", scene.SceneID, r.StartTime, r.SnippetLength, r.SnippetAmount, r.Resolution, r.ExtraSnippet)))
+	hash.Write([]byte(fmt.Sprintf("test-%v-%v-%v-%v-%v-%v-%v", scene.SceneID, r.SnippetLength, r.SnippetAmount, r.Resolution, r.ExtraSnippet, r.UseCUDA, r.Pitch)))
 
 	previewFn := fmt.Sprintf("test%x", hash.Sum(nil))
 	destFile := filepath.Join(common.VideoPreviewDir, previewFn+".mp4")
@@ -929,16 +959,23 @@ func (i ConfigResource) generateTestPreview(req *restful.Request, resp *restful.
 	if _, err := os.Stat(destFile); os.IsNotExist(err) {
 		// Preview file does not exist, generate it
 		go func() {
-			tasks.RenderPreview(
-				files[0].GetPath(),
+			defer models.ClearStopFlag("previews")
+			err := tasks.RenderPreview(
+				videoFile.GetPath(),
 				destFile,
-				files[0].VideoProjection,
-				r.StartTime,
+				videoFile.VideoProjection,
 				r.SnippetLength,
 				r.SnippetAmount,
 				r.Resolution,
 				r.ExtraSnippet,
+				r.UseCUDA,
+				r.Pitch,
 			)
+			if err != nil {
+				log.Errorf("error generating test preview: %v", err)
+				common.PublishWS("options.previews.previewError", map[string]interface{}{"message": err.Error()})
+				return
+			}
 
 			common.PublishWS("options.previews.previewReady", map[string]interface{}{"previewFn": previewFn})
 		}()
@@ -948,6 +985,17 @@ func (i ConfigResource) generateTestPreview(req *restful.Request, resp *restful.
 	}
 
 	common.PublishWS("options.previews.previewReady", map[string]interface{}{"previewFn": previewFn})
+	resp.WriteHeader(http.StatusOK)
+}
+
+func (i ConfigResource) clearTestPreview(req *restful.Request, resp *restful.Response) {
+	files, _ := filepath.Glob(filepath.Join(common.VideoPreviewDir, "test*.mp4"))
+	for _, f := range files {
+		os.Remove(f)
+	}
+	os.RemoveAll(filepath.Join(common.VideoPreviewDir, "tmp"))
+
+	common.PublishWS("options.previews.previewCleared", nil)
 	resp.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/mozillazg/go-slugify"
 
+	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/models"
 	"github.com/xbapps/xbvr/pkg/tasks"
 )
@@ -142,6 +145,10 @@ func (i SceneResource) WebService() *restful.WebService {
 		Writes(models.Scene{}))
 
 	ws.Route(ws.POST("/selectscript/{scene-id}").To(i.selectScript).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Scene{}))
+
+	ws.Route(ws.POST("/{scene-id}/clear-preview").To(i.clearScenePreview).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Writes(models.Scene{}))
 
@@ -476,6 +483,52 @@ func (i SceneResource) getScene(req *restful.Request, resp *restful.Response) {
 		_ = scene.GetIfExistByPK(uint(id))
 	}
 	db.Close()
+
+	resp.WriteHeaderAndEntity(http.StatusOK, scene)
+}
+
+func (i SceneResource) clearScenePreview(req *restful.Request, resp *restful.Response) {
+	var scene models.Scene
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	sceneID := req.PathParameter("scene-id")
+	if strings.Contains(sceneID, "-") {
+		err := scene.GetIfExist(sceneID)
+		if err != nil {
+			log.Error(err)
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+	} else {
+		id, err := strconv.Atoi(sceneID)
+		if err != nil {
+			log.Error(err)
+			resp.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		err = scene.GetIfExistByPK(uint(id))
+		if err != nil {
+			log.Error(err)
+			resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}
+
+	// Match the user's SQL: UPDATE scenes SET has_video_preview = 0 WHERE scene_id = '<scene_id>'
+	if err := db.Model(&models.Scene{}).Where("scene_id = ?", scene.SceneID).Update("has_video_preview", false).Error; err != nil {
+		log.Error(err)
+		resp.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	scene.HasVideoPreview = false
+
+	previewPath := filepath.Join(common.VideoPreviewDir, scene.SceneID+".mp4")
+	if _, err := os.Stat(previewPath); err == nil {
+		if err := os.Remove(previewPath); err != nil {
+			log.Warnf("failed to delete preview file %s: %v", previewPath, err)
+		}
+	}
 
 	resp.WriteHeaderAndEntity(http.StatusOK, scene)
 }

--- a/pkg/api/tasks.go
+++ b/pkg/api/tasks.go
@@ -81,6 +81,12 @@ func (i TaskResource) WebService() *restful.WebService {
 	ws.Route(ws.GET("/preview/generate").To(i.previewGenerate).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
+	ws.Route(ws.GET("/preview/stop").To(i.previewStop).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
+	ws.Route(ws.GET("/preview/count").To(i.previewCount).
+		Metadata(restfulspec.KeyOpenAPITags, tags))
+
 	ws.Route(ws.GET("/funscript/export-all").To(i.exportAllFunscripts).
 		Metadata(restfulspec.KeyOpenAPITags, tags))
 
@@ -203,6 +209,21 @@ func (i TaskResource) restoreBundle(req *restful.Request, resp *restful.Response
 
 func (i TaskResource) previewGenerate(req *restful.Request, resp *restful.Response) {
 	go tasks.GeneratePreviews(nil)
+}
+
+func (i TaskResource) previewStop(req *restful.Request, resp *restful.Response) {
+	tasks.StopPreviewGeneration()
+	resp.WriteHeader(http.StatusOK)
+}
+
+func (i TaskResource) previewCount(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var left int64
+	db.Model(&models.Scene{}).Where("is_available = ? AND has_video_preview = ?", true, false).Count(&left)
+
+	resp.WriteHeaderAndEntity(http.StatusOK, map[string]int64{"left": left, "total": left})
 }
 
 func (i TaskResource) scrapeJAVR(req *restful.Request, resp *restful.Response) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type ObjectConfig struct {
 		Password string `default:"" json:"password"`
 	} `json:"security"`
 	Web struct {
+		Theme                string `default:"light" json:"theme"`
 		TagSort              string `default:"by-tag-count" json:"tagSort"`
 		SceneHidden          bool   `default:"true" json:"sceneHidden"`
 		SceneWatchlist       bool   `default:"true" json:"sceneWatchlist"`
@@ -38,6 +39,7 @@ type ObjectConfig struct {
 		SceneWatched         bool   `default:"false" json:"sceneWatched"`
 		SceneEdit            bool   `default:"false" json:"sceneEdit"`
 		SceneDuration        bool   `default:"false" json:"sceneDuration"`
+		SceneDate            bool   `default:"true" json:"sceneDate"`
 		SceneCuepoint        bool   `default:"true" json:"sceneCuepoint"`
 		ShowHspFile          bool   `default:"true" json:"showHspFile"`
 		ShowSubtitlesFile    bool   `default:"true" json:"showSubtitlesFile"`
@@ -45,6 +47,7 @@ type ObjectConfig struct {
 		ShowScriptHeatmap    bool   `default:"true" json:"showScriptHeatmap"`
 		ShowAllHeatmaps      bool   `default:"false" json:"showAllHeatmaps"`
 		ShowOpenInNewWindow  bool   `default:"true" json:"showOpenInNewWindow"`
+		ShowStashdbLink      bool   `default:"true" json:"showStashdbLink"`
 		UpdateCheck          bool   `default:"true" json:"updateCheck"`
 		IsAvailOpacity       int    `default:"40" json:"isAvailOpacity"`
 		SceneCardAspectRatio string `default:"1:1" json:"sceneCardAspectRatio"`
@@ -112,11 +115,12 @@ type ObjectConfig struct {
 	Library struct {
 		Preview struct {
 			Enabled       bool    `default:"true" json:"enabled"`
-			StartTime     int     `default:"10" json:"startTime"`
 			SnippetLength float64 `default:"0.4" json:"snippetLength"`
 			SnippetAmount int     `default:"20" json:"snippetAmount"`
 			Resolution    int     `default:"400" json:"resolution"`
 			ExtraSnippet  bool    `default:"false" json:"extraSnippet"`
+			UseCUDA       bool    `default:"true" json:"useCUDA"`
+			Pitch         int     `default:"15" json:"pitch"`
 		} `json:"preview"`
 	} `json:"library"`
 	Cron struct {

--- a/pkg/models/db.go
+++ b/pkg/models/db.go
@@ -141,6 +141,23 @@ func RemoveLock(lock string) {
 	common.PublishWS("lock.change", map[string]interface{}{"name": lock, "locked": false})
 }
 
+func SetStopFlag(lock string) {
+	(&KV{Key: "stop-" + lock, Value: "1"}).Save()
+}
+
+func ClearStopFlag(lock string) {
+	(&KV{Key: "stop-" + lock}).Delete()
+}
+
+func CheckStopFlag(lock string) bool {
+	db, _ := GetDB()
+	defer db.Close()
+
+	var obj KV
+	err := db.Where(&KV{Key: "stop-" + lock}).First(&obj).Error
+	return err == nil
+}
+
 func RemoveAllLocks() {
 	db, _ := GetDB()
 	defer db.Close()

--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -70,6 +70,8 @@ type RequestActorList struct {
 	MaxHeight      optional.Int      `json:"max_height"`
 	MinWeight      optional.Int      `json:"min_weight"`
 	MaxWeight      optional.Int      `json:"max_weight"`
+	MinCupSize     optional.Int      `json:"min_cup_size"`
+	MaxCupSize     optional.Int      `json:"max_cup_size"`
 	MinCount       optional.Int      `json:"min_count"`
 	MaxCount       optional.Int      `json:"max_count"`
 	MinAvail       optional.Int      `json:"min_avail"`
@@ -365,6 +367,12 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 	if r.MaxWeight.OrElse(150) < 150 {
 		tx = tx.Where("actors.weight <= ?", r.MaxWeight.OrElse(150))
 	}
+	if r.MinCupSize.OrElse(0) > 0 {
+		tx = tx.Where("actors.cup_size >= ?", r.MinCupSize.OrElse(0))
+	}
+	if r.MaxCupSize.OrElse(9) < 9 {
+		tx = tx.Where("actors.cup_size <= ?", r.MaxCupSize.OrElse(9))
+	}
 	if r.MinCount.OrElse(0) > 0 {
 		tx = tx.Where("actors.`count` >= ?", r.MinCount.OrElse(0))
 	}
@@ -487,9 +495,9 @@ func QueryActors(r RequestActorList, enablePreload bool) ResponseActorList {
 		txList.Find(&out.Actors)
 		for idx, actor := range out.Actors {
 			if strings.ToLower(actor.Name) >= strings.ToLower(r.JumpTo.OrElse("")) {
+				cnt = idx
 				break
 			}
-			cnt = idx
 		}
 		offset = (cnt / limit) * limit
 	}

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -300,6 +300,25 @@ func (o *Scene) PreviewExists() bool {
 	return true
 }
 
+// SetAlphaChromaKey sets a default alpha passthrough chroma key on the scene
+// if one is not already present with hasAlpha enabled.
+func (o *Scene) SetAlphaChromaKey() {
+	if o.ChromaKey != "" {
+		var ckdata map[string]interface{}
+		if err := json.Unmarshal([]byte(o.ChromaKey), &ckdata); err == nil {
+			if hasAlpha, ok := ckdata["hasAlpha"]; ok {
+				if b, ok := hasAlpha.(bool); ok && b {
+					return
+				}
+				if str, ok := hasAlpha.(string); ok && str == "true" {
+					return
+				}
+			}
+		}
+	}
+	o.ChromaKey = `{"enabled":true,"hasAlpha":true,"h":0,"opacity":0,"s":0,"threshold":0,"v":0}`
+}
+
 func (o *Scene) UpdateStatus() {
 	// Check if file with scene association exists
 	files, err := o.GetFiles()

--- a/pkg/server/myfiles.go
+++ b/pkg/server/myfiles.go
@@ -1,8 +1,7 @@
 package server
 
 import (
-	"fmt"
-	"io"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,23 +13,56 @@ import (
 type MyFilesHandler struct {
 }
 
-func (h MyFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := filepath.Join(common.MyFilesDir, r.URL.Path)
-	fi, err := os.Stat(path)
+// commonMimeTypes is an explicit fallback map. On Windows, mime.TypeByExtension
+// reads from the registry and may return an empty string for common types,
+// which breaks clients (like DeoVR) that require a correct Content-Type.
+var commonMimeTypes = map[string]string{
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png":  "image/png",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".bmp":  "image/bmp",
+	".svg":  "image/svg+xml",
+	".mp4":  "video/mp4",
+	".webm": "video/webm",
+	".json": "application/json",
+}
 
-	if os.IsNotExist(err) || strings.Contains(path, "..") { // check the path exists and not trying to go up directory levels
-		// file does not exist
-		http.Error(w, err.Error(), http.StatusNotFound)
+func (h MyFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "..") { // prevent directory traversal
+		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
 
-	//copy the relevant headers. If you want to preserve the downloaded file name, extract it with go's url parser.
-	if strings.HasSuffix(path, ".json") {
-		w.Header().Set("Content-Type", r.Header.Get("application/json"))
+	path := filepath.Join(common.MyFilesDir, r.URL.Path)
+	f, err := os.Open(path)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
 	}
-	w.Header().Set("Content-Length", fmt.Sprint(fi.Size())) // useful for download progress
+	defer f.Close()
 
-	//stream the body to the client without fully loading it into memory
-	reader, _ := os.Open(path)
-	io.Copy(w, reader)
+	fi, err := f.Stat()
+	if err != nil || fi.IsDir() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	// set Content-Type based on the file extension so clients (browsers, DeoVR)
+	// correctly interpret images, json, etc. mime.TypeByExtension is unreliable
+	// on Windows (reads from the registry), so use an explicit map first.
+	ext := strings.ToLower(filepath.Ext(path))
+	ctype := commonMimeTypes[ext]
+	if ctype == "" {
+		ctype = mime.TypeByExtension(ext)
+	}
+	if ctype != "" {
+		w.Header().Set("Content-Type", ctype)
+	}
+
+	// http.ServeContent handles Range requests, conditional GETs and sets
+	// Accept-Ranges/Last-Modified headers. Strict clients like DeoVR require
+	// these to load thumbnails reliably.
+	http.ServeContent(w, r, fi.Name(), fi.ModTime(), f)
 }

--- a/pkg/tasks/deps.go
+++ b/pkg/tasks/deps.go
@@ -78,7 +78,7 @@ func downloadFfbinaries(tool string) error {
 		return errors.Errorf("Unknown architecture: %v/%v", runtime.GOOS, runtime.GOARCH)
 	}
 
-	resp, err := resty.New().R().Get("https://ffbinaries.com/api/v1/version/4.2.1")
+	resp, err := resty.New().R().Get("https://ffbinaries.com/api/v1/version/latest")
 	if err != nil {
 		return err
 	}

--- a/pkg/tasks/preview.go
+++ b/pkg/tasks/preview.go
@@ -1,23 +1,50 @@
 package tasks
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/darwayne/go-timecode/timecode"
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/config"
 	"github.com/xbapps/xbvr/pkg/ffprobe"
 	"github.com/xbapps/xbvr/pkg/models"
 )
 
+var (
+	previewCmdMu sync.Mutex
+	previewCmd   *exec.Cmd
+)
+
+// StopPreviewGeneration signals the preview loop to stop and kills the current
+// FFmpeg process so the UI can interrupt generation without closing the app.
+func StopPreviewGeneration() {
+	models.SetStopFlag("previews")
+
+	previewCmdMu.Lock()
+	defer previewCmdMu.Unlock()
+	if previewCmd != nil && previewCmd.Process != nil {
+		if err := previewCmd.Process.Kill(); err != nil {
+			log.Warnf("failed to kill ffmpeg process: %v", err)
+		}
+	}
+}
+
 func GeneratePreviews(endTime *time.Time) {
 	if !models.CheckLock("previews") {
+		models.ClearStopFlag("previews")
 		models.CreateLock("previews")
-		defer models.RemoveLock("previews")
+		defer func() {
+			models.RemoveLock("previews")
+			models.ClearStopFlag("previews")
+		}()
 		log.Infof("Generating previews")
 		db, _ := models.GetDB()
 		defer db.Close()
@@ -26,6 +53,10 @@ func GeneratePreviews(endTime *time.Time) {
 		db.Model(&models.Scene{}).Where("is_available = ?", true).Where("has_video_preview = ?", false).Order("release_date desc").Find(&scenes)
 
 		for _, scene := range scenes {
+			if models.CheckStopFlag("previews") {
+				log.Infof("Preview generation stopped by user")
+				return
+			}
 			files, _ := scene.GetFiles()
 			if len(files) > 0 {
 				if endTime != nil && time.Now().After(*endTime) {
@@ -40,11 +71,12 @@ func GeneratePreviews(endTime *time.Time) {
 							files[i].GetPath(),
 							destFile,
 							files[i].VideoProjection,
-							config.Config.Library.Preview.StartTime,
 							config.Config.Library.Preview.SnippetLength,
 							config.Config.Library.Preview.SnippetAmount,
 							config.Config.Library.Preview.Resolution,
 							config.Config.Library.Preview.ExtraSnippet,
+							config.Config.Library.Preview.UseCUDA,
+							config.Config.Library.Preview.Pitch,
 						)
 						if err == nil {
 							scene.HasVideoPreview = true
@@ -62,85 +94,339 @@ func GeneratePreviews(endTime *time.Time) {
 	log.Infof("Previews generated")
 }
 
-func RenderPreview(inputFile string, destFile string, videoProjection string, startTime int, snippetLength float64, snippetAmount int, resolution int, extraSnippet bool) error {
-	tmpPath := filepath.Join(common.VideoPreviewDir, "tmp")
+func RenderPreview(inputFile string, destFile string, videoProjection string, snippetLength float64, snippetAmount int, resolution int, extraSnippet bool, useCUDA bool, pitch int) error {
+	tmpPath := filepath.Join(common.VideoPreviewDir, "tmp", filepath.Base(destFile)+"-"+strconv.FormatInt(time.Now().UnixNano(), 10))
 	os.MkdirAll(tmpPath, os.ModePerm)
 	defer os.RemoveAll(tmpPath)
 
-	// Get video duration
 	ffdata, err := ffprobe.GetProbeData(inputFile, time.Second*10)
 	if err != nil {
 		return err
 	}
-	vs := ffdata.GetFirstVideoStream()
 	dur := ffdata.Format.DurationSeconds
 
-	crop := "iw/2:ih:iw/2:ih" // LR videos
-	if vs.Height == vs.Width {
-		crop = "iw/2:ih/2:iw/4:ih/2" // TB videos
-	}
-	if videoProjection == "flat" {
-		crop = "iw:ih:iw:ih" // LR videos
-	}
-	// Mono 360 crop args: (no way of accurately determining)
-	// "iw/2:ih:iw/4:ih"
-	vfArgs := fmt.Sprintf("crop=%v,scale=%v:%v", crop, resolution, resolution)
+	filenameLower := strings.ToLower(filepath.Base(inputFile))
+	projectionLower := strings.ToLower(videoProjection)
+	isHighBitDepth := isHighBitDepth(ffdata.GetFirstVideoStream())
+	isFlat := projectionLower == "flat"
 
-	// Prepare snippets
-	interval := (dur - float64(startTime)) / float64(snippetAmount)
-	for i := 1; i <= snippetAmount; i++ {
-		start := time.Duration(float64(i)*interval+float64(startTime)) * time.Second
-		snippetFile := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i))
-		args := []string{
-			"-y",
-			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
-			"-i", inputFile,
-			"-vf", vfArgs,
+	// Detect projection sub-type.
+	isTB := strings.Contains(filenameLower, "360_tb") || projectionLower == "360_tb"
+	is180SBS := strings.Contains(filenameLower, "180_sbs") || projectionLower == "180_sbs" ||
+		strings.Contains(filenameLower, "180f") || strings.Contains(projectionLower, "180f") ||
+		strings.Contains(filenameLower, "f180") || strings.Contains(projectionLower, "f180") ||
+		strings.Contains(filenameLower, "vr180") || strings.Contains(projectionLower, "vr180")
+	isFisheye := strings.Contains(filenameLower, "fisheye") || strings.Contains(projectionLower, "fisheye") ||
+		strings.Contains(filenameLower, "mkx") || strings.Contains(projectionLower, "mkx") ||
+		strings.Contains(filenameLower, "rf52") || strings.Contains(projectionLower, "rf52") ||
+		strings.Contains(filenameLower, "vrca220") || strings.Contains(projectionLower, "vrca220")
+
+	idFov := 190
+	if isFisheye {
+		switch {
+		case strings.Contains(filenameLower, "mkx200") || strings.Contains(filenameLower, "fisheye200") ||
+			strings.Contains(projectionLower, "mkx200") || strings.Contains(projectionLower, "fisheye200"):
+			idFov = 200
+		case strings.Contains(filenameLower, "fisheye190") || strings.Contains(projectionLower, "fisheye190"):
+			idFov = 190
+		case strings.Contains(filenameLower, "fisheye180") || strings.Contains(projectionLower, "fisheye180"):
+			idFov = 180
+		case strings.Contains(filenameLower, "vrca220") || strings.Contains(projectionLower, "vrca220"):
+			idFov = 220
+		}
+	}
+
+	// NVENC settings optimized for small preview size.
+	nvencArgs := []string{"-c:v", "h264_nvenc", "-preset", "p4", "-profile:v", "high", "-rc", "vbr", "-cq", "32", "-b:v", "0"}
+
+	// Build the filter graph and hardware acceleration flags according to the
+	// pipeline matrix.
+	var hwaccelArgs []string
+	var vfArgs string
+
+	if isFlat {
+		// Path 1: flat video.
+		vfArgs = fmt.Sprintf("scale=%v:-2", resolution)
+		if useCUDA {
+			hwaccelArgs = []string{"-hwaccel", "cuda"}
+		}
+	} else if useCUDA && !isHighBitDepth && isTB {
+		// Path 2: 360 top-bottom VR with GPU Vulkan pipeline.
+		// v360_vulkan supports equirect input but not hequirect/fisheye, so only TB
+		// uses this path. The filter does not support in_stereo/out_stereo, so we crop
+		// one eye before uploading to Vulkan. To keep the CPU<->GPU transfer small, the
+		// whole frame is first downscaled on the GPU with scale_cuda.
+		hwaccelArgs = []string{"-hwaccel", "cuda", "-init_hw_device", "vulkan=vk:0", "-filter_hw_device", "vk", "-hwaccel_output_format", "cuda"}
+
+		vulkanFilter := fmt.Sprintf("v360_vulkan=input=e:output=flat:pitch=%d:ih_fov=360:iv_fov=180:h_fov=100:v_fov=50", pitch)
+		vfArgs = fmt.Sprintf("scale_cuda=3840:-2,hwdownload,format=nv12,crop=iw:ih/2:0:0,format=yuv444p,hwupload,%v,scale_vulkan=%v:%v,hwdownload,format=yuv444p",
+			vulkanFilter, resolution, resolution/2)
+	} else {
+		// Path 3: 10-bit+ VR with CUDA decode and CPU filters.
+		// Path 4: VR without CUDA (pure CPU).
+		if useCUDA {
+			// Without -noaccurate_seek, NVDEC can now decode 10-bit streams reliably.
+			// GPU decode removes the 20-30 s CPU decode lag on 8K HEVC.
+			hwaccelArgs = []string{"-hwaccel", "cuda"}
+		}
+
+		var dewarpFilter string
+		switch {
+		case isTB:
+			dewarpFilter = fmt.Sprintf("v360=equirect:flat:in_stereo=tb:out_stereo=2d:pitch=-%d:h_fov=100:v_fov=50", pitch)
+		case is180SBS:
+			dewarpFilter = fmt.Sprintf("v360=hequirect:flat:in_stereo=sbs:out_stereo=2d:pitch=-%d:h_fov=100:v_fov=60", pitch)
+		case isFisheye:
+			dewarpFilter = fmt.Sprintf("v360=fisheye:flat:in_stereo=sbs:out_stereo=2d:pitch=-%d:id_fov=%v:h_fov=100:v_fov=60", pitch, idFov)
+		default:
+			dewarpFilter = fmt.Sprintf("v360=hequirect:flat:in_stereo=sbs:out_stereo=2d:pitch=-%d:h_fov=100:v_fov=60", pitch)
+		}
+		if isHighBitDepth {
+			// Downsample the already scaled/dewarped image to 8-bit before handing it
+			// to h264_nvenc, which cannot accept 10-bit input on the high profile.
+			vfArgs = fmt.Sprintf("setpts=PTS-STARTPTS,scale=1600:-2,%v,scale=%v:-2,format=yuv420p", dewarpFilter, resolution)
+		} else {
+			vfArgs = fmt.Sprintf("setpts=PTS-STARTPTS,scale=1600:-2,%v,scale=%v:-2", dewarpFilter, resolution)
+		}
+	}
+
+	// Helper to render a single snippet.
+	// Ищет быстрым поиском, при ошибке пробует точный поиск,
+	// затем чистый CPU, а если файл полностью разбит — создает пустую заглушку.
+	renderSnippet := func(startSeconds float64, snippetFile string) error {
+		// Внутренний хелпер для сборки аргументов
+		buildArgs := func(accurateSeek bool, pureCPU bool) []string {
+			// -nostdin критически важен, чтобы ffmpeg не ждал ввода в фоне
+			args := []string{"-y", "-nostdin", "-threads", "4"}
+
+			if !pureCPU {
+				args = append(args, hwaccelArgs...)
+			}
+
+			if accurateSeek {
+				args = append(args,
+					"-i", inputFile,
+					"-ss", fmt.Sprintf("%.3f", startSeconds),
+				)
+			} else {
+				args = append(args,
+					"-ss", fmt.Sprintf("%.3f", startSeconds),
+					"-noaccurate_seek",
+					"-i", inputFile,
+				)
+			}
+
+			args = append(args, "-vf", vfArgs)
+
+			if useCUDA && !pureCPU {
+				args = append(args, nvencArgs...)
+			} else {
+				args = append(args, "-c:v", "libx264", "-preset", "ultrafast")
+			}
+
+			args = append(args,
+				"-pix_fmt", "yuv420p",
+				"-t", fmt.Sprintf("%v", snippetLength),
+				"-an", snippetFile,
+			)
+			return args
+		}
+
+		// Хелпер для запуска ffmpeg с жестким таймаутом
+		runWithTimeout := func(args []string, timeout time.Duration) error {
+			log.Infof("ffmpeg args: %v", args)
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+
+			// exec.CommandContext kills the process when ctx expires.
+			// Copy SysProcAttr from buildCmd to preserve CREATE_NO_WINDOW on Windows.
+			tmpl := buildCmd(GetBinPath("ffmpeg"), args...)
+			cmd := exec.CommandContext(ctx, GetBinPath("ffmpeg"), args...)
+			cmd.SysProcAttr = tmpl.SysProcAttr
+
+			previewCmdMu.Lock()
+			previewCmd = cmd
+			previewCmdMu.Unlock()
+			defer func() {
+				previewCmdMu.Lock()
+				previewCmd = nil
+				previewCmdMu.Unlock()
+			}()
+
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if ctx.Err() == context.DeadlineExceeded {
+				return fmt.Errorf("ffmpeg hung and was killed by timeout")
+			}
+			if err != nil {
+				log.Errorf("ffmpeg error: %v", err)
+				if stderr.Len() > 0 {
+					log.Errorf("ffmpeg stderr: %s", stderr.String())
+				}
+				return fmt.Errorf("ffmpeg failed: %w (stderr: %s)", err, stderr.String())
+			}
+			return nil
+		}
+
+		// Попытка 1: Fast Seek + GPU (Самый быстрый вариант)
+		if err := runWithTimeout(buildArgs(false, false), 10*time.Second); err == nil {
+			return nil
+		}
+		log.Warnf("[Preview] Fast seek failed or hung at %.3f, retrying with Accurate Seek + GPU...", startSeconds)
+
+		// Попытка 2: Accurate Seek + GPU (Точный поиск, если уплыли ключевые кадры)
+		if err := runWithTimeout(buildArgs(true, false), 10*time.Second); err == nil {
+			return nil
+		}
+		log.Warnf("[Preview] Accurate Seek + GPU failed or hung at %.3f, retrying on pure CPU...", startSeconds)
+
+		// Попытка 3: Accurate Seek + Pure CPU (обычно спасает, если завис драйвер GPU)
+		if err := runWithTimeout(buildArgs(true, true), 10*time.Second); err == nil {
+			return nil
+		}
+
+		// Попытка 4: Финальный щит (генерация заглушки)
+		log.Errorf("[Preview] Critical corruption/hang at %.3f. Generating black frame placeholder.", startSeconds)
+
+		dummyArgs := []string{
+			"-y", "-nostdin", "-f", "lavfi",
+			"-i", fmt.Sprintf("color=c=black:s=600x400:d=%v:r=60", snippetLength),
 			"-pix_fmt", "yuv420p",
-			"-t", fmt.Sprintf("%v", snippetLength),
-			"-an", snippetFile,
+			snippetFile,
 		}
-		cmd := buildCmd(GetBinPath("ffmpeg"), args...)
-		err := cmd.Run()
-		if err != nil {
-			return err
+
+		// Для лавфи ставим короткий таймаут в 3 секунды, там зависать нечему
+		if dummyErr := runWithTimeout(dummyArgs, 3*time.Second); dummyErr != nil {
+			return fmt.Errorf("failed to render snippet and failed to create fallback placeholder: %v", dummyErr)
 		}
+
+		return nil
 	}
 
-	// Ensure ending is always in preview
+	// Prepare snippets in parallel with a max concurrency of 4.
+	type snippetJob struct {
+		index    int
+		startSec float64
+		filePath string
+	}
+
+	// New timestamp grid: safe window from 60.0s to (dur - 20.0 - 1.2).
+	startTime := 60.0
+	availableDuration := dur - startTime - 20.0 - 1.2
+	if availableDuration < 0 {
+		availableDuration = 0
+	}
+	step := availableDuration / float64(snippetAmount)
+
+	jobs := make([]snippetJob, 0, snippetAmount+1)
+	for i := 1; i <= snippetAmount; i++ {
+		startSeconds := startTime + float64(i-1)*step
+		if startSeconds < 0 {
+			startSeconds = 0
+		}
+		if startSeconds > dur-snippetLength {
+			startSeconds = dur - snippetLength
+		}
+		if startSeconds < 0 {
+			startSeconds = 0
+		}
+		jobs = append(jobs, snippetJob{
+			index:    i,
+			startSec: startSeconds,
+			filePath: filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i)),
+		})
+	}
+
+	// Ensure ending is always in preview.
 	if extraSnippet && dur/float64(snippetAmount) > float64(150) {
-		snippetAmount = snippetAmount + 1
-
-		start := time.Duration(dur-float64(150)) * time.Second
-		snippetFile := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", snippetAmount))
-		args := []string{
-			"-y",
-			"-ss", strings.TrimSuffix(timecode.New(start, timecode.IdentityRate).String(), ":00"),
-			"-i", inputFile,
-			"-vf", vfArgs,
-			"-t", fmt.Sprintf("%v", snippetLength),
-			"-an", snippetFile,
+		snippetAmount++
+		startSeconds := dur - 150.0
+		if startSeconds+snippetLength > dur {
+			startSeconds = dur - snippetLength
 		}
+		if startSeconds < 0 {
+			startSeconds = 0
+		}
+		jobs = append(jobs, snippetJob{
+			index:    snippetAmount,
+			startSec: startSeconds,
+			filePath: filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", snippetAmount)),
+		})
+	}
 
-		cmd := buildCmd(GetBinPath("ffmpeg"), args...)
-		err := cmd.Run()
-		if err != nil {
+	var wg sync.WaitGroup
+	semaphore := make(chan struct{}, 2)
+	var errMu sync.Mutex
+	jobErrors := make(map[int]error)
+
+	for _, job := range jobs {
+		wg.Add(1)
+		go func(job snippetJob) {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			if err := renderSnippet(job.startSec, job.filePath); err != nil {
+				errMu.Lock()
+				jobErrors[job.index] = err
+				errMu.Unlock()
+				log.Errorf("snippet %v render failed: %v", job.index, err)
+				return
+			}
+
+			snippetSize := int64(0)
+			if fi, statErr := os.Stat(job.filePath); statErr == nil {
+				snippetSize = fi.Size()
+			}
+			if snippetSize < 1000 {
+				err := fmt.Errorf("snippet %v is missing or too small (path=%v, size=%v)", job.index, job.filePath, snippetSize)
+				errMu.Lock()
+				jobErrors[job.index] = err
+				errMu.Unlock()
+				log.Errorf("%v", err)
+				return
+			}
+		}(job)
+	}
+
+	wg.Wait()
+
+	for _, job := range jobs {
+		if err := jobErrors[job.index]; err != nil {
 			return err
 		}
 	}
 
-	// Prepare concat file
+	// Prepare concat file.
 	concatFile := filepath.Join(tmpPath, "concat.txt")
 	f, err := os.Create(concatFile)
 	if err != nil {
 		return err
 	}
 	for i := 1; i <= snippetAmount; i++ {
-		f.WriteString(fmt.Sprintf("file '%v.mp4'\n", i))
+		snippetPath := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i))
+		if _, err := os.Stat(snippetPath); os.IsNotExist(err) {
+			f.Close()
+			return fmt.Errorf("snippet %v does not exist: %w", i, err)
+		}
+		f.WriteString(fmt.Sprintf("file '%v'\n", filepath.ToSlash(snippetPath)))
 	}
 	f.Close()
 
-	// Save result
+	// Log concat input for debugging.
+	concatData, _ := os.ReadFile(concatFile)
+	log.Infof("concat input: %s", string(concatData))
+	for i := 1; i <= snippetAmount; i++ {
+		snippetPath := filepath.Join(tmpPath, fmt.Sprintf("%v.mp4", i))
+		if fi, err := os.Stat(snippetPath); err == nil {
+			log.Infof("snippet %v size: %v bytes", i, fi.Size())
+		} else {
+			log.Warnf("snippet %v stat error: %v", i, err)
+		}
+	}
+
+	// Save result.
 	args := []string{
 		"-y",
 		"-f", "concat",
@@ -149,11 +435,40 @@ func RenderPreview(inputFile string, destFile string, videoProjection string, st
 		"-c", "copy",
 		filepath.ToSlash(destFile),
 	}
-	cmd := buildCmd(GetBinPath("ffmpeg"), args...)
-	err = cmd.Run()
-	if err != nil {
-		return err
-	}
+	return runFFmpeg(args)
+}
 
+func isHighBitDepth(vs *ffprobe.Stream) bool {
+	if vs == nil {
+		return false
+	}
+	return strings.Contains(vs.PixFmt, "10le") || strings.Contains(vs.PixFmt, "10be") ||
+		strings.Contains(vs.PixFmt, "12le") || strings.Contains(vs.PixFmt, "12be") ||
+		strings.Contains(vs.PixFmt, "16le") || strings.Contains(vs.PixFmt, "16be")
+}
+
+func runFFmpeg(args []string) error {
+	log.Infof("ffmpeg args: %v", args)
+	cmd := buildCmd(GetBinPath("ffmpeg"), args...)
+
+	previewCmdMu.Lock()
+	previewCmd = cmd
+	previewCmdMu.Unlock()
+	defer func() {
+		previewCmdMu.Lock()
+		previewCmd = nil
+		previewCmdMu.Unlock()
+	}()
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		log.Errorf("ffmpeg error: %v", err)
+		if stderr.Len() > 0 {
+			log.Errorf("ffmpeg stderr: %s", stderr.String())
+		}
+		return fmt.Errorf("ffmpeg failed: %w (stderr: %s)", err, stderr.String())
+	}
 	return nil
 }

--- a/pkg/tasks/task_utils_windows.go
+++ b/pkg/tasks/task_utils_windows.go
@@ -10,6 +10,8 @@ import (
 
 func buildCmd(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: 0x08000000 | 0x00004000, // CREATE_NO_WINDOW | BELOW_NORMAL_PRIORITY_CLASS
+	}
 	return cmd
 }

--- a/pkg/tasks/volume.go
+++ b/pkg/tasks/volume.go
@@ -117,7 +117,12 @@ func RescanVolumes(id int) {
 			if len(scenes) == 1 {
 				files[i].SceneID = scenes[0].ID
 				files[i].Save()
+				if files[i].HasAlpha {
+					scenes[0].SetAlphaChromaKey()
+					scenes[0].Save()
+				}
 				scenes[0].UpdateStatus()
+				downloadSceneCover(&scenes[0], db, tlog)
 			} else {
 				if config.Config.Storage.MatchOhash && config.Config.Advanced.StashApiKey != "" {
 					hash := files[i].OsHash
@@ -154,9 +159,14 @@ func RescanVolumes(id int) {
 								tmp, _ := json.Marshal(pfTxt)
 								scene.FilenamesArr = string(tmp)
 								scene.Save()
+								if files[i].HasAlpha {
+									scene.SetAlphaChromaKey()
+									scene.Save()
+								}
 								models.AddAction(scene.SceneID, "match", "filenames_arr", scene.FilenamesArr)
 
 								scene.UpdateStatus()
+								downloadSceneCover(&scene, db, tlog)
 								log.Infof("File %s matched to Scene %s matched using stashdb hash %s", path.Base(files[i].Filename), scene.SceneID, hash)
 							}
 						}
@@ -533,4 +543,50 @@ func ScanLocalSubtitlesFile(path string, volID uint, sceneId uint) {
 		fl.SceneID = sceneId
 	}
 	fl.Save()
+}
+
+// downloadSceneCover reads the scene's Images JSON, finds the first "cover"
+// entry, downloads the image to myfiles/covers/<scene_id>.jpg, and updates
+// cover_url in the database so the UI serves the local copy.
+func downloadSceneCover(scene *models.Scene, db *gorm.DB, tlog *logrus.Entry) {
+	if scene.Images == "" {
+		return
+	}
+
+	var images []models.Image
+	if err := json.Unmarshal([]byte(scene.Images), &images); err != nil {
+		tlog.Warnf("Cannot parse images JSON for scene %s: %v", scene.SceneID, err)
+		return
+	}
+
+	// Find the first cover image URL
+	var coverURL string
+	for _, img := range images {
+		if img.Type == "cover" && img.URL != "" {
+			coverURL = img.URL
+			break
+		}
+	}
+	if coverURL == "" {
+		return
+	}
+
+	// Skip if cover is already a local file
+	if strings.HasPrefix(scene.CoverURL, "/myfiles/") {
+		return
+	}
+
+	coversDir := filepath.Join(common.MyFilesDir, "covers")
+	_ = os.MkdirAll(coversDir, os.ModePerm)
+
+	destPath := filepath.Join(coversDir, scene.SceneID+".jpg")
+
+	if err := downloadFile(coverURL, destPath); err != nil {
+		tlog.Warnf("Failed to download cover for scene %s from %s: %v", scene.SceneID, coverURL, err)
+		return
+	}
+
+	scene.CoverURL = "/myfiles/covers/" + scene.SceneID + ".jpg"
+	db.Model(scene).Update("cover_url", scene.CoverURL)
+	tlog.Infof("Downloaded cover for scene %s", scene.SceneID)
 }

--- a/ui/public/dark-theme.css
+++ b/ui/public/dark-theme.css
@@ -1,0 +1,979 @@
+* {
+	scrollbar-color: #474747 transparent;
+	scrollbar-width: thin;
+}
+
+body {
+	font-weight: 500 !important;
+	line-height: 1.3 !important;
+	color: #b5b5b5;
+	font-size: 1em;
+}
+
+html {
+	background-color: #1b1b1b !important;
+	font-family: -apple-system, BlinkMacSystemFont, ui-sans-serif, InterVariable, system-ui, sans-serif;
+	font-size: 16px;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+	min-width: 300px;
+	overflow-x: hidden;
+	overflow-y: scroll;
+	text-rendering: optimizeLegibility;
+	-webkit-text-size-adjust: 100%;
+	-moz-text-size-adjust: 100%;
+	-ms-text-size-adjust: 100%;
+	text-size-adjust: 100%;
+}
+
+a:link,
+a:visited,
+a:hover,
+a:active {
+	text-decoration: none !important;
+	color: #b5b5b5 !important;
+}
+
+.column.is-2 .card .card-image .bbox {
+	width: 167px;
+	height: 100px;
+}
+.column.is-one-fifth .card .card-image .bbox {
+	width: 207px;
+	height: 130px;
+}
+.column.is-one-quarter .card .card-image .bbox {
+	width: 264px;
+	height: 158px;
+}
+.column.is-one-third .card .card-image .bbox {
+	width: 360px;
+	height: 216px;
+}
+.actor-scenes .column.is-2 {
+	flex: 0 0 25%;
+	width: 25%;
+}
+.actor-scenes .column.is-2 .card .card-image .bbox {
+	width: 100% !important;
+	height: auto !important;
+	position: relative;
+}
+.actor-scenes .column.is-2 .card .card-image .bbox:after {
+	display: none;
+}
+
+.b-table .table-wrapper.has-mobile-cards tr:not([class*=is-]) {
+	background: transparent;
+}
+.b-table .table-wrapper.has-mobile-cards tr:not([class*=is-]):hover {
+	background-color: transparent;
+}
+.b-table .table-wrapper.has-mobile-cards tr:not(.detail):not(.is-empty):not(.table-footer) td {
+	border-bottom: 1px solid #232323;
+}
+.progress-wrapper.is-not-native::-moz-progress-bar,
+.progress::-moz-progress-bar {
+	background-color: #167df0;
+}
+.content table th:not([align]) {
+	text-align: inherit;
+	border-color: #5b5b5b;
+	font-weight: 700;
+	color: #ffffff;
+	background-color: #1b1b1b;
+}
+.control.pagination-input .input {
+	background-color: #cfcfcf;
+	color: #000;
+	font-size: unset;
+}
+.control {
+	font-size: unset;
+}
+.button,
+.file-cta,
+.file-name,
+.input,
+.pagination-ellipsis,
+.pagination-link,
+.pagination-next,
+.pagination-previous,
+.select select,
+.taginput .taginput-container.is-focusable,
+.textarea {
+	font-size: unset;
+}
+.pagination-list {
+	flex-wrap: inherit;
+}
+.tag:not(body).is-warning {
+	background-color: #505050;
+	color: #fff;
+}
+.tag:not(body).is-primary {
+	background-color: #505050;
+	color: #fff;
+}
+.tag:not(body).is-info.is-light {
+	background-color: #393939;
+	color: #b5b5b5;
+}
+.button.is-success {
+	background-color: #0c42aa;
+	border-color: transparent;
+	color: #fff;
+}
+.button.is-info.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #b5b5b5;
+}
+.button.is-info.is-light.is-hovered,
+.button.is-info.is-light:hover {
+	background-color: #ededed;
+	color: #000000;
+}
+.button.is-info.is-light.is-hovered,
+.button.is-info.is-light:hover {
+	background-color: #e6e6e6;
+	border-color: transparent;
+	color: #000;
+}
+.tag:not(body).is-info {
+	background-color: #3b3b3b;
+	color: #fff;
+	z-index: 5;
+}
+
+.button.is-danger {
+	background-color: #1b1b1b;
+	border-color: transparent;
+	color: #b5b5b5;
+}
+.button.is-danger.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #f14668;
+}
+.button.is-danger.is-outlined.is-hovered {
+	color: black;
+}
+.button.is-primary.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #b5b5b5;
+}
+.button.is-primary.is-outlined:hover {
+	background-color: #5b5b5b;
+	border-color: transparent;
+}
+.button.is-dark.is-outlined {
+	background-color: transparent;
+	border-color: transparent !important;
+	color: #b5b5b5;
+}
+
+.button {
+	background-color: #1b1b1b;
+	border-color: transparent;
+	border-width: 1px;
+	color: #b5b5b5;
+	cursor: pointer;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	padding-bottom: calc(.5em - 1px);
+	padding-left: 1em;
+	padding-right: 1em;
+	padding-top: calc(.5em - 1px);
+	text-align: center;
+	white-space: nowrap;
+}
+.button.is-hovered,
+.button:hover {
+	border-color: #b5b5b5;
+	color: #b5b5b5;
+	background: #393939;
+}
+.checkbox:hover,
+.radio:hover {
+	color: #b5b5b5;
+}
+.tag:not(body) {
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	background-color: #393939;
+	border-radius: 4px;
+	color: #ffffff;
+	display: -webkit-inline-box;
+	display: -ms-inline-flexbox;
+	display: inline-flex;
+	font-size: .75rem;
+	height: 2em;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	line-height: 1.5;
+	padding-left: .75em;
+	padding-right: .75em;
+	white-space: nowrap;
+}
+.input,
+.select select,
+.taginput .taginput-container.is-focusable,
+.textarea {
+	background-color: #232323;
+	border-color: #393939;
+	border-radius: 4px;
+	color: #b5b5b5;
+}
+.label {
+	color: #b5b5b5;
+	display: block;
+	font-size: 1rem;
+	font-weight: 600;
+}
+.field.is-floating-label .label:before {
+	content: "";
+	display: block;
+	position: absolute;
+	top: .775em;
+	left: 0;
+	right: 0;
+	height: .375em;
+	background-color: #393939;
+	z-index: -1;
+}
+.select:not(.is-multiple):not(.is-loading):after {
+	border-color: #b5b5b5;
+	right: 1.125em;
+	z-index: 4;
+}
+.pagination-link,
+.pagination-next,
+.pagination-previous {
+	border-color: #808080;
+	color: #b5b5b5;
+	min-width: 2.5em;
+}
+.pagination-link:hover,
+.pagination-next:hover,
+.pagination-previous:hover {
+	border-color: #b5b5b5;
+	color: #b5b5b5;
+	background-color: #393939;
+}
+.is-divider,
+.is-divider-vertical {
+	display: block;
+	position: relative;
+	border-top: .1rem solid #a8a8a8;
+	height: .1rem;
+	margin: 2rem 0;
+	text-align: center;
+}
+.is-divider:after {
+	background-color: #1b1b1b;
+}
+.is-divider-vertical[data-content]:after,
+.is-divider[data-content]:after {
+	background: #1b1b1b;
+	color: #b5b5b5;
+	content: attr(data-content);
+	display: inline-block;
+	font-size: .75rem;
+	padding: .4rem .4rem;
+	-webkit-transform: translateY(-1.1rem);
+	transform: translateY(-1.1rem);
+	text-align: center;
+}
+.navbar.is-light {
+	background-color: #232323;
+}
+.select fieldset[disabled] select,
+.select select[disabled],
+.taginput [disabled].taginput-container.is-focusable,
+.taginput fieldset[disabled] .taginput-container.is-focusable,
+[disabled].input,
+[disabled].textarea,
+fieldset[disabled] .input,
+fieldset[disabled] .select select,
+fieldset[disabled] .taginput .taginput-container.is-focusable,
+fieldset[disabled] .textarea {
+	background-color: #212121;
+	border-color: #212121;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+	color: #7a7a7a;
+}
+.navbar.is-light .navbar-burger {
+	color: #5b5b5b;
+}
+.navbar.is-light .navbar-end .navbar-link,
+.navbar.is-light .navbar-end > .navbar-item,
+.navbar.is-light .navbar-start .navbar-link,
+.navbar.is-light .navbar-start > .navbar-item {
+	color: #b5b5b5;
+}
+.navbar.is-light .navbar-end .navbar-link.is-active,
+.navbar.is-light .navbar-end .navbar-link:focus,
+.navbar.is-light .navbar-end .navbar-link:hover,
+.navbar.is-light .navbar-end > a.navbar-item.is-active,
+.navbar.is-light .navbar-end > a.navbar-item:focus,
+.navbar.is-light .navbar-end > a.navbar-item:hover,
+.navbar.is-light .navbar-start .navbar-link.is-active,
+.navbar.is-light .navbar-start .navbar-link:focus,
+.navbar.is-light .navbar-start .navbar-link:hover,
+.navbar.is-light .navbar-start > a.navbar-item.is-active,
+.navbar.is-light .navbar-start > a.navbar-item:focus,
+.navbar.is-light .navbar-start > a.navbar-item:hover {
+	background-color: #393939;
+	color: #b5b5b5;
+}
+.navbar.is-light .navbar-end .navbar-link,
+.navbar.is-light .navbar-end > .navbar-item,
+.navbar.is-light .navbar-start .navbar-link,
+.navbar.is-light .navbar-start > .navbar-item {
+	color: #b5b5b5;
+}
+.content table tfoot td,
+.content table tfoot th {
+	color: #5b5b5b;
+}
+.bbox {
+	background-color: #1b1b1b !important;
+	cursor: pointer !important;
+}
+.dropdown-content {
+	background-color: #393939;
+}
+.modal-card .timepicker .dropdown-content .control .select select {
+	font-weight: 600;
+	padding-right: calc(.75em - 1px);
+	border-width: 1px;
+}
+.modal-card .is-divider[data-content]:after {
+	background: #212121;
+}
+.modal-card-body {
+	-webkit-overflow-scrolling: touch;
+	background-color: #212121;
+	-webkit-box-flex: 1;
+	-ms-flex-positive: 1;
+	flex-grow: 1;
+	-ms-flex-negative: 1;
+	flex-shrink: 1;
+	overflow: auto;
+	padding: 20px;
+}
+.modal-background {
+	background-color: hsla(0, 0%, 4%, .86) !important;
+}
+.modal-card-foot,
+.modal-card-head {
+	background-color: #121212;
+}
+.modal-card-title {
+	color: #b5b5b5;
+}
+.modal-card-head {
+	border-bottom: 1px solid #7873734a;
+}
+.modal-card-foot {
+	border-top: 1px solid #7873734a;
+}
+.tabs a {
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	border-bottom-color: #b5b5b5;
+	border-bottom-style: solid;
+	border-bottom-width: 1px;
+	color: #b5b5b5;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	margin-bottom: -1px;
+	padding: .5em 1em;
+	vertical-align: top;
+}
+.tabs a:hover {
+	border-bottom-color: #b5b5b5;
+	color: #b5b5b5;
+}
+.message-body {
+	border-color: #5b5b5b;
+	border-radius: 4px;
+	border-style: solid;
+	border-width: 0 0 0 4px;
+	color: #b5b5b5;
+	padding: 1.25em 1.5em;
+}
+.message {
+	background-color: #121212;
+	border-radius: 4px;
+	font-size: 1rem;
+}
+strong {
+	color: #b5b5b5;
+	font-weight: 700;
+}
+.videosize {
+	color: #fff !important;
+	font-weight: 550;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+	color: #b5b5b5;
+	font-weight: 600;
+	line-height: 1.125;
+}
+h1.title::before {
+	content: "XB";
+	color: #b5b5b5;
+	position: absolute;
+}
+h1.title {
+	color: #ff5800;
+	font-weight: 600;
+}
+table th {
+	color: #b5b5b5;
+}
+.title {
+	color: #b5b5b5;
+	font-size: 2rem;
+	font-weight: 600;
+	line-height: 1.125;
+}
+.navbar-brand h1 small {
+	font-size: .4em;
+	margin-left: 0.2em;
+	opacity: .8;
+	color: #b5b5b5;
+	margin-bottom: 4px;
+}
+.table {
+	background-color: transparent;
+	color: #b5b5b5;
+}
+.tabs ul {
+	border-bottom-color: #b5b5b5;
+	background-color: #393939;
+}
+.tabs.is-boxed a:hover {
+	background-color: #393939;
+	border-bottom-color: #b5b5b5;
+}
+.b-tabs .tabs.is-boxed li a:focus {
+	background-color: #393939;
+	border-bottom-color: #b5b5b5;
+}
+.tabs.is-boxed a:focus {
+	background-color: #393939;
+	border-bottom-color: #b5b5b5;
+}
+.tabs.is-boxed li.is-active a {
+	background-color: #b5b5b5;
+	border-color: transparent;
+}
+.tabs li.is-active a {
+	border-bottom-color: #b5b5b5;
+	color: #b5b5b5;
+}
+code,
+hr {
+	background-color: #7873734a;
+}
+.card {
+	background-color: #1b1b1b;
+	border-radius: .25rem;
+	-webkit-box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 4%, .1), 0 0 0 1px hsla(0, 0%, 4%, .02);
+	box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 4%, .1), 0 0 0 1px hsla(0, 0%, 4%, .02);
+	color: #b5b5b5;
+	max-width: 100%;
+	position: relative;
+}
+.modal-card .card {
+	background-color: transparent;
+}
+.menu-list a {
+	color: #a2a2a2;
+}
+.b-table .table th.is-sortable:hover {
+	border-color: #b5b5b5;
+	background-color: #393939;
+}
+.b-table .table th.is-sortable {
+	border-color: #5b5b5b;
+	color: #ffffff;
+	background-color: #1b1b1b;
+}
+.b-table .table th.is-current-sort {
+	border-color: #b5b5b5;
+	font-weight: 700;
+	color: #ffffff;
+	background-color: #1b1b1b;
+}
+.b-table .table-wrapper.has-sticky-header {
+	height: 300px;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+.datepicker .datepicker-table .datepicker-body .datepicker-cell.is-selectable {
+	color: #b5b5b5;
+}
+.datepicker .dropdown-content {
+	background-color: #393939;
+	border-radius: 4px;
+	-webkit-box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 4%, .1), 0 0 0 1px hsla(0, 0%, 4%, .02);
+	box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 4%, .1), 0 0 0 1px hsla(0, 0%, 4%, .02);
+}
+.dropdown .dropdown-menu .has-link a,
+a.dropdown-item,
+button.dropdown-item {
+	padding-right: 3rem;
+	text-align: inherit;
+	white-space: nowrap;
+	width: 100%;
+	color: #b5b5b5;
+}
+.dropdown .dropdown-menu .has-link a:hover,
+a.dropdown-item:hover,
+button.dropdown-item:hover {
+	background-color: #808080;
+	color: #000000;
+}
+.button[disabled],
+fieldset[disabled] .button {
+	background-color: #808080;
+	border-color: #808080;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+	opacity: .5;
+	color: #c6c6c6;
+}
+.button.is-light {
+	background-color: #393939;
+	border-color: #393939;
+	color: rgb(241 241 241);
+}
+.button.is-light.is-hovered,
+.button.is-light:hover {
+	background-color: #b5b5b5;
+	border-color: transparent;
+	color: rgba(0, 0, 0, .7);
+}
+.select select option {
+	color: #b5b5b5;
+	padding: calc(.5em - 1px) calc(.75em - 1px);
+}
+.input:active,
+.input:focus,
+.is-active.input,
+.is-active.textarea,
+.is-focused.input,
+.is-focused.textarea,
+.select select.is-active,
+.select select.is-focused,
+.select select:active,
+.select select:focus,
+.taginput .is-active.taginput-container.is-focusable,
+.taginput .is-focused.taginput-container.is-focusable,
+.taginput .taginput-container.is-focusable:active,
+.taginput .taginput-container.is-focusable:focus,
+.textarea:active,
+.textarea:focus {
+	border-color: #4a4a4a;
+	-webkit-box-shadow: 0 0 0 .125em rgba(111, 111, 111, .25);
+	box-shadow: 0 0 0 .125em rgba(111, 111, 111, .25);
+}
+.button.is-dark.is-outlined {
+	background-color: transparent;
+	border-color: #5b5b5b;
+	color: #b5b5b5;
+}
+.button.is-dark.is-active,
+.button.is-dark:active {
+	background-color: #5b5b5b;
+	border-color: #5b5b5b;
+	color: #fff;
+}
+.button.is-dark.is-outlined.is-focused,
+.button.is-dark.is-outlined.is-hovered,
+.button.is-dark.is-outlined:focus,
+.button.is-dark.is-outlined:hover {
+	background-color: #5b5b5b;
+	border-color: #5b5b5b;
+	color: #fff;
+}
+.button.is-primary {
+	background-color: #3b3b3b;
+	border-color: transparent;
+}
+.button.is-primary.is-hovered,
+.button.is-primary:hover {
+	background-color: #3b3b3b;
+	border-color: transparent;
+	color: #b5b5b5;
+}
+.button.is-focused,
+.button:focus {
+	border-color: #dbdbdb;
+	color: #b5b5b5;
+}
+.button.is-primary.is-focused:not(:active),
+.button.is-primary:focus:not(:active) {
+	-webkit-box-shadow: 0 0 0 .125em rgba(121, 87, 213, .25);
+	box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+}
+.button.is-focused:not(:active),
+.button:focus:not(:active) {
+	-webkit-box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+	box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+}
+.button.is-primary.is-active,
+.button.is-primary:active {
+	background-color: #808080;
+	color: #b5b5b5;
+}
+.select:not(.is-multiple):not(.is-loading):hover:after {
+	border-color: #b5b5b5;
+}
+.select:not(.is-multiple):not(.is-loading):after {
+	border-color: #808080;
+	right: 1.125em;
+	z-index: 4;
+}
+.menu {
+	font-size: 1rem;
+	padding-top: 0.2em;
+}
+.menu-list a {
+	border-radius: 2px;
+	color: #b5b5b5;
+	display: block;
+	padding: .5em .75em;
+	background-color: #1b1b1b;
+}
+.menu-list a:hover {
+	background-color: #393939;
+	color: #b5b5b5
+}
+.menu-list a.is-active {
+	background-color: #b5b5b5;
+	color: #fff
+}
+.menu-list li ul {
+	border-left: 1px solid #b5b5b5;
+	margin: .75em;
+	padding-left: .75em
+}
+.menu-label {
+	color: #b5b5b5;
+	font-size: .75em;
+	letter-spacing: .1em;
+	text-transform: uppercase;
+	font-weight: 600
+}
+.select select:not([multiple]) {
+	padding-right: 2.5em;
+}
+.table td,
+.table th {
+	border-color: #232323;
+}
+.content table thead td,
+.content table thead th {
+	color: #b5b5b5;
+}
+.content table td,
+.content table th {
+	border-color: #232323;
+}
+.table thead td,
+.table thead th {
+	border-width: 0 0 2px;
+	color: #b5b5b5;
+}
+.navbar-brand,
+.navbar-tabs {
+	-webkit-box-align: stretch;
+	-ms-flex-align: stretch;
+	align-items: stretch;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-negative: 0;
+	flex-shrink: 0;
+	min-height: 3.25rem;
+	/*background: linear-gradient(90deg, #b5b5b5, transparent 90%);*/
+}
+.navbar-menu {
+	background-color: #232323;
+	-webkit-box-shadow: 0 8px 16px hsla(0, 0%, 4%, .1);
+	box-shadow: 0 8px 16px hsla(0, 0%, 4%, .1);
+	padding: .5rem 0;
+}
+.navbar.is-light .navbar-burger {
+	color: #b5b5b5;
+}
+.navbar.is-light .navbar-brand .navbar-link.is-active,
+.navbar.is-light .navbar-brand .navbar-link:focus,
+.navbar.is-light .navbar-brand .navbar-link:hover,
+.navbar.is-light .navbar-brand > a.navbar-item.is-active,
+.navbar.is-light .navbar-brand > a.navbar-item:focus,
+.navbar.is-light .navbar-brand > a.navbar-item:hover {
+	background-color: transparent;
+}
+.b-table .table-wrapper.has-sticky-header tr:first-child th {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	background: #212121;
+}
+.b-tooltip.is-primary .tooltip-content {
+	background: #515151;
+	color: #fff;
+}
+.loading-overlay .loading-background {
+	background: none !important;
+}
+.video-js .vjs-big-play-button {
+	font-size: 3em;
+	line-height: 2.8em;
+	height: 3em;
+	width: 3em;
+	border-radius: 99px;
+}
+.img {
+	background-color: black;
+}
+.carousel-arrow .icon {
+	color: #fff;
+	border-radius: 9999px;
+}
+.carousel-arrow .icon {
+	position: absolute;
+	background-color: rgba(43, 51, 63, .6);
+	-webkit-transition: all .4s;
+	transition: all .4s;
+	opacity: 0.5;
+}
+.carousel-arrow .icon.has-icons-left {
+	left: 0.2rem;
+	height: 2em;
+	width: 2em;
+}
+.carousel-arrow .icon.has-icons-right {
+	right: 0.2rem;
+	height: 2em;
+	width: 2em;
+}
+.prev {
+	left: 0;
+	border-radius: 3px 0 0 3px;
+	background-color: #3b3b3b;
+}
+.next {
+	right: 0;
+	border-radius: 3px 0 0 3px;
+	background-color: #3b3b3b;
+}
+.prev[data-v-449617a4] {
+	left: 8px;
+}
+.next[data-v-449617a4] {
+	right: 8px;
+}
+.is-large.delete,
+.is-large.modal-close {
+	min-height: 50px;
+	min-width: 50px;
+}
+.is-large.modal-close:hover {
+	color: black;
+	background-color: #ff5800;
+}
+.modal-close {
+	position: fixed;
+	right: 5px;
+	top: 20px;
+	background-color: #3b3b3b;
+}
+#scrollButtons[data-v-50899169] {
+	display: none;
+}
+.menu-list a.is-active {
+	font-weight: 600;
+	background-color: #3b3b3b;
+	color: white;
+}
+.tabs.is-boxed li.is-active a {
+	background-color: #3b3b3b;
+	border-color: transparent;
+	border-bottom-color: transparent;
+}
+.b-tabs .tabs.is-boxed li a:focus {
+	background-color: #3b3b3b;
+	border-bottom-color: #302e2e;
+}
+.pagination-link.is-current {
+	background-color: #ba4f17;
+	border-color: #ba4f17;
+}
+#toTop[data-v-50899169],
+#toggleInfiniteScroll[data-v-50899169] {
+	display: none;
+	background-color: #393939;
+	color: #4a4a4a;
+	padding: 15px;
+	border-radius: 10px;
+	font-size: 18px;
+	margin-right: 8px;
+}
+.button.is-link,
+.button.is-info,
+.button.is-warning,
+.file.is-primary .file-cta {
+	background-color: #3b3b3b;
+	border-color: transparent;
+	color: #fff;
+}
+.file.is-primary .file-cta:hover {
+	background-color: #515151
+}
+.button.is-link:hover,
+.button.is-warning:hover,
+.dropdown .dropdown-menu .has-link a.is-active,
+a.dropdown-item.is-active,
+button.dropdown-item.is-active {
+	background-color: #515151;
+	color: #fff;
+}
+.button.is-link[disabled],
+.button.is-primary[disabled],
+fieldset[disabled] .button.is-link {
+	background-color: #3b3b3b;
+	border-color: transparent;
+}
+
+.field-body .field .field {
+	background-color: transparent;
+}
+
+.label.switch.is-rounded:hover {
+	background: #ff5800;
+}
+.b-tooltip.is-danger .tooltip-content {
+	background: #ba4f17;
+	color: #fff;
+}
+.b-checkbox.checkbox:hover input[type="checkbox"]:not(:disabled) + .check {
+	border-color: #515151;
+}
+.b-checkbox.checkbox input[type="checkbox"]:checked + .check {
+	background: #ba4f17 url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Cpath style='fill:%23fff' d='M.04.627.146.52.43.804.323.91zm.177.177L.854.167.96.273.323.91z'/%3E%3C/svg%3E") no-repeat 50%;
+	border-color: #ba4f17;
+}
+.b-radio.radio input[type="radio"]:checked + .check,
+.b-radio.radio input[type="radio"]:checked + .check:hover,
+.b-radio.radio input[type="radio"]:checked + .check::before {
+	border-color: #ba4f17;
+}
+.b-radio.radio input[type="radio"] + .check::before {
+	background-color: #ba4f17;
+}
+.b-radio.radio:hover input[type="radio"]:not(:disabled) + .check {
+	border-color: #ff5800;
+}
+.switch input[type="checkbox"]:checked + .check.is-dark,
+.switch input[type="checkbox"]:checked + .check.is-info,
+.input[type="checkbox"]:checked + .check.is-dark,
+.switch input[type="checkbox"]:checked + .check {
+	background: #ba4f17;
+}
+.switch input[type="checkbox"]:checked + .check.is-info:hover,
+.switch input[type="checkbox"]:checked + .check:hover {
+	background: #ff5800;
+}
+.b-slider .b-slider-track {
+	background: #515151;
+}
+.b-slider.is-link .b-slider-fill,
+.b-slider.is-primary .b-slider-fill {
+	background: #ba4f17 !important;
+}
+.tabs li.is-active a {
+	border-bottom-color: #ba4f17 !important;
+	font-weight: 600;
+	color: #ba4f17;
+}
+.b-tabs .tabs li a:focus {
+	border-bottom-color: #ba4f17;
+}
+.loading-overlay .loading-icon::after {
+	-webkit-animation: spinAround .5s linear infinite;
+	animation: spinAround .5s linear infinite;
+	border: 2px solid #ff5800;
+	border-radius: 9999px;
+	border-right-color: transparent;
+	border-top-color: transparent;
+	content: "";
+	display: block;
+	position: absolute;
+	top: calc(50% - 1.5em);
+	left: calc(50% - 1.5em);
+	width: 3em;
+	height: 3em;
+	border-width: .25em;
+}
+
+.modal-card {
+	width: 94% !important;
+	height: 94% !important;
+}
+
+.modal-warning .modal-card {
+	height: auto !important;
+	max-height: 40vh !important;
+}
+
+.dialog .modal-card {
+	height: fit-content !important;
+}
+
+.scene_title {
+	font-size: 13px;
+}
+
+.column {
+	padding: .9rem;
+}
+
+.tag:not(body) {
+	font-size: .6rem;
+}
+
+.columns {
+	margin-top: 0 !important;
+}
+
+.b-tabs .tab-content {
+	padding: 0;
+}
+
+.content.is-small {
+	padding-top: 1.5em;
+}
+
+.thumbnail[data-v-449617a4] {
+	height: 170px;
+	padding-bottom: 0.2em;
+}

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>XBVR</title>
+    <script>
+      (function() {
+        var t = localStorage.getItem('xbvr-theme') || 'light';
+        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.classList.add('xbvr-theme-' + t);
+        var l = document.createElement('link');
+        l.rel = 'stylesheet';
+        l.id = 'xbvr-theme-css';
+        l.href = '<%= BASE_URL %>' + t + '-theme.css';
+        document.head.appendChild(l);
+      })();
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/ui/public/light-theme.css
+++ b/ui/public/light-theme.css
@@ -1,0 +1,979 @@
+* {
+	scrollbar-color: #b8b8b8 transparent;
+	scrollbar-width: thin;
+}
+
+body {
+	font-weight: 500 !important;
+	line-height: 1.3 !important;
+	color: #000000;
+	font-size: 1em;
+}
+
+html {
+	background-color: #f4f4f5 !important;
+	font-family: -apple-system, BlinkMacSystemFont, ui-sans-serif, InterVariable, system-ui, sans-serif;
+	font-size: 16px;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+	min-width: 300px;
+	overflow-x: hidden;
+	overflow-y: scroll;
+	text-rendering: optimizeLegibility;
+	-webkit-text-size-adjust: 100%;
+	-moz-text-size-adjust: 100%;
+	-ms-text-size-adjust: 100%;
+	text-size-adjust: 100%;
+}
+
+a:link,
+a:visited,
+a:hover,
+a:active {
+	text-decoration: none !important;
+	color: #000000 !important;
+}
+
+.column.is-2 .card .card-image .bbox {
+	width: 167px;
+	height: 100px;
+}
+.column.is-one-fifth .card .card-image .bbox {
+	width: 207px;
+	height: 130px;
+}
+.column.is-one-quarter .card .card-image .bbox {
+	width: 264px;
+	height: 158px;
+}
+.column.is-one-third .card .card-image .bbox {
+	width: 360px;
+	height: 216px;
+}
+.actor-scenes .column.is-2 {
+	flex: 0 0 25%;
+	width: 25%;
+}
+.actor-scenes .column.is-2 .card .card-image .bbox {
+	width: 100% !important;
+	height: auto !important;
+	position: relative;
+}
+.actor-scenes .column.is-2 .card .card-image .bbox:after {
+	display: none;
+}
+
+.b-table .table-wrapper.has-mobile-cards tr:not([class*=is-]) {
+	background: transparent;
+}
+.b-table .table-wrapper.has-mobile-cards tr:not([class*=is-]):hover {
+	background-color: transparent;
+}
+.b-table .table-wrapper.has-mobile-cards tr:not(.detail):not(.is-empty):not(.table-footer) td {
+	border-bottom: 1px solid #ededed;
+}
+.progress-wrapper.is-not-native::-moz-progress-bar,
+.progress::-moz-progress-bar {
+	background-color: #167df0;
+}
+.content table th:not([align]) {
+	text-align: inherit;
+	border-color: #585858;
+	font-weight: 700;
+	color: #000000;
+	background-color: #f4f4f5;
+}
+.control.pagination-input .input {
+	background-color: #303030;
+	color: #000;
+	font-size: unset;
+}
+.control {
+	font-size: unset;
+}
+.button,
+.file-cta,
+.file-name,
+.input,
+.pagination-ellipsis,
+.pagination-link,
+.pagination-next,
+.pagination-previous,
+.select select,
+.taginput .taginput-container.is-focusable,
+.textarea {
+	font-size: unset;
+}
+.pagination-list {
+	flex-wrap: inherit;
+}
+.tag:not(body).is-warning {
+	background-color: #aeaeae;
+	color: #000;
+}
+.tag:not(body).is-primary {
+	background-color: #aeaeae;
+	color: #000;
+}
+.tag:not(body).is-info.is-light {
+	background-color: #d4d4d5;
+	color: #000000;
+}
+.button.is-success {
+	background-color: #0c42aa;
+	border-color: transparent;
+	color: #000;
+}
+.button.is-info.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #000000;
+}
+.button.is-info.is-light.is-hovered,
+.button.is-info.is-light:hover {
+	background-color: #393939;
+	color: #000000;
+}
+.button.is-info.is-light.is-hovered,
+.button.is-info.is-light:hover {
+	background-color: #1a1a1a;
+	border-color: transparent;
+	color: #000;
+}
+.tag:not(body).is-info {
+	background-color: #d0d0d1;
+	color: #000;
+	z-index: 5;
+}
+
+.button.is-danger {
+	background-color: #f4f4f5;
+	border-color: transparent;
+	color: #000000;
+}
+.button.is-danger.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #f14668;
+}
+.button.is-danger.is-outlined.is-hovered {
+	color: white;
+}
+.button.is-primary.is-outlined {
+	background-color: transparent;
+	border-color: transparent;
+	color: #000000;
+}
+.button.is-primary.is-outlined:hover {
+	background-color: #585858;
+	border-color: transparent;
+}
+.button.is-dark.is-outlined {
+	background-color: transparent;
+	border-color: transparent !important;
+	color: #000000;
+}
+
+.button {
+	background-color: #f4f4f5;
+	border-color: transparent;
+	border-width: 1px;
+	color: #000000;
+	cursor: pointer;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	padding-bottom: calc(.5em - 1px);
+	padding-left: 1em;
+	padding-right: 1em;
+	padding-top: calc(.5em - 1px);
+	text-align: center;
+	white-space: nowrap;
+}
+.button.is-hovered,
+.button:hover {
+	border-color: #000000;
+	color: #000000;
+	background: #d4d4d5;
+}
+.checkbox:hover,
+.radio:hover {
+	color: #000000;
+}
+.tag:not(body) {
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	background-color: #d4d4d5;
+	border-radius: 4px;
+	color: #000000;
+	display: -webkit-inline-box;
+	display: -ms-inline-flexbox;
+	display: inline-flex;
+	font-size: .75rem;
+	height: 2em;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	line-height: 1.5;
+	padding-left: .75em;
+	padding-right: .75em;
+	white-space: nowrap;
+}
+.input,
+.select select,
+.taginput .taginput-container.is-focusable,
+.textarea {
+	background-color: #ededed;
+	border-color: #d4d4d5;
+	border-radius: 4px;
+	color: #000000;
+}
+.label {
+	color: #000000;
+	display: block;
+	font-size: 1rem;
+	font-weight: 600;
+}
+.field.is-floating-label .label:before {
+	content: "";
+	display: block;
+	position: absolute;
+	top: .775em;
+	left: 0;
+	right: 0;
+	height: .375em;
+	background-color: #d4d4d5;
+	z-index: -1;
+}
+.select:not(.is-multiple):not(.is-loading):after {
+	border-color: #000000;
+	right: 1.125em;
+	z-index: 4;
+}
+.pagination-link,
+.pagination-next,
+.pagination-previous {
+	border-color: #b0b0b0;
+	color: #000000;
+	min-width: 2.5em;
+}
+.pagination-link:hover,
+.pagination-next:hover,
+.pagination-previous:hover {
+	border-color: #000000;
+	color: #000000;
+	background-color: #d4d4d5;
+}
+.is-divider,
+.is-divider-vertical {
+	display: block;
+	position: relative;
+	border-top: .1rem solid #585858;
+	height: .1rem;
+	margin: 2rem 0;
+	text-align: center;
+}
+.is-divider:after {
+	background-color: #f4f4f5;
+}
+.is-divider-vertical[data-content]:after,
+.is-divider[data-content]:after {
+	background: #f4f4f5;
+	color: #000000;
+	content: attr(data-content);
+	display: inline-block;
+	font-size: .75rem;
+	padding: .4rem .4rem;
+	-webkit-transform: translateY(-1.1rem);
+	transform: translateY(-1.1rem);
+	text-align: center;
+}
+.navbar.is-light {
+	background-color: #ededed;
+}
+.select fieldset[disabled] select,
+.select select[disabled],
+.taginput [disabled].taginput-container.is-focusable,
+.taginput fieldset[disabled] .taginput-container.is-focusable,
+[disabled].input,
+[disabled].textarea,
+fieldset[disabled] .input,
+fieldset[disabled] .select select,
+fieldset[disabled] .taginput .taginput-container.is-focusable,
+fieldset[disabled] .textarea {
+	background-color: #ededed;
+	border-color: #ededed;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+	color: #858585;
+}
+.navbar.is-light .navbar-burger {
+	color: #585858;
+}
+.navbar.is-light .navbar-end .navbar-link,
+.navbar.is-light .navbar-end > .navbar-item,
+.navbar.is-light .navbar-start .navbar-link,
+.navbar.is-light .navbar-start > .navbar-item {
+	color: #000000;
+}
+.navbar.is-light .navbar-end .navbar-link.is-active,
+.navbar.is-light .navbar-end .navbar-link:focus,
+.navbar.is-light .navbar-end .navbar-link:hover,
+.navbar.is-light .navbar-end > a.navbar-item.is-active,
+.navbar.is-light .navbar-end > a.navbar-item:focus,
+.navbar.is-light .navbar-end > a.navbar-item:hover,
+.navbar.is-light .navbar-start .navbar-link.is-active,
+.navbar.is-light .navbar-start .navbar-link:focus,
+.navbar.is-light .navbar-start .navbar-link:hover,
+.navbar.is-light .navbar-start > a.navbar-item.is-active,
+.navbar.is-light .navbar-start > a.navbar-item:focus,
+.navbar.is-light .navbar-start > a.navbar-item:hover {
+	background-color: #d4d4d5;
+	color: #000000;
+}
+.navbar.is-light .navbar-end .navbar-link,
+.navbar.is-light .navbar-end > .navbar-item,
+.navbar.is-light .navbar-start .navbar-link,
+.navbar.is-light .navbar-start > .navbar-item {
+	color: #000000;
+}
+.content table tfoot td,
+.content table tfoot th {
+	color: #585858;
+}
+.bbox {
+	background-color: #f4f4f5 !important;
+	cursor: pointer !important;
+}
+.dropdown-content {
+	background-color: #d4d4d5;
+}
+.modal-card .timepicker .dropdown-content .control .select select {
+	font-weight: 600;
+	padding-right: calc(.75em - 1px);
+	border-width: 1px;
+}
+.modal-card .is-divider[data-content]:after {
+	background: #ededed;
+}
+.modal-card-body {
+	-webkit-overflow-scrolling: touch;
+	background-color: #ededed;
+	-webkit-box-flex: 1;
+	-ms-flex-positive: 1;
+	flex-grow: 1;
+	-ms-flex-negative: 1;
+	flex-shrink: 1;
+	overflow: auto;
+	padding: 20px;
+}
+.modal-background {
+	background-color: hsla(0, 0%, 96%, .86) !important;
+}
+.modal-card-foot,
+.modal-card-head {
+	background-color: #f0f0f0;
+}
+.modal-card-title {
+	color: #000000;
+}
+.modal-card-head {
+	border-bottom: 1px solid #c8c8c94a;
+}
+.modal-card-foot {
+	border-top: 1px solid #c8c8c94a;
+}
+.tabs a {
+	-webkit-box-align: center;
+	-ms-flex-align: center;
+	align-items: center;
+	border-bottom-color: #000000;
+	border-bottom-style: solid;
+	border-bottom-width: 1px;
+	color: #000000;
+	-webkit-box-pack: center;
+	-ms-flex-pack: center;
+	justify-content: center;
+	margin-bottom: -1px;
+	padding: .5em 1em;
+	vertical-align: top;
+}
+.tabs a:hover {
+	border-bottom-color: #000000;
+	color: #000000;
+}
+.message-body {
+	border-color: #585858;
+	border-radius: 4px;
+	border-style: solid;
+	border-width: 0 0 0 4px;
+	color: #000000;
+	padding: 1.25em 1.5em;
+}
+.message {
+	background-color: #f0f0f0;
+	border-radius: 4px;
+	font-size: 1rem;
+}
+strong {
+	color: #000000;
+	font-weight: 700;
+}
+.videosize {
+	color: #000 !important;
+	font-weight: 550;
+}
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+	color: #000000;
+	font-weight: 600;
+	line-height: 1.125;
+}
+h1.title::before {
+	content: "XB";
+	color: #000000;
+	position: absolute;
+}
+h1.title {
+	color: #ff5800;
+	font-weight: 600;
+}
+table th {
+	color: #000000;
+}
+.title {
+	color: #000000;
+	font-size: 2rem;
+	font-weight: 600;
+	line-height: 1.125;
+}
+.navbar-brand h1 small {
+	font-size: .4em;
+	margin-left: 0.2em;
+	opacity: .8;
+	color: #000000;
+	margin-bottom: 4px;
+}
+.table {
+	background-color: transparent;
+	color: #000000;
+}
+.tabs ul {
+	border-bottom-color: #000000;
+	background-color: #d4d4d5;
+}
+.tabs.is-boxed a:hover {
+	background-color: #d4d4d5;
+	border-bottom-color: #000000;
+}
+.b-tabs .tabs.is-boxed li a:focus {
+	background-color: #d4d4d5;
+	border-bottom-color: #000000;
+}
+.tabs.is-boxed a:focus {
+	background-color: #d4d4d5;
+	border-bottom-color: #000000;
+}
+.tabs.is-boxed li.is-active a {
+	background-color: #000000;
+	border-color: transparent;
+}
+.tabs li.is-active a {
+	border-bottom-color: #000000;
+	color: #000000;
+}
+code,
+hr {
+	background-color: #c8c8c94a;
+}
+.card {
+	background-color: #f4f4f5;
+	border-radius: .25rem;
+	-webkit-box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 96%, .1), 0 0 0 1px hsla(0, 0%, 96%, .02);
+	box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 96%, .1), 0 0 0 1px hsla(0, 0%, 96%, .02);
+	color: #000000;
+	max-width: 100%;
+	position: relative;
+}
+.modal-card .card {
+	background-color: transparent;
+}
+.menu-list a {
+	color: #5d5d5d;
+}
+.b-table .table th.is-sortable:hover {
+	border-color: #000000;
+	background-color: #d4d4d5;
+}
+.b-table .table th.is-sortable {
+	border-color: #585858;
+	color: #000000;
+	background-color: #f4f4f5;
+}
+.b-table .table th.is-current-sort {
+	border-color: #000000;
+	font-weight: 700;
+	color: #000000;
+	background-color: #f4f4f5;
+}
+.b-table .table-wrapper.has-sticky-header {
+	height: 300px;
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+.datepicker .datepicker-table .datepicker-body .datepicker-cell.is-selectable {
+	color: #000000;
+}
+.datepicker .dropdown-content {
+	background-color: #d4d4d5;
+	border-radius: 4px;
+	-webkit-box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 96%, .1), 0 0 0 1px hsla(0, 0%, 96%, .02);
+	box-shadow: 0 .5em 1em -.125em hsla(0, 0%, 96%, .1), 0 0 0 1px hsla(0, 0%, 96%, .02);
+}
+.dropdown .dropdown-menu .has-link a,
+a.dropdown-item,
+button.dropdown-item {
+	padding-right: 3rem;
+	text-align: inherit;
+	white-space: nowrap;
+	width: 100%;
+	color: #000000;
+}
+.dropdown .dropdown-menu .has-link a:hover,
+a.dropdown-item:hover,
+button.dropdown-item:hover {
+	background-color: #b0b0b0;
+	color: #000000;
+}
+.button[disabled],
+fieldset[disabled] .button {
+	background-color: #b0b0b0;
+	border-color: #b0b0b0;
+	-webkit-box-shadow: none;
+	box-shadow: none;
+	opacity: .5;
+	color: #393939;
+}
+.button.is-light {
+	background-color: #d4d4d5;
+	border-color: #d4d4d5;
+	color: rgb(14 14 14);
+}
+.button.is-light.is-hovered,
+.button.is-light:hover {
+	background-color: #000000;
+	border-color: transparent;
+	color: rgba(255, 255, 255, .7);
+}
+.select select option {
+	color: #000000;
+	padding: calc(.5em - 1px) calc(.75em - 1px);
+}
+.input:active,
+.input:focus,
+.is-active.input,
+.is-active.textarea,
+.is-focused.input,
+.is-focused.textarea,
+.select select.is-active,
+.select select.is-focused,
+.select select:active,
+.select select:focus,
+.taginput .is-active.taginput-container.is-focusable,
+.taginput .is-focused.taginput-container.is-focusable,
+.taginput .taginput-container.is-focusable:active,
+.taginput .taginput-container.is-focusable:focus,
+.textarea:active,
+.textarea:focus {
+	border-color: #c4c4c5;
+	-webkit-box-shadow: 0 0 0 .125em rgba(111, 111, 111, .25);
+	box-shadow: 0 0 0 .125em rgba(111, 111, 111, .25);
+}
+.button.is-dark.is-outlined {
+	background-color: transparent;
+	border-color: #585858;
+	color: #000000;
+}
+.button.is-dark.is-active,
+.button.is-dark:active {
+	background-color: #585858;
+	border-color: #585858;
+	color: #000;
+}
+.button.is-dark.is-outlined.is-focused,
+.button.is-dark.is-outlined.is-hovered,
+.button.is-dark.is-outlined:focus,
+.button.is-dark.is-outlined:hover {
+	background-color: #585858;
+	border-color: #585858;
+	color: #000;
+}
+.button.is-primary {
+	background-color: #d0d0d1;
+	border-color: transparent;
+}
+.button.is-primary.is-hovered,
+.button.is-primary:hover {
+	background-color: #d0d0d1;
+	border-color: transparent;
+	color: #000000;
+}
+.button.is-focused,
+.button:focus {
+	border-color: #242424;
+	color: #000000;
+}
+.button.is-primary.is-focused:not(:active),
+.button.is-primary:focus:not(:active) {
+	-webkit-box-shadow: 0 0 0 .125em rgba(121, 87, 213, .25);
+	box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+}
+.button.is-focused:not(:active),
+.button:focus:not(:active) {
+	-webkit-box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+	box-shadow: 0 0 0 0.125em rgb(111, 111, 111, 25%);
+}
+.button.is-primary.is-active,
+.button.is-primary:active {
+	background-color: #b0b0b0;
+	color: #000000;
+}
+.select:not(.is-multiple):not(.is-loading):hover:after {
+	border-color: #000000;
+}
+.select:not(.is-multiple):not(.is-loading):after {
+	border-color: #b0b0b0;
+	right: 1.125em;
+	z-index: 4;
+}
+.menu {
+	font-size: 1rem;
+	padding-top: 0.2em;
+}
+.menu-list a {
+	border-radius: 2px;
+	color: #000000;
+	display: block;
+	padding: .5em .75em;
+	background-color: #f4f4f5;
+}
+.menu-list a:hover {
+	background-color: #d4d4d5;
+	color: #000000
+}
+.menu-list a.is-active {
+	background-color: #000000;
+	color: #fff
+}
+.menu-list li ul {
+	border-left: 1px solid #000000;
+	margin: .75em;
+	padding-left: .75em
+}
+.menu-label {
+	color: #000000;
+	font-size: .75em;
+	letter-spacing: .1em;
+	text-transform: uppercase;
+	font-weight: 600
+}
+.select select:not([multiple]) {
+	padding-right: 2.5em;
+}
+.table td,
+.table th {
+	border-color: #ededed;
+}
+.content table thead td,
+.content table thead th {
+	color: #000000;
+}
+.content table td,
+.content table th {
+	border-color: #ededed;
+}
+.table thead td,
+.table thead th {
+	border-width: 0 0 2px;
+	color: #000000;
+}
+.navbar-brand,
+.navbar-tabs {
+	-webkit-box-align: stretch;
+	-ms-flex-align: stretch;
+	align-items: stretch;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-ms-flex-negative: 0;
+	flex-shrink: 0;
+	min-height: 3.25rem;
+	/*background: linear-gradient(90deg, #000000, transparent 90%);*/
+}
+.navbar-menu {
+	background-color: #ededed;
+	-webkit-box-shadow: 0 8px 16px hsla(0, 0%, 96%, .1);
+	box-shadow: 0 8px 16px hsla(0, 0%, 96%, .1);
+	padding: .5rem 0;
+}
+.navbar.is-light .navbar-burger {
+	color: #000000;
+}
+.navbar.is-light .navbar-brand .navbar-link.is-active,
+.navbar.is-light .navbar-brand .navbar-link:focus,
+.navbar.is-light .navbar-brand .navbar-link:hover,
+.navbar.is-light .navbar-brand > a.navbar-item.is-active,
+.navbar.is-light .navbar-brand > a.navbar-item:focus,
+.navbar.is-light .navbar-brand > a.navbar-item:hover {
+	background-color: transparent;
+}
+.b-table .table-wrapper.has-sticky-header tr:first-child th {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	background: #ededed;
+}
+.b-tooltip.is-primary .tooltip-content {
+	background: #aeaeae;
+	color: #000;
+}
+.loading-overlay .loading-background {
+	background: none !important;
+}
+.video-js .vjs-big-play-button {
+	font-size: 3em;
+	line-height: 2.8em;
+	height: 3em;
+	width: 3em;
+	border-radius: 99px;
+}
+.img {
+	background-color: white;
+}
+.carousel-arrow .icon {
+	color: #000;
+	border-radius: 9999px;
+}
+.carousel-arrow .icon {
+	position: absolute;
+	background-color: rgba(43, 51, 63, .6);
+	-webkit-transition: all .4s;
+	transition: all .4s;
+	opacity: 0.5;
+}
+.carousel-arrow .icon.has-icons-left {
+	left: 0.2rem;
+	height: 2em;
+	width: 2em;
+}
+.carousel-arrow .icon.has-icons-right {
+	right: 0.2rem;
+	height: 2em;
+	width: 2em;
+}
+.prev {
+	left: 0;
+	border-radius: 3px 0 0 3px;
+	background-color: #d0d0d1;
+}
+.next {
+	right: 0;
+	border-radius: 3px 0 0 3px;
+	background-color: #d0d0d1;
+}
+.prev[data-v-449617a4] {
+	left: 8px;
+}
+.next[data-v-449617a4] {
+	right: 8px;
+}
+.is-large.delete,
+.is-large.modal-close {
+	min-height: 50px;
+	min-width: 50px;
+}
+.is-large.modal-close:hover {
+	color: white;
+	background-color: #ff5800;
+}
+.modal-close {
+	position: fixed;
+	right: 5px;
+	top: 20px;
+	background-color: #d0d0d1;
+}
+#scrollButtons[data-v-50899169] {
+	display: none;
+}
+.menu-list a.is-active {
+	font-weight: 600;
+	background-color: #d0d0d1;
+	color: black;
+}
+.tabs.is-boxed li.is-active a {
+	background-color: #d0d0d1;
+	border-color: transparent;
+	border-bottom-color: transparent;
+}
+.b-tabs .tabs.is-boxed li a:focus {
+	background-color: #d0d0d1;
+	border-bottom-color: #cfcfcf;
+}
+.pagination-link.is-current {
+	background-color: #ba4f17;
+	border-color: #ba4f17;
+}
+#toTop[data-v-50899169],
+#toggleInfiniteScroll[data-v-50899169] {
+	display: none;
+	background-color: #d4d4d5;
+	color: #c4c4c5;
+	padding: 15px;
+	border-radius: 10px;
+	font-size: 18px;
+	margin-right: 8px;
+}
+.button.is-link,
+.button.is-info,
+.button.is-warning,
+.file.is-primary .file-cta {
+	background-color: #d0d0d1;
+	border-color: transparent;
+	color: #000;
+}
+.file.is-primary .file-cta:hover {
+	background-color: #aeaeae
+}
+.button.is-link:hover,
+.button.is-warning:hover,
+.dropdown .dropdown-menu .has-link a.is-active,
+a.dropdown-item.is-active,
+button.dropdown-item.is-active {
+	background-color: #aeaeae;
+	color: #000;
+}
+.button.is-link[disabled],
+.button.is-primary[disabled],
+fieldset[disabled] .button.is-link {
+	background-color: #d0d0d1;
+	border-color: transparent;
+}
+
+.field-body .field .field {
+	background-color: transparent;
+}
+
+.label.switch.is-rounded:hover {
+	background: #ff5800;
+}
+.b-tooltip.is-danger .tooltip-content {
+	background: #ba4f17;
+	color: #000;
+}
+.b-checkbox.checkbox:hover input[type="checkbox"]:not(:disabled) + .check {
+	border-color: #aeaeae;
+}
+.b-checkbox.checkbox input[type="checkbox"]:checked + .check {
+	background: #ba4f17 url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Cpath style='fill:%23fff' d='M.04.627.146.52.43.804.323.91zm.177.177L.854.167.96.273.323.91z'/%3E%3C/svg%3E") no-repeat 50%;
+	border-color: #ba4f17;
+}
+.b-radio.radio input[type="radio"]:checked + .check,
+.b-radio.radio input[type="radio"]:checked + .check:hover,
+.b-radio.radio input[type="radio"]:checked + .check::before {
+	border-color: #ba4f17;
+}
+.b-radio.radio input[type="radio"] + .check::before {
+	background-color: #ba4f17;
+}
+.b-radio.radio:hover input[type="radio"]:not(:disabled) + .check {
+	border-color: #ff5800;
+}
+.switch input[type="checkbox"]:checked + .check.is-dark,
+.switch input[type="checkbox"]:checked + .check.is-info,
+.input[type="checkbox"]:checked + .check.is-dark,
+.switch input[type="checkbox"]:checked + .check {
+	background: #ba4f17;
+}
+.switch input[type="checkbox"]:checked + .check.is-info:hover,
+.switch input[type="checkbox"]:checked + .check:hover {
+	background: #ff5800;
+}
+.b-slider .b-slider-track {
+	background: #aeaeae;
+}
+.b-slider.is-link .b-slider-fill,
+.b-slider.is-primary .b-slider-fill {
+	background: #ba4f17 !important;
+}
+.tabs li.is-active a {
+	border-bottom-color: #ba4f17 !important;
+	font-weight: 600;
+	color: #ba4f17;
+}
+.b-tabs .tabs li a:focus {
+	border-bottom-color: #ba4f17;
+}
+.loading-overlay .loading-icon::after {
+	-webkit-animation: spinAround .5s linear infinite;
+	animation: spinAround .5s linear infinite;
+	border: 2px solid #ff5800;
+	border-radius: 9999px;
+	border-right-color: transparent;
+	border-top-color: transparent;
+	content: "";
+	display: block;
+	position: absolute;
+	top: calc(50% - 1.5em);
+	left: calc(50% - 1.5em);
+	width: 3em;
+	height: 3em;
+	border-width: .25em;
+}
+
+.modal-card {
+	width: 94% !important;
+	height: 94% !important;
+}
+
+.modal-warning .modal-card {
+	height: auto !important;
+	max-height: 40vh !important;
+}
+
+.dialog .modal-card {
+	height: fit-content !important;
+}
+
+.scene_title {
+	font-size: 13px;
+}
+
+.column {
+	padding: .9rem;
+}
+
+.tag:not(body) {
+	font-size: .6rem;
+}
+
+.columns {
+	margin-top: 0 !important;
+}
+
+.b-tabs .tab-content {
+	padding: 0;
+}
+
+.content.is-small {
+	padding-top: 1.5em;
+}
+
+.thumbnail[data-v-449617a4] {
+	height: 170px;
+	padding-bottom: 0.2em;
+}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -39,7 +39,13 @@ import MigrationOverlay from './components/MigrationOverlay'
 
 export default {
   components: { Navbar, Socket, QuickFind, GlobalEvents, Details, EditScene, ActorDetails, EditActor, SearchStashdbScenes, SearchStashdbActors, MigrationOverlay },
+  mounted () {
+    this.applyTheme(this.theme)
+  },
   computed: {
+    theme () {
+      return this.$store.state.optionsWeb.web.theme
+    },
     showOverlay () {
       return this.$store.state.overlay.details.show
     },
@@ -58,6 +64,38 @@ export default {
     showSearchStashdbActors() {
       return this.$store.state.overlay.searchStashDbActors.show
     },
+  },
+  watch: {
+    theme (val) {
+      this.applyTheme(val)
+    }
+  },
+  methods: {
+    applyTheme (theme) {
+      const validTheme = theme === 'dark' ? 'dark' : 'light'
+      const html = document.documentElement
+      const body = document.body
+
+      html.setAttribute('data-theme', validTheme)
+      html.classList.remove('xbvr-theme-dark', 'xbvr-theme-light')
+      html.classList.add('xbvr-theme-' + validTheme)
+      if (body) {
+        body.classList.remove('xbvr-theme-dark', 'xbvr-theme-light')
+        body.classList.add('xbvr-theme-' + validTheme)
+      }
+
+      const baseUrl = (process.env.BASE_URL || '/ui/')
+      const existing = document.getElementById('xbvr-theme-css')
+      if (existing && existing.parentNode) {
+        existing.parentNode.removeChild(existing)
+      }
+      const themeLink = document.createElement('link')
+      themeLink.id = 'xbvr-theme-css'
+      themeLink.rel = 'stylesheet'
+      themeLink.href = baseUrl + validTheme + '-theme.css?v=' + Date.now()
+      document.head.appendChild(themeLink)
+      localStorage.setItem('xbvr-theme', validTheme)
+    }
   }
 }
 </script>
@@ -68,5 +106,9 @@ export default {
   }
   .modal-background {
     background-color: rgba(0, 0, 0, .40) !important;
+  }
+  .modal-warning .animation-content .modal-card {
+    height: auto !important;
+    max-height: 40vh !important;
   }
 </style>

--- a/ui/src/Socket.vue
+++ b/ui/src/Socket.vue
@@ -73,6 +73,9 @@ export default {
       if (dataArr.argsDict.name === 'rescan') {
         this.$store.state.messages.lockRescan = dataArr.argsDict.locked
       }
+      if (dataArr.argsDict.name === 'previews') {
+        this.$store.state.messages.lockPreview = dataArr.argsDict.locked
+      }
     })
 
     ws.subscribe('state.change.optionsStorage', (arr, obj) => {
@@ -81,6 +84,14 @@ export default {
 
     ws.subscribe('options.previews.previewReady', (arr, obj) => {
       this.$store.commit('optionsPreviews/showPreview', { previewFn: arr.argsDict.previewFn })
+    })
+
+    ws.subscribe('options.previews.previewError', (arr, obj) => {
+      this.$store.commit('optionsPreviews/previewFailed', { message: arr.argsDict.message })
+    })
+
+    ws.subscribe('options.previews.previewCleared', (arr, obj) => {
+      this.$store.commit('optionsPreviews/clearPreview')
     })
 
     // Remote

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -23,9 +23,11 @@ Vue.config.keyCodes = {
 Vue.use(Buefy)
 Vue.use(vueDebounce)
 
-new Vue({
+const app = new Vue({
   router,
   store,
   i18n,
   render: h => h(App)
 }).$mount('#app')
+
+store.dispatch('optionsWeb/load')

--- a/ui/src/store/actorList.js
+++ b/ui/src/store/actorList.js
@@ -24,6 +24,8 @@ const defaultFilterState = {
   max_height: 220,  
   min_weight: 25,
   max_weight: 150,  
+  min_cup_size: 0,
+  max_cup_size: 9,
   min_count: 0,
   max_count: 150,  
   min_avail: 0,
@@ -41,7 +43,7 @@ const state = {
   isLoading: false,
   offset: 0,
   total: 0,
-  limit: 18,
+  limit: 15,
   show_actor_id: '',
   filterOpts: {
     cast: [],

--- a/ui/src/store/messages.js
+++ b/ui/src/store/messages.js
@@ -2,6 +2,7 @@ const state = {
   lockScrape: false,
   lastScrapeMessage: '',
   lockRescan: false,
+  lockPreview: false,
   lastRescanMessage: '',
   lastProgressMessage: '',
   runningScrapers: []

--- a/ui/src/store/optionsPreviews.js
+++ b/ui/src/store/optionsPreviews.js
@@ -1,7 +1,10 @@
 const state = {
   isPreviewReady: false,
   generatingPreview: false,
-  previewFn: ''
+  previewFn: '',
+  previewError: '',
+  previewStartTime: null,
+  previewElapsed: 0
 }
 
 const mutations = {
@@ -9,11 +12,36 @@ const mutations = {
     state.isPreviewReady = false
     state.generatingPreview = true
     state.previewFn = ''
+    state.previewError = ''
+    state.previewStartTime = Date.now()
+    state.previewElapsed = 0
   },
   showPreview (state, payload) {
     state.isPreviewReady = true
     state.generatingPreview = false
     state.previewFn = payload.previewFn
+    state.previewError = ''
+    state.previewStartTime = null
+  },
+  previewFailed (state, payload) {
+    state.isPreviewReady = false
+    state.generatingPreview = false
+    state.previewFn = ''
+    state.previewError = (payload && payload.message) || 'Preview generation failed'
+    state.previewStartTime = null
+  },
+  tickPreviewTimer (state) {
+    if (state.previewStartTime) {
+      state.previewElapsed = Math.floor((Date.now() - state.previewStartTime) / 1000)
+    }
+  },
+  clearPreview (state) {
+    state.isPreviewReady = false
+    state.generatingPreview = false
+    state.previewFn = ''
+    state.previewError = ''
+    state.previewStartTime = null
+    state.previewElapsed = 0
   }
 }
 

--- a/ui/src/store/optionsWeb.js
+++ b/ui/src/store/optionsWeb.js
@@ -3,6 +3,7 @@ import ky from 'ky'
 const state = {
   loading: false,
   web: {
+    theme: 'light',
     tagSort: 'By Tag Count',
     sceneHidden: true,
     sceneWatchlist: true,
@@ -11,6 +12,7 @@ const state = {
     sceneWatched: false,
     sceneEdit: false,
     sceneDuration: false,
+    sceneDate: true,
     sceneCuepoint: true,
     showHspFile: true,
     showSubtitlesFile: true,
@@ -20,6 +22,7 @@ const state = {
     showScriptHeatmap: false,
     showAllHeatmaps: false,
     showOpenInNewWindow: true,
+    showStashdbLink: true,
     sceneCardAspectRatio: "1:1",
     sceneCardScaleToFit: true,
     actorCardAspectRatio: "1:1",
@@ -36,6 +39,7 @@ const actions = {
     ky.get('/api/options/state')
       .json()
       .then(data => {
+        state.web.theme = data.config.web.theme || 'light'
         state.web.tagSort = data.config.web.tagSort
         state.web.sceneHidden = data.config.web.sceneHidden
         state.web.sceneWatchlist = data.config.web.sceneWatchlist
@@ -44,6 +48,7 @@ const actions = {
         state.web.sceneWatched = data.config.web.sceneWatched
         state.web.sceneEdit = data.config.web.sceneEdit
         state.web.sceneDuration = data.config.web.sceneDuration
+        state.web.sceneDate = data.config.web.sceneDate
         state.web.sceneCuepoint = data.config.web.sceneCuepoint
         state.web.showHspFile = data.config.web.showHspFile
         state.web.showSubtitlesFile = data.config.web.showSubtitlesFile
@@ -53,6 +58,7 @@ const actions = {
         state.web.updateCheck = data.config.web.updateCheck
         state.web.isAvailOpacity = data.config.web.isAvailOpacity
         state.web.showOpenInNewWindow = data.config.web.showOpenInNewWindow
+        state.web.showStashdbLink = data.config.web.showStashdbLink !== false
         state.web.sceneCardAspectRatio = data.config.web.sceneCardAspectRatio
         state.web.sceneCardScaleToFit = data.config.web.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.config.web.actorCardAspectRatio
@@ -65,6 +71,7 @@ const actions = {
     ky.put('/api/options/interface/web', { json: { ...state.web } })
       .json()
       .then(data => {
+        state.web.theme = data.theme || 'light'
         state.web.tagSort = data.tagSort
         state.web.sceneHidden = data.sceneHidden
         state.web.sceneWatchlist = data.sceneWatchlist
@@ -73,6 +80,7 @@ const actions = {
         state.web.sceneWatched = data.sceneWatched
         state.web.sceneEdit = data.sceneEdit
         state.web.sceneDuration = data.sceneDuration
+        state.web.sceneDate = data.sceneDate
         state.web.sceneCuepoint = data.sceneCuepoint
         state.web.showHspFile = data.showHspFile
         state.web.showSubtitlesFile = data.showSubtitlesFile
@@ -82,6 +90,7 @@ const actions = {
         state.web.updateCheck = data.updateCheck
         state.web.isAvailOpacity = data.isAvailOpacity
         state.web.showOpenInNewWindow = data.showOpenInNewWindow
+        state.web.showStashdbLink = data.showStashdbLink
         state.web.sceneCardAspectRatio = data.sceneCardAspectRatio
         state.web.sceneCardScaleToFit = data.sceneCardScaleToFit
         state.web.actorCardAspectRatio = data.actorCardAspectRatio

--- a/ui/src/views/actors/ActorCard.vue
+++ b/ui/src/views/actors/ActorCard.vue
@@ -21,7 +21,12 @@
       <actor-favourite-button :actor="actor" v-if="this.$store.state.optionsWeb.web.sceneFavourite"/>
       <actor-watchlist-button :actor="actor" v-if="this.$store.state.optionsWeb.web.sceneWatchlist"/>
       <actor-edit-button :actor="actor"/>&nbsp;
-      <link-stashdb-button :item="actor" objectType="actor" />
+      <link-stashdb-button :item="actor" objectType="actor" v-if="!hideStashdb" />
+      <b-tooltip :label="$t('Delete actor')" :delay="500">
+        <button class="button is-small is-danger is-outlined" @click.stop="deleteActor(actor)">
+          <b-icon pack="mdi" icon="delete-outline" size="is-small"></b-icon>
+        </button>
+      </b-tooltip>
       <b-tooltip :label="$t('Your rating')" :delay="500">
       <b-tag type="is-warning" v-if="actor.star_rating != 0 " size="is-small" style="height:30px;">
         <b-icon pack="mdi" icon="star" size="is-small"/>
@@ -58,10 +63,11 @@ import ActorEditButton from '../../components/ActorEditButton'
 import LinkStashdbButton from '../../components/LinkStashdbButton'
 import VueLoadImage from 'vue-load-image'
 import { tr } from 'date-fns/locale'
+import ky from 'ky'
 
 export default {
   name: 'ActorCard',
-  props: { actor: Object, colleague: String },
+  props: { actor: Object, colleague: String, hideStashdb: Boolean },
    components: {ActorFavouriteButton, ActorWatchlistButton, VueLoadImage, ActorEditButton, LinkStashdbButton},
   data () {
     return {
@@ -102,7 +108,7 @@ export default {
       if (u.startsWith('http')) {
         return '/img/700x/' + u.replace('://', ':/')
       } else {
-        return u
+        return encodeURI(u)
       }
     },
     showDetails (actor) {
@@ -114,6 +120,11 @@ export default {
         return false
       }
       return true
+    },
+    deleteActor (actor) {
+      ky.delete(`/api/actor/delete/${actor.id}`).then(() => {
+        this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset - this.$store.state.actorList.limit })
+      })
     },
     showColleague (main_actor, colleague) {      
       this.$store.state.sceneList.filters.cast = ["&" + main_actor , "&"+ colleague]

--- a/ui/src/views/actors/ActorDetails.vue
+++ b/ui/src/views/actors/ActorDetails.vue
@@ -39,7 +39,7 @@
                   </template>
                 </b-carousel>
                 <div class="flexcentre">
-                <b-button class="button is-primary is-small" style="display: flex; justify-content: center;" v-on:click="setActorImage()">{{$t('Set Main Image')}}</b-button>
+                <b-button class="button is-primary is-small" style="display: flex; justify-content: center;" v-on:click="setMainActorImage()">{{$t('Set Main Image')}}</b-button>
                 <b-button v-if="images.length != 0" class="button is-primary is-small" style="display: flex; justify-content: center;margin-left: 1em;" v-on:click="deleteActorImage()">{{$t('Delete Image')}}</b-button>
                 </div>
               </b-tab-item>
@@ -92,7 +92,12 @@
                       <actor-favourite-button :actor="actor"/>&nbsp;
                       <actor-watchlist-button :actor="actor"/>&nbsp;
                       <actor-edit-button :actor="actor"/>&nbsp;
-                      <link-stashdb-button :item="actor" objectType="actor" />
+                      <link-stashdb-button :item="actor" objectType="actor" />&nbsp;
+                      <b-tooltip :label="$t('Delete actor')" position="is-left" :delay="250">
+                        <button class="button is-small is-danger is-outlined" @click="deleteActor">
+                          <b-icon pack="mdi" icon="delete-outline" size="is-small"></b-icon>
+                        </button>
+                      </b-tooltip>
                     </div>
                   </div>
                 </div>
@@ -136,6 +141,9 @@
                     <b-field v-if="measurements() != ''">
                       <strong class="attribute-heading">{{ $t('Measurements') }}:</strong> <small class="attribute-data">{{ measurements() }}</small>
                     </b-field>
+                    <b-field v-if="actor.band_size != 0 && actor.cup_size != ''">
+                      <strong class="attribute-heading">{{ $t('Bra/cup size') }}:</strong> <small class="attribute-data">{{ actor.cup_size }}</small>
+                    </b-field>
                     <b-field v-if="actor.breast_type != ''">
                       <strong class="attribute-heading">{{ $t('Breast Type') }}:</strong> <small class="attribute-data">{{ actor.breast_type }}</small>
                     </b-field>
@@ -157,28 +165,28 @@
                   <template #header>                    
                     Scenes ({{ actor.scenes.length }}) <a v-if="showOpenInNewWindow" :href='getCastScenesUrl([actor.name])' target="_blank" style="padding-left: 0.1em; border-bottom-style: none;"><b-icon pack="mdi" icon="open-in-new" size="is-small" style="background-color: hsl(0, 0%, 100%);"></b-icon></a>
                   </template>
-                  <div v-show="activeTab == 1" :class="['columns', 'is-multiline', actor.scenes.length > 6 ? 'scroll' : '']">
-                    <div :class="['column', 'is-multiline', 'is-one-third']"
+                  <div v-show="activeTab == 1" :class="['columns', 'is-multiline', 'actor-scenes', actor.scenes.length > 6 ? 'scroll' : '']" :style="actor.scenes.length > 6 ? { height: scenesScrollHeight } : null">
+                    <div :class="['column', 'is-2']"
                       v-for="(scene, idx) in actor.scenes" :key="idx" class="image-wrapper">
                       <SceneCard :item="scene" :reRead=true />
                     </div>
                   </div>
                 </b-tab-item>
                 <b-tab-item :label="$t('Akas')" :visible="akas.aka_groups != null || akas.actors != null || akas.possible_akas != null">
-                  <div v-show="activeTab == 2">
-                    <b-field :label="$t('Aka Groups')" v-if="akas.aka_groups != null &&  akas.aka_groups.length!=0">
-                      <div  class="columns is-multiline">
-                        <div :class="['column', 'is-multiline', 'is-one-third']"
+                  <div v-show="activeTab == 2" class="columns is-multiline scroll">
+                    <b-field :label="$t('Aka Groups')" v-if="akas.aka_groups != null &&  akas.aka_groups.length!=0" class="column is-full">
+                      <div class="columns is-multiline">
+                        <div :class="['column', 'is-multiline', 'is-2']"
                           v-for="(akaactor, idx) in akas.aka_groups" :key="idx" class="image-wrapper">
-                          <ActorCard :actor="akaactor"/>
+                          <ActorCard :actor="akaactor" :hideStashdb="true"/>
                         </div>
                       </div>
                     </b-field>
-                    <b-field :label="$t('Other Actors In Groups')" v-if="akas.actors != null &&  akas.actors.length!=0">
-                      <div  class="columns is-multiline">
-                        <div :class="['column', 'is-multiline', 'is-one-third']"
+                    <b-field :label="$t('Other Actors In Groups')" v-if="akas.actors != null &&  akas.actors.length!=0" class="column is-full">
+                      <div class="columns is-multiline">
+                        <div :class="['column', 'is-multiline', 'is-2']"
                           v-for="(akaactor, idx) in akas.actors" :key="idx" class="image-wrapper">
-                          <ActorCard :actor="akaactor"/>
+                          <ActorCard :actor="akaactor" :hideStashdb="true"/>
                           <b-tooltip position="is-bottom" :label="$t('Remove Cast from Aka Group. Select the Aka group and Actors to remove in the Cast Filter')" multilined :delay="200">
                             <button class="button is-small is-outlined" @click="removeFromAkaGroup(akaactor.name)" v-if="actor.name.startsWith('aka:')">
                               <b-icon pack="mdi" icon="account-minus-outline"></b-icon>
@@ -187,11 +195,11 @@
                         </div>
                       </div>
                     </b-field>
-                    <b-field :label="$t('Possible Matches')" v-if="akas.possible_akas != null &&  akas.possible_akas.length!=0">
+                    <b-field :label="$t('Possible Matches')" v-if="akas.possible_akas != null &&  akas.possible_akas.length!=0" class="column is-full">
                       <div class="columns is-multiline">
-                        <div :class="['column', 'is-multiline', 'is-one-third']"
+                        <div :class="['column', 'is-multiline', 'is-2']"
                           v-for="(akaactor, idx) in akas.possible_akas" :key="idx" class="image-wrapper">
-                          <ActorCard :actor="akaactor"/>
+                          <ActorCard :actor="akaactor" :hideStashdb="true"/>
                           <b-tooltip position="is-bottom" :label="$t('Add Cast to Aka Group. Select the Aka group and Actors to add in the Cast Filter')" multilined :delay="200">
                             <button class="button is-small is-outlined" @click="addToAkaGroup(akaactor.name)" v-if='actor.name.startsWith("aka:")'>
                               <b-icon pack="mdi" icon="account-plus-outline"></b-icon>
@@ -201,12 +209,12 @@
                       </div>
                     </b-field>
                   </div>
-                </b-tab-item>                
+                </b-tab-item>
                 <b-tab-item :visible="colleagues.length != 0" :label="`Colleagues (${colleagues.length})`">
                   <div v-show="activeTab == 3" class="columns is-multiline scroll">
-                    <div :class="['column', 'is-multiline', 'is-one-third']"
+                    <div :class="['column', 'is-multiline', 'is-2']"
                       v-for="(colleague, idx) in colleagues" :key="idx" class="image-wrapper">
-                      <ActorCard :actor="colleague" :colleague="actor.name" />
+                      <ActorCard :actor="colleague" :colleague="actor.name" :hideStashdb="true" />
                     </div>
                   </div>
                 </b-tab-item>
@@ -321,6 +329,10 @@ export default {
     showOpenInNewWindow () {
       return this.$store.state.optionsWeb.web.showOpenInNewWindow
     },
+    scenesScrollHeight () {
+      const rows = Math.ceil(this.actor.scenes.length / 4)
+      return `${rows * 11}em`
+    },
   },
   mounted () {    
       ky.get('/api/actor/countrylist')
@@ -336,10 +348,11 @@ export default {
     },  
     methods: {
     getImageURL (u, size) {
+      if (!u) return '/ui/images/blank_female_profile.png'
       if (u.startsWith('http') || u.startsWith('https')) {
         return '/img/' + size + '/' + u.replace('://', ':/')
       } else {
-        return u
+        return encodeURI(u)
       }
     },
     getIndicatorURL (idx) {      
@@ -435,40 +448,42 @@ export default {
       active +=  "-"      
       if (this.actor.end_year > 0) {
         active += this.actor.end_year 
+      } else {
+        active += "Present"
       }
       return active
     },
     measurements(){      
-      let metric_measurements=""
       let imperial_measurements=""
+      let metric_measurements=""
       if (this.actor.band_size != 0) {
-        metric_measurements=this.actor.band_size
         imperial_measurements=Math.round(this.actor.band_size / 2.54)
+        metric_measurements=this.actor.band_size
       }
       if (this.actor.cup_size != ''){
-        metric_measurements +=  this.actor.cup_size        
-        imperial_measurements += this.actor.cup_size        
+        imperial_measurements +=  this.actor.cup_size        
+        metric_measurements += this.actor.cup_size        
       }
       if (this.actor.waist_size != 0) {
-        if (metric_measurements!='') {
-          metric_measurements += '-'
+        if (imperial_measurements!='') {
           imperial_measurements += '-'
+          metric_measurements += '-'
         }
+        imperial_measurements += Math.round(this.actor.waist_size / 2.54)
         metric_measurements += this.actor.waist_size
-        imperial_measurements += Math.round(this.actor.waist_size  / 2.54)
       }
       if (this.actor.hip_size != 0) {
-        if (metric_measurements!='') {
-          metric_measurements += '-'
+        if (imperial_measurements!='') {
           imperial_measurements += '-'
+          metric_measurements += '-'
         }
-        metric_measurements += this.actor.hip_size
         imperial_measurements += Math.round(this.actor.hip_size / 2.54)
+        metric_measurements += this.actor.hip_size
       } 
-      if (metric_measurements==''){
+      if (imperial_measurements==''){
         return ''
       }
-      return imperial_measurements + " / " + metric_measurements
+      return metric_measurements + " cm / " + imperial_measurements + " inch"
     },
     joinArray(jsonArr){
       const arr = JSON.parse(jsonArr);
@@ -484,6 +499,28 @@ export default {
         this.carouselSlide=0
         this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset - this.$store.state.actorList.limit })
       })    
+    },
+    setMainActorImage () {
+      ky.post('/api/actor/setmainimage', {
+      json: {
+        actor_id: this.actor.id,
+        url: this.images[this.carouselSlide]
+      }}).json().then(data => {
+        this.$store.state.overlay.actordetails.actor = data
+        this.carouselSlide = 0
+        this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset - this.$store.state.actorList.limit })
+        this.$buefy.toast.open({ message: 'Main image saved to myfiles/actors', type: 'is-success' })
+      }).catch(() => {
+        this.$buefy.toast.open({ message: 'Failed to save main image', type: 'is-danger' })
+      })
+    },
+    deleteActor () {
+      ky.delete(`/api/actor/delete/${this.actor.id}`).json().then(() => {
+        this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset - this.$store.state.actorList.limit })
+        this.$store.commit('overlay/hideActorDetails')
+      }).catch(err => {
+        this.$buefy.toast.open({ message: `Failed to delete actor: ${err}`, type: 'is-danger' })
+      })
     },
     deleteActorImage (val) {
       ky.delete('/api/actor/delimage', {
@@ -666,10 +703,6 @@ export default {
   padding-top: calc(100% - 40px - 1em) !important;
 }
 
-.modal-card {
-  width: 85%;
-}
-
 .missing {
   opacity: 0.6;
 }
@@ -802,7 +835,6 @@ span.is-active img {
   max-height: 100%;
 }
 div.scroll {
-  height: 1000px;
   overflow-x: hidden;
   overflow-y: auto;
   text-align: center;
@@ -810,6 +842,7 @@ div.scroll {
 .attribute-container {  
   display: flex; 
   flex-wrap: wrap;
+  padding: 20px;
 }
 .attribute-heading {  
   width: 120px; 

--- a/ui/src/views/actors/Actors.vue
+++ b/ui/src/views/actors/Actors.vue
@@ -34,16 +34,8 @@ export default {
         : 'none'
     })
     toTop.addEventListener('click', function () {
-      scrollToTop()
+      window.scrollTo({ top: 0, behavior: 'smooth' })
     })
-
-    const scrollToTop = () => {
-      const c = document.documentElement.scrollTop || document.body.scrollTop
-      if (c > 0) {
-        window.requestAnimationFrame(scrollToTop)
-        window.scrollTo(0, c - c / 16)
-      }
-    }
   },
   beforeRouteEnter (to, from, next) {
     next(vm => {
@@ -51,7 +43,10 @@ export default {
         vm.$store.commit('actorList/stateFromQuery', to.query)
       }
       vm.$store.dispatch('optionsWeb/load')
-      vm.$store.dispatch('actorList/load', { offset: 0 })
+      const page = parseInt(to.query.page) || 1
+      const limit = vm.$store.state.actorList.limit
+      const offset = (page - 1) * limit
+      vm.$store.dispatch('actorList/load', { offset })
       vm.$store.dispatch('optionsAdvanced/load')
     })
   },
@@ -59,7 +54,10 @@ export default {
     if (to.query !== undefined) {
       this.$store.commit('actorList/stateFromQuery', to.query)
     }
-    this.$store.dispatch('actorList/load', { offset: 0 })
+    const page = parseInt(to.query.page) || 1
+    const limit = this.$store.state.actorList.limit
+    const offset = (page - 1) * limit
+    this.$store.dispatch('actorList/load', { offset })
     next()
   },
   computed: {

--- a/ui/src/views/actors/EditActor.vue
+++ b/ui/src/views/actors/EditActor.vue
@@ -17,7 +17,7 @@
         <b-tabs position="is-centered" :animated="false">
 
           <b-tab-item :label="$t('Information')">
-            <b-field grouped group-multiline style="margin-bottom: 2em;">
+            <b-field grouped group-multiline style="margin-bottom: 2em;margin-top: 2em;">
               <b-field :label="$t('Nationality')" label-position="on-border" class="field-extra">
                 <b-taginput v-model="countries" autocomplete :data="filteredCountries" @typing="getFilteredCountries" maxtags="1" :open-on-focus=true :has-counter="false">
                   <template slot-scope="props">{{ props.option }}</template>
@@ -37,7 +37,7 @@
                  <b-button :label="$t('Clear')" type="is-danger" icon-left="close" outlined @click="birthdate = null" />
                </b-datepicker>
             </b-field>
-            <b-field grouped group-multiline style="margin-bottom: 2em;">
+            <b-field grouped group-multiline style="margin-bottom: 2em;margin-top: 2em;">
               <b-field :label="$t('Eye Color')" label-position="on-border">
                 <b-input type="text" v-model="actor.eye_color" @blur="blur('eye_color')"/>
               </b-field>
@@ -45,7 +45,7 @@
                 <b-input type="text" v-model="actor.hair_color" @blur="blur('hair_color')"/>
               </b-field>
             </b-field>
-            <b-field grouped group-multiline style="margin-bottom: 2em;">
+            <b-field grouped group-multiline style="margin-bottom: 2em;margin-top: 2em;">
               <b-field v-if="useImperialEntry" :label="$t('Weight in lbs')" label-position="on-border">
                 <b-input type="number" v-model.number="actor.lbs" :placeholder="$t('Enter Weight in lbs')"  @blur="blur('weight')"/>                 
               </b-field>
@@ -62,7 +62,7 @@
                 <b-input type="number" v-model.number="actor.height"  placeholder="Height in cm" @blur="blur('height')"/>
               </b-field>
             </b-field>
-            <b-field grouped group-multiline style="margin-bottom: 2em;">
+            <b-field grouped group-multiline style="margin-bottom: 2em;margin-top: 2em;">
               <b-field :label="$t('Measurements')" label-position="on-border">
                 <b-input type="text" v-model="actor.measurements" placeholder="eg 36C-24-36" pattern="(^(\d{2})?([A-Za-z]{0,2})-(\d{2})?-(\d{2}$)?)|^[A-Z]{0,2}$" validation-message="use the format 99A-99-99"
                   @blur="blur('measurements')"/>
@@ -71,7 +71,7 @@
                 <b-input type="text" v-model="actor.breast_type" placeholder="eg Fake, Natural" @blur="blur('breast_type')"/>
               </b-field>
             </b-field>
-            <b-field grouped group-multiline style="margin-bottom: 2em;">
+            <b-field grouped group-multiline style="margin-bottom: 2em;margin-top: 2em;">
               <b-field :label="$t('Active From')" label-position="on-border">
                 <b-input type="number" v-model.number="actor.start_year" :max="new Date().getFullYear()" pattern="^[1-2]\d{1,3}$|^0$|^$"  validation-message="Up to the current year" @blur="blur('start_year')"/>
               </b-field>

--- a/ui/src/views/actors/Filters.vue
+++ b/ui/src/views/actors/Filters.vue
@@ -121,6 +121,10 @@
           <td><b-slider :min="25" :max="150" :step="1" :tooltip="true" v-model="weights" lazy class="slider"></b-slider></td>
         </tr>
         <tr>
+          <td class="slider-title"><strong><small>{{ $t("Bra/cup size") }}:</small></strong></td>
+          <td><b-slider :min="0" :max="9" :step="1" :tooltip="true" :custom-formatter="formatCupSize" v-model="cupSizes" lazy class="slider"></b-slider></td>
+        </tr>
+        <tr>
           <td class="slider-title"><strong><small>{{ $t("Scenes") }}:</small></strong></td>
           <td><b-slider :min="0" :max="150" :step="1" :tooltip="true" v-model="scenecounts" lazy class="slider" ></b-slider></td>
         </tr>
@@ -335,6 +339,10 @@ export default {
       }
       return txt
     },
+    formatCupSize(value) {
+      const cupSizes = ['AA', 'A', 'B', 'C', 'D', 'DD', 'E', 'F', 'G', 'N']
+      return cupSizes[value] || value
+    },
     async fetchFilters() {
         this.filteredAttributes=['Loading attributes']
         ky.get('/api/actor/filters').json().then(data => {
@@ -405,6 +413,18 @@ export default {
         if (this.$store.state.actorList.filters.min_weight != value[0] || this.$store.state.actorList.filters.max_weight != value[1]){
           this.$store.state.actorList.filters.min_weight = value[0]
           this.$store.state.actorList.filters.max_weight = value[1]
+          this.reloadList()
+        }
+      }
+    },
+    cupSizes: {
+      get () {
+        return [this.$store.state.actorList.filters.min_cup_size, this.$store.state.actorList.filters.max_cup_size]
+      },
+      set (value) {
+        if (this.$store.state.actorList.filters.min_cup_size != value[0] || this.$store.state.actorList.filters.max_cup_size != value[1]){
+          this.$store.state.actorList.filters.min_cup_size = value[0]
+          this.$store.state.actorList.filters.max_cup_size = value[1]
           this.reloadList()
         }
       }

--- a/ui/src/views/actors/List.vue
+++ b/ui/src/views/actors/List.vue
@@ -87,50 +87,6 @@
         <ActorCard :actor="actor"/>
       </div>
     </div>
-      <div class="columns is-gapless is-centered" v-if="hideLetters">
-        <b-radio-button v-model="jumpTo" native-value="" size="is-small"></b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="A" size="is-small">A</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="B" size="is-small">B</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="C" size="is-small">C</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="D" size="is-small">D</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="E" size="is-small">E</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="F" size="is-small">F</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="G" size="is-small">G</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="H" size="is-small">H</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="I" size="is-small">I</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="J" size="is-small">J</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="K" size="is-small">K</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="L" size="is-small">L</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="M" size="is-small">M</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="N" size="is-small">N</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="O" size="is-small">O</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="P" size="is-small">P</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="Q" size="is-small">Q/R</b-radio-button>        
-        <b-radio-button v-model="jumpTo" native-value="S" size="is-small">S</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="T" size="is-small">T</b-radio-button>
-        <b-radio-button v-model="jumpTo" native-value="U" size="is-small">U/V</b-radio-button>        
-        <b-radio-button v-model="jumpTo" native-value="W" size="is-small">W/X/Y/Z</b-radio-button>
-      </div>
-      <div class="columns is-gapless is-centered">          
-        <b-tooltip :label="$t('Press k to page back, l to page forward')" :delay="500" position="is-top">
-          <b-pagination
-            :total="total"
-            v-model="current"
-            range-before=2
-            range-after=3 
-            size="is-small"                                              
-            :per-page="limit"
-            aria-next-label="Next page"
-            aria-previous-label="Previous page"
-            aria-page-label="Page"
-            aria-current-label="Current page"
-            :page-input=true
-            @change="pageChanged"
-            debounce-page-input="250"
-            >
-        </b-pagination>
-      </b-tooltip>
-      </div>
   </div>
 </template>
 
@@ -147,6 +103,10 @@ export default {
       current: 1,      
     }
   },
+  created () {
+    const page = parseInt(this.$route.query.page) || 1
+    this.current = page
+  },
   computed: {
     cardSize: {
       get () {
@@ -156,16 +116,16 @@ export default {
         this.$store.state.actorList.filters.cardSize = value
         switch (value){
           case "1":
-            this.limit=36
+            this.limit=24
             break
           case "2":
-            this.limit=18
+            this.limit=15
             break
           case "3":
-            this.limit=10
+            this.limit=12
             break
           case "4":
-            this.limit=8
+            this.limit=6
             break
             }            
         }      
@@ -199,15 +159,15 @@ export default {
     cardSizeClass () {
       switch (this.$store.state.actorList.filters.cardSize) {
         case '1':
-          return 'is-1'
+          return 'is-2'
         case '2':
-          return 'is-2'
-        case '3':
           return 'is-one-fifth'
-        case '4':
+        case '3':
           return 'is-one-quarter'
+        case '4':
+          return 'is-one-third'
         default:
-          return 'is-2'
+          return 'is-one-fifth'
       }
     },
     isLoading () {
@@ -252,12 +212,20 @@ export default {
       this.$router.push({
         name: 'actors',
         query: {
-          q: this.$store.getters['actorList/filterQueryParams']
+          q: this.$store.getters['actorList/filterQueryParams'],
+          page: this.current
         }
       })
     },
-    async pageChanged () {      
-      this.$store.state.actorList.offset = (this.current -1) * this.$store.state.actorList.limit
+    async pageChanged () {
+      this.$store.state.actorList.offset = (this.current - 1) * this.$store.state.actorList.limit
+      this.$router.push({
+        name: 'actors',
+        query: {
+          ...this.$route.query,
+          page: this.current
+        }
+      }).catch(() => {})
       this.$store.dispatch('actorList/load', { offset: this.$store.state.actorList.offset })
     },
     nextpage () {

--- a/ui/src/views/options/sections/InterfaceWeb.vue
+++ b/ui/src/views/options/sections/InterfaceWeb.vue
@@ -7,6 +7,13 @@
       <div class="columns">
         <div class="column">
           <section>
+            <b-field label="Theme">
+              <b-select placeholder="Select theme" v-model="theme">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+              </b-select>
+            </b-field>
+
             <b-field label="Tag Sort">
               <div class="block">
                 <b-radio v-model="tagSort" name="tagSort" native-value="by-tag-count">
@@ -61,6 +68,11 @@
               </b-switch>
             </b-field>
             <b-field>
+              <b-switch v-model="sceneDate" type="is-dark">
+                show Release Date
+              </b-switch>
+            </b-field>
+            <b-field>
               <b-switch v-model="sceneCuepoint" type="is-dark">
                 show Cuepoints button
               </b-switch>
@@ -88,6 +100,11 @@
             <b-field>
               <b-switch v-model="openInNewWindow" type="is-dark">
                 show Open Tag in New Window
+              </b-switch>
+            </b-field>
+            <b-field>
+              <b-switch v-model="showStashdbLink" type="is-dark">
+                show Link to StashDB button
               </b-switch>
             </b-field>
             <b-field label="Opacity of unavailable scenes">
@@ -152,6 +169,14 @@ export default {
     }
   },
   computed: {
+    theme: {
+      get () {
+        return this.$store.state.optionsWeb.web.theme
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.theme = value
+      }
+    },
     tagSort: {
       get () {
         return this.$store.state.optionsWeb.web.tagSort
@@ -248,6 +273,14 @@ export default {
         this.$store.state.optionsWeb.web.sceneDuration = value
       }
     },
+    sceneDate: {
+      get () {
+        return this.$store.state.optionsWeb.web.sceneDate
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.sceneDate = value
+      }
+    },
     sceneCuepoint: {
       get () {
         return this.$store.state.optionsWeb.web.sceneCuepoint
@@ -278,6 +311,14 @@ export default {
       },
       set (value) {
         this.$store.state.optionsWeb.web.showOpenInNewWindow = value
+      }
+    },
+    showStashdbLink: {
+      get () {
+        return this.$store.state.optionsWeb.web.showStashdbLink
+      },
+      set (value) {
+        this.$store.state.optionsWeb.web.showStashdbLink = value
       }
     },
     isAvailOpacity: {

--- a/ui/src/views/options/sections/Previews.vue
+++ b/ui/src/views/options/sections/Previews.vue
@@ -7,20 +7,10 @@
       <div class="columns">
         <div class="column">
           <section>
-            <b-field label="Start time">
-              <div class="columns">
-                <div class="column is-two-thirds">
-                  <b-slider :min="5" :max="60" :step="5" :tooltip="false" v-model="startTime"></b-slider>
-                </div>
-                <div class="column">
-                  <div class="content">{{startTime}}sec</div>
-                </div>
-              </div>
-            </b-field>
             <b-field label="Snippet length">
               <div class="columns">
                 <div class="column is-two-thirds">
-                  <b-slider :min="0.2" :max="5" :step="0.2" :tooltip="false" v-model="snippetLength"></b-slider>
+                  <b-slider :min="0.2" :max="5" :step="0.1" :tooltip="false" v-model="snippetLength"></b-slider>
                 </div>
                 <div class="column">
                   <div class="content">{{snippetLength}}sec</div>
@@ -40,6 +30,9 @@
             <b-field>
               <b-checkbox v-model="extraSnippet">Grab extra snippet from the end of video</b-checkbox>
             </b-field>
+            <b-field>
+              <b-checkbox v-model="useCUDA">Use CUDA hardware acceleration</b-checkbox>
+            </b-field>
             <b-field label="Preview resolution">
               <div class="columns">
                 <div class="column is-two-thirds">
@@ -50,23 +43,38 @@
                 </div>
               </div>
             </b-field>
+            <b-field label="Tilt">
+              <div class="columns">
+                <div class="column is-two-thirds">
+                  <b-slider :min="0" :max="60" :step="1" :tooltip="false" v-model="pitch"></b-slider>
+                </div>
+                <div class="column">
+                  <div class="content">{{pitch}}</div>
+                </div>
+              </div>
+            </b-field>
             <b-field grouped>
               <b-button type="is-primary" @click="saveSettings" style="margin-right:1em">Save settings</b-button>
-              <b-button @click="testSettings">Test settings</b-button>
+              <b-button @click="testSettings" style="margin-right:1em">Test settings</b-button>
+              <b-button @click="clearTestPreview" v-if="isPreviewReady || previewError || previewElapsed > 0">Clear test preview</b-button>
             </b-field>
           </section>
           <hr/>
           <section>
             <p>
-              Once you picked preview settings, you should start generating them.
+              Once you test preview settings, you can start generating them.<br/>
+              When hit Stop - generation process actually stops only after last file finished.
             </p>
-            <p>
-              BETA NOTE: Please note this is CPU-heavy process and once started, it could be stopped only by closing the
-              app.
-            </p>
-            <b-field>
-              <b-button type="is-primary" @click="startGenerating">Start generating previews</b-button>
+            <b-field grouped>
+              <b-button type="is-primary" @click="startGenerating" :disabled="previewLeft === 0 || isGenerating" style="margin-right:1em">Start generating previews</b-button>
+              <b-button @click="stopPreview" :disabled="!isGenerating">Stop generating</b-button>
             </b-field>
+            <p v-if="previewStarted" style="margin-top:0.5em">
+              <span v-if="previewCalculating">Calculating...</span>
+              <span v-else-if="previewTotal !== null">
+                <strong>Total:</strong> {{ previewTotal }} <strong>Left:</strong> {{ previewLeft }}
+              </span>
+            </p>
           </section>
         </div>
         <div class="column">
@@ -78,6 +86,10 @@
               </div>
             </div>
           </div>
+          <div class="timer" v-if="generatingPreview || isPreviewReady">Preview generation time: {{ previewTimer }}</div>
+          <b-message v-if="previewError" type="is-danger" :closable="false">
+            {{ previewError }}
+          </b-message>
         </div>
       </div>
     </div>
@@ -93,15 +105,33 @@ export default {
   data () {
     return {
       isLoading: true,
-      startTime: 5,
       snippetLength: 0.2,
       snippetAmount: 2,
       resolution: 300,
-      extraSnippet: false
+      extraSnippet: false,
+      useCUDA: true,
+      pitch: 15,
+      timerInterval: null,
+      countInterval: null,
+      previewLeft: null,
+      previewTotal: null,
+      previewCalculating: false,
+      previewStarted: false
     }
   },
   async mounted () {
     await this.loadState()
+    await this.fetchPreviewCount()
+    this.countInterval = setInterval(() => {
+      this.fetchPreviewCount()
+    }, 10000)
+  },
+  beforeDestroy () {
+    this.stopTimer()
+    if (this.countInterval) {
+      clearInterval(this.countInterval)
+      this.countInterval = null
+    }
   },
   computed: {
     generatingPreview () {
@@ -112,6 +142,30 @@ export default {
     },
     previewFn () {
       return this.$store.state.optionsPreviews.previewFn
+    },
+    previewError () {
+      return this.$store.state.optionsPreviews.previewError
+    },
+    previewElapsed () {
+      return this.$store.state.optionsPreviews.previewElapsed
+    },
+    isGenerating () {
+      return this.generatingPreview || this.$store.state.messages.lockPreview
+    },
+    previewTimer () {
+      const total = this.previewElapsed
+      const m = Math.floor(total / 60).toString().padStart(2, '0')
+      const s = (total % 60).toString().padStart(2, '0')
+      return `${m}:${s}`
+    }
+  },
+  watch: {
+    generatingPreview (newVal, oldVal) {
+      if (newVal && !oldVal) {
+        this.startTimer()
+      } else if (!newVal && oldVal) {
+        this.stopTimer()
+      }
     }
   },
   methods: {
@@ -120,11 +174,12 @@ export default {
       await ky.get('/api/options/state')
         .json()
         .then(data => {
-          this.startTime = data.config.library.preview.startTime
           this.snippetLength = data.config.library.preview.snippetLength
           this.snippetAmount = data.config.library.preview.snippetAmount
           this.resolution = data.config.library.preview.resolution
           this.extraSnippet = data.config.library.preview.extraSnippet
+          this.useCUDA = data.config.library.preview.useCUDA !== false
+          this.pitch = data.config.library.preview.pitch !== undefined ? data.config.library.preview.pitch : 15
           this.isLoading = false
         })
     },
@@ -132,11 +187,12 @@ export default {
       this.isLoading = true
       await ky.put('/api/options/previews', {
         json: {
-          startTime: this.startTime,
           snippetLength: this.snippetLength,
           snippetAmount: this.snippetAmount,
           resolution: this.resolution,
-          extraSnippet: this.extraSnippet
+          extraSnippet: this.extraSnippet,
+          useCUDA: this.useCUDA,
+          pitch: this.pitch
         }
       })
         .json()
@@ -148,16 +204,55 @@ export default {
       this.$store.commit('optionsPreviews/hidePreview')
       await ky.post('/api/options/previews/test', {
         json: {
-          startTime: this.startTime,
           snippetLength: this.snippetLength,
           snippetAmount: this.snippetAmount,
           resolution: this.resolution,
-          extraSnippet: this.extraSnippet
+          extraSnippet: this.extraSnippet,
+          useCUDA: this.useCUDA,
+          pitch: this.pitch
         }
       })
     },
+    async fetchPreviewCount (setTotal = false) {
+      try {
+        const data = await ky.get('/api/task/preview/count').json()
+        this.previewLeft = data.left
+        if (setTotal) {
+          this.previewTotal = data.total
+        }
+      } catch (e) {
+        // ignore
+      }
+    },
     async startGenerating () {
+      this.previewStarted = true
+      this.previewCalculating = true
+      this.previewLeft = null
+      this.previewTotal = null
       await ky.get('/api/task/preview/generate')
+      await this.fetchPreviewCount(true)
+      this.previewCalculating = false
+    },
+    async stopPreview () {
+      await ky.get('/api/task/preview/stop')
+    },
+    async clearTestPreview () {
+      await ky.delete('/api/options/previews/test')
+      this.stopTimer()
+      this.$store.commit('optionsPreviews/clearPreview')
+    },
+    startTimer () {
+      this.stopTimer()
+      this.$store.commit('optionsPreviews/tickPreviewTimer')
+      this.timerInterval = setInterval(() => {
+        this.$store.commit('optionsPreviews/tickPreviewTimer')
+      }, 1000)
+    },
+    stopTimer () {
+      if (this.timerInterval) {
+        clearInterval(this.timerInterval)
+        this.timerInterval = null
+      }
     },
     prettyBytes
   }
@@ -182,5 +277,13 @@ export default {
     content: '';
     display: block;
     padding-bottom: 100%;
+  }
+
+  .timer {
+    text-align: center;
+    font-size: 1.5em;
+    font-weight: bold;
+    margin-top: 0.5em;
+    font-family: monospace;
   }
 </style>

--- a/ui/src/views/scenes/Details.vue
+++ b/ui/src/views/scenes/Details.vue
@@ -148,15 +148,11 @@
               <div v-for="(image, idx) in castimages" :key="idx" class="image-wrapper">
                 <b-tooltip  type="is-light" :label="image.actor_label"  :delay=100>
                   <vue-load-image>
-                    <img slot="image" :src="getImageURL(image.src)" alt="Image" class="thumbnail" @mouseover="showTooltip(idx)" @mouseout="hideTooltip(idx)" @click='showActorDetail([image.actor_id])' />
+                    <img slot="image" :src="getImageURL(image.src)" alt="Image" class="thumbnail" @click='showActorDetail([image.actor_id])' />
                     <img slot="preloader" :src="getImageURL('https://i.stack.imgur.com/kOnzy.gif')" style="height: 50px;display: block;margin-left:auto;margin-right: auto;" @click='showCastScenes([image.actor_name])' />
                     <img slot="error" src="/ui/images/blank_female_profile.png" width="80" @click='showActorDetail([image.actor_id])' />
                   </vue-load-image>
                 </b-tooltip>
-
-                <div v-if="image.visible" class="tooltip">
-                  <img :src="getImageURL(image.src)" alt="Tooltip Image" />
-                </div>
               </div>
             </div>
 
@@ -266,6 +262,9 @@
                       <div class="media-right">
                         <button class="button is-dark is-small is-outlined" title="Unmatch file from scene" @click='unmatchFile(f)'>
                           <b-icon pack="fas" icon="unlink" size="is-small"></b-icon>
+                        </button>&nbsp;
+                        <button class="button is-warning is-small is-outlined" title="Clear preview" @click='clearPreview' v-if="idx === 0">
+                          <b-icon pack="fas" icon="eraser" size="is-small"></b-icon>
                         </button>&nbsp;
                         <button class="button is-danger is-small is-outlined" title="Delete file from disk" @click='removeFile(f)'>
                           <b-icon pack="fas" icon="trash" size="is-small"></b-icon>
@@ -826,10 +825,34 @@ watch:{
         message: `You're about to unmatch the file <strong>${file.filename}</strong> from this scene. Afterwards, it can be matched again to this or any other scene.`,
         type: 'is-info is-wide',
         hasIcon: true,
+        customClass: 'modal-warning',
         id: 'heh',
         onConfirm: () => {
           ky.post(`/api/files/unmatch`, {json:{file_id: file.id}}).json().then(data => {
             this.$store.commit('overlay/showDetails', { scene: data })
+          })
+        }
+      })
+    },
+    clearPreview () {
+      this.$buefy.dialog.confirm({
+        title: 'Clear preview',
+        message: `You're about to clear the video preview for this scene. The preview will be regenerated the next time previews are generated.`,
+        type: 'is-warning is-wide',
+        hasIcon: true,
+        customClass: 'modal-warning',
+        onConfirm: () => {
+          ky.post(`/api/scene/${this.item.scene_id}/clear-preview`, { json: {} }).json().then(data => {
+            this.$store.commit('overlay/showDetails', { scene: data })
+            this.$buefy.toast.open({
+              message: 'Preview cleared',
+              type: 'is-success'
+            })
+          }).catch(err => {
+            this.$buefy.toast.open({
+              message: `Failed to clear preview: ${err}`,
+              type: 'is-danger'
+            })
           })
         }
       })
@@ -1242,10 +1265,6 @@ watch:{
   left: 50% !important;
   top: 50% !important;
   transform: translate(-50%, -50%) !important;
-}
-
-.modal-card {
-  width: 85%;
 }
 
 .missing {

--- a/ui/src/views/scenes/EditScene.vue
+++ b/ui/src/views/scenes/EditScene.vue
@@ -10,7 +10,7 @@
     <div class="modal-card">
       <header class="modal-card-head">
         <p class="modal-card-title">{{ this.scene.id == 0 ? $t('Display scene details') : $t('Edit scene details') }}</p>
-        <button class="delete" @click="close" aria-label="close"></button>
+        <button class="modal-close is-large" @click="close" aria-label="close"></button>
       </header>
 
       <section class="modal-card-body">

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -6,9 +6,9 @@
            @click="showDetails(item)"
            @mouseover="preview = true"
            @mouseleave="preview = false">
-        <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}`" autoplay loop></video>
+        <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}?t=${Date.now()}`" :style="{objectFit: sceneCardScale}" autoplay loop muted></video>
         <div class="overlay align-bottom-left">
-          <div style="padding: 5px">
+          <div style="padding: 2px">
             <b-tag v-if="item.is_watched && !this.$store.state.optionsWeb.web.sceneWatched">
               <b-icon pack="mdi" icon="eye" size="is-small"/>
             </b-tag>
@@ -60,12 +60,12 @@
       <wishlist-button v-if="this.$store.state.optionsWeb.web.sceneWishlist && !item.is_available" :item="item"/>
       <watched-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneWatched"/>
       <edit-button :item="item" v-if="this.$store.state.optionsWeb.web.sceneEdit" />
-      <link-stashdb-button :item="item" v-if="!this.stashLinkExists" objectType="scene"/>
+      <link-stashdb-button :item="item" v-if="this.$store.state.optionsWeb.web.showStashdbLink && !this.stashLinkExists" objectType="scene"/>
 
       <span class="is-pulled-right" style="font-size:11px;text-align:right;">
         <a v-if="item.members_url != ''" :href="item.members_url" target="_blank" title="Members Link" rel="noreferrer"><b-icon pack="mdi" icon="link-lock" custom-size="mdi-18px" style="height:0.7rem"/></a>
         <a :href="item.scene_url" :class="{'has-text-white has-background-primary-dark': item.is_subscribed }" target="_blank" rel="noreferrer" style="padding:2px">{{item.site}}</a><br/>
-        <span v-if="item.release_date !== '0001-01-01T00:00:00Z'">
+        <span v-if="item.release_date !== '0001-01-01T00:00:00Z' && this.$store.state.optionsWeb.web.sceneDate">
           {{format(parseISO(item.release_date), "yyyy-MM-dd")}}
         </span>        
       </span>
@@ -278,7 +278,6 @@ export default {
   }
 
   video {
-    object-fit: cover;
     position: absolute;
     width: 100%;
     height: 100%;

--- a/ui/src/views/scenes/Scenes.vue
+++ b/ui/src/views/scenes/Scenes.vue
@@ -49,16 +49,8 @@ export default {
       toggleBtn.style.display = show ? 'block' : 'none'
     })
     toTop.addEventListener('click', function () {
-      scrollToTop()
+      window.scrollTo({ top: 0, behavior: 'smooth' })
     })
-
-    const scrollToTop = () => {
-      const c = document.documentElement.scrollTop || document.body.scrollTop
-      if (c > 0) {
-        window.requestAnimationFrame(scrollToTop)
-        window.scrollTo(0, c - c / 16)
-      }
-    }
   },
   beforeRouteEnter (to, from, next) {
     next(vm => {
@@ -83,11 +75,12 @@ export default {
 <style scoped>
   #scrollButtons {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 8px;
     position: fixed;
     bottom: 20px;
     left: 30px;
-    width: 18.5%;
+    z-index: 1000;
   }
   #toTop, #toggleInfiniteScroll {
     display: none;
@@ -96,7 +89,8 @@ export default {
     padding: 15px;
     border-radius: 10px;
     font-size: 18px;
-    margin-right: 8px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
   }
   #toTop:hover, #toggleInfiniteScroll:hover {
     background-color: #BDBDBD;


### PR DESCRIPTION
…themes, use local covers

refactor(preview): overhaul VR preview generation pipeline

- Speed: downscale input (scale=1600:-2) before heavy v360 filter; generation time reduced from ~1.5 min to ~30 sec.
- GPU acceleration: use CUDA/NVENC and v360_vulkan for VR180 dewarp; fall back to CPU v360/scale_cuda for unsupported inputs and 10-bit content.
- 10-bit stability: convert 10-bit to 8-bit before v360 and h264_nvenc to prevent OOM/crash on 8K VR.
- Parallelism: limit preview workers to 2 and cap each FFmpeg process at -threads 4 to avoid RAM exhaustion.
- Fast-seek: apply -noaccurate_seek + setpts=PTS-STARTPTS; retry empty snippets with accurate seek; validate snippet sizes before concat.
- Timestamp logic: build a 14-snippet grid inside a safe window (60 sec offset from start, ignore last 20 sec of video).
- UI: remove the redundant StartTime setting (hardcoded to 60 sec).
- Quality: fix CUDA chroma ghosting (yuv444p), reduce dewarp tilt from 20° to 15°, add NVENC rate control, log snippet sizes, use unique tmp dirs.

fix(ui): implement and restore dark/light theme switching

- Add full dark theme and derive light theme from it.
- Fix regression where the UI got stuck in dark mode and the light theme broke.
- Switch themes via a single data-theme attribute and one dynamic stylesheet.
- Ensure theme CSS is always the last element in <head> so it overrides webpack-injected Bulma defaults; add cache-buster.
- Restore manual fixes: danger color #f14668, transparent active tab border, #ba4f17 pagination current, scroll button styling.

feat(covers): serve local cover images for DeoVR

- Use local cover images for DeoVR responses.
- Auto-resolve relative cover URLs to the connection host.
- Serve myfiles with http.ServeContent for Range/conditional requests.
- Add explicit MIME type map for Windows where the registry returns empty Content-Type.
- Add Windows CI build for the tray binary.