### PR TITLE
fix: clear stale derived fields when a scene has no files

### DIFF
--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -376,8 +376,18 @@ func (o *Scene) UpdateStatus() {
 			changed = true
 		}
 	} else {
+		if o.TotalFileSize != 0 {
+			o.TotalFileSize = 0
+			changed = true
+		}
+
 		if o.IsAvailable {
 			o.IsAvailable = false
+			changed = true
+		}
+
+		if o.IsAccessible {
+			o.IsAccessible = false
 			changed = true
 		}
 


### PR DESCRIPTION
`Scene.UpdateStatus`'s no-files branch never resets `total_file_size` or `is_accessible`, so a scene keeps reporting a size and accessibility after all its files are removed.