### PR TITLE
fix: match files to scenes whose titles contain apostrophes

### DIFF
--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -673,7 +673,12 @@ func (i SceneResource) searchSceneIndex(req *restful.Request, resp *restful.Resp
 	}
 
 	defer idx.Bleve.Close()
-	query := bleve.NewQueryStringQuery(q)
+	// The index analyzer splits on apostrophes ("Sister's" -> "sister", "s"), so a query
+	// keeping the apostrophe ("Sister's") or dropping it ("Sisters") never lines up with
+	// the indexed terms. Normalising apostrophes to spaces ("Sister s") matches how titles
+	// are tokenised, which is what filename-derived match queries need.
+	bleveQuery := strings.NewReplacer("'", " ", "’", " ", "`", " ").Replace(q)
+	query := bleve.NewQueryStringQuery(bleveQuery)
 
 	searchRequest := bleve.NewSearchRequest(query)
 	searchRequest.Fields = []string{"Id", "title", "cast", "site", "description"}

--- a/ui/src/views/files/SceneMatch.vue
+++ b/ui/src/views/files/SceneMatch.vue
@@ -151,9 +151,8 @@ export default {
       this.data = []
       this.queryString = (
         this.file.filename
-          .replace(/\.|_|\+|-/g, ' ').replace(/\s+/g, ' ').trim()
-          .split(' ').filter(isNotCommonWord).join(' ')
-          .replace(/ s /g, '\'s '))
+          .replace(/[._+'’`-]/g, ' ').replace(/\s+/g, ' ').trim()
+          .split(' ').filter(isNotCommonWord).join(' '))
       this.loadData()
     },
     loadData: async function loadData () {


### PR DESCRIPTION
When matching an unmatched file to a scene, filenames containing apostrophes never scored well against scene titles that have them.

The title index analyzer splits on apostrophes, so a possessive like `Foo's` is stored as two tokens (`foo` + `s`). A query that keeps the apostrophe (`Foo's`) or drops it to a single word (`Foos`) never lines up with those tokens, whereas `Foo s` (apostrophe → space) matches exactly.

Fix: normalize apostrophes (straight `'`, curly `’`, backtick) to spaces before building the bleve query — this helps the match box, quick search, and manual search alike. The match-box query builder is also updated to turn apostrophes into spaces, and drops an old `" s " → "'s "` reconstruction that was adding apostrophes that hurt matching.