### PR TITLE
fix: RealJamVR and PornCornVR scrapers

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -20,7 +20,7 @@ import (
 
 var log = &common.Log
 
-var UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36"
+var UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
 
 func createCollector(domains ...string) *colly.Collector {
 	c := colly.NewCollector(


### PR DESCRIPTION
Old Chrome version in user agent resulted in 403 Forbidden errors.