### PR TITLE
fix: reset tag and actor scene counts when they reach zero

### DIFF
--- a/pkg/models/model_actor.go
+++ b/pkg/models/model_actor.go
@@ -130,10 +130,10 @@ func (i *Actor) CountActorTags() {
 	var results []CountResults
 
 	commonDb.Model(&Actor{}).
-		Select("actors.id, count as existingcnt, count(*) cnt, sum(scenes.is_available ) is_available, avail_count as existingavail").
+		Select("actors.id, actors.count as existingcnt, count(scenes.id) cnt, coalesce(sum(scenes.is_available), 0) is_available, actors.avail_count as existingavail").
 		Group("actors.id").
-		Joins("join scene_cast on scene_cast.actor_id = actors.id").
-		Joins("join scenes on scenes.id=scene_cast.scene_id and scenes.deleted_at is null").
+		Joins("left join scene_cast on scene_cast.actor_id = actors.id").
+		Joins("left join scenes on scenes.id=scene_cast.scene_id and scenes.deleted_at is null").
 		Scan(&results)
 
 	for i := range results {

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -327,10 +327,10 @@ func (i *Tag) CountTags() {
 
 	var results []CountResults
 	db.Model(&Tag{}).
-		Select("tags.id, count as existingcnt, count(*) cnt").
+		Select("tags.id, tags.count as existingcnt, count(scenes.id) cnt").
 		Group("tags.id").
-		Joins("join scene_tags on scene_tags.tag_id = tags.id").
-		Joins("join scenes on scenes.id=scene_tags.scene_id and scenes.deleted_at is null").
+		Joins("left join scene_tags on scene_tags.tag_id = tags.id").
+		Joins("left join scenes on scenes.id=scene_tags.scene_id and scenes.deleted_at is null").
 		Scan(&results)
 
 	for i := range results {


### PR DESCRIPTION
`CountTags`/`CountActorTags` recompute cached counts with inner joins, so a tag or actor whose linked scenes all go away produces no result row and its stale `count`/`avail_count` is never reset — it sticks at the last non-zero value. Switching to left joins recomputes every tag/actor, so counts correctly fall to zero.