### PR TITLE
feat: add promoted tag badges, filter, and HereSphere thumbnails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.etcd.io/bbolt v1.4.0 // indirect
-	golang.org/x/image v0.38.0 // indirect
+	golang.org/x/image v0.38.0
 	golang.org/x/term v0.42.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/pkg/api/heresphere.go
+++ b/pkg/api/heresphere.go
@@ -700,9 +700,10 @@ func (i HeresphereResource) getHeresphereScene(req *restful.Request, resp *restf
 
 	if scene.IsScripted {
 		title = scene.GetFunscriptTitle()
-		if config.Config.Interfaces.DeoVR.RenderHeatmaps {
-			thumbnailURL = getProto(req) + "://" + req.Request.Host + "/imghm/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
-		}
+	}
+
+	if (scene.IsScripted && config.Config.Interfaces.DeoVR.RenderHeatmaps) || scene.HasPromotedTags() {
+		thumbnailURL = getProto(req) + "://" + req.Request.Host + "/imghs/" + fmt.Sprint(scene.ID) + "/" + strings.Replace(scene.CoverURL, "://", ":/", -1)
 	}
 
 	if scene.Watchlist {

--- a/pkg/api/scenes.go
+++ b/pkg/api/scenes.go
@@ -400,6 +400,7 @@ func (i SceneResource) getFilters(req *restful.Request, resp *restful.Response) 
 	outAttributes = append(outAttributes, "Available from RealVR")
 	outAttributes = append(outAttributes, "Available from SLR")
 	outAttributes = append(outAttributes, "Multiple Scenes Available at an Alternate Site")
+	outAttributes = append(outAttributes, "Has Promoted Tag")
 	type Results struct {
 		Result string
 	}

--- a/pkg/api/tags.go
+++ b/pkg/api/tags.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	restfulspec "github.com/emicklei/go-restful-openapi/v2"
+	"github.com/emicklei/go-restful/v3"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+type ResponseGetTags struct {
+	Results int          `json:"results"`
+	Tags    []models.Tag `json:"tags"`
+}
+
+type RequestPromoteTag struct {
+	IsPromoted bool `json:"is_promoted"`
+}
+
+type TagResource struct{}
+
+func (i TagResource) WebService() *restful.WebService {
+	tags := []string{"Tag"}
+
+	ws := new(restful.WebService)
+
+	ws.Path("/api/tag").
+		Consumes(restful.MIME_JSON).
+		Produces(restful.MIME_JSON)
+
+	ws.Route(ws.GET("/list").To(i.getTagList).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(ResponseGetTags{}))
+
+	ws.Route(ws.POST("/promote/{tag-id}").To(i.promoteTag).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Writes(models.Tag{}))
+
+	return ws
+}
+
+func (i TagResource) getTagList(req *restful.Request, resp *restful.Response) {
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var tags []models.Tag
+	db.Model(&models.Tag{}).
+		Select("id, name, is_promoted").
+		Order("name").
+		Find(&tags)
+
+	type sceneCount struct {
+		TagID uint
+		Count int
+	}
+	var counts []sceneCount
+	db.Table("scenes").
+		Select("scene_tags.tag_id, count(*) as count").
+		Joins("join scene_tags on scene_tags.scene_id = scenes.id").
+		Where("scenes.deleted_at is null").
+		Group("scene_tags.tag_id").
+		Scan(&counts)
+
+	countMap := make(map[uint]int, len(counts))
+	for _, c := range counts {
+		countMap[c.TagID] = c.Count
+	}
+	for i := range tags {
+		tags[i].Count = countMap[tags[i].ID]
+	}
+
+	out := ResponseGetTags{
+		Results: len(tags),
+		Tags:    tags,
+	}
+	resp.WriteHeaderAndEntity(http.StatusOK, out)
+}
+
+func (i TagResource) promoteTag(req *restful.Request, resp *restful.Response) {
+	tagID, err := strconv.Atoi(req.PathParameter("tag-id"))
+	if err != nil {
+		resp.WriteHeaderAndEntity(http.StatusBadRequest, err)
+		return
+	}
+
+	var r RequestPromoteTag
+	err = req.ReadEntity(&r)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	db, _ := models.GetDB()
+	defer db.Close()
+
+	var tag models.Tag
+	if err := db.First(&tag, tagID).Error; err != nil {
+		resp.WriteHeaderAndEntity(http.StatusNotFound, err)
+		return
+	}
+
+	tag.IsPromoted = r.IsPromoted
+	if err := db.Save(&tag).Error; err != nil {
+		log.Error(err)
+		resp.WriteHeaderAndEntity(http.StatusInternalServerError, err)
+		return
+	}
+
+	resp.WriteHeaderAndEntity(http.StatusOK, tag)
+}

--- a/pkg/imgbadge/imgbadge.go
+++ b/pkg/imgbadge/imgbadge.go
@@ -1,0 +1,215 @@
+package imgbadge
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"sync"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/gobold"
+	"golang.org/x/image/font/opentype"
+	"golang.org/x/image/math/fixed"
+)
+
+const (
+	badgeHeight    = 36
+	badgePaddingX  = 15
+	badgeGap       = 9
+	badgeMargin    = 9
+	iconSize       = 15
+	iconGap        = 8
+	maxNamedBadges = 3
+	textSize       = 21.0
+)
+
+var (
+	fontFace font.Face
+	fontOnce sync.Once
+	fontErr  error
+)
+
+func face() (font.Face, error) {
+	fontOnce.Do(func() {
+		ttf, err := opentype.Parse(gobold.TTF)
+		if err != nil {
+			fontErr = err
+			return
+		}
+		fontFace, fontErr = opentype.NewFace(ttf, &opentype.FaceOptions{
+			Size:    textSize,
+			DPI:     72,
+			Hinting: font.HintingFull,
+		})
+	})
+	return fontFace, fontErr
+}
+
+func badgeWidth(f font.Face, s string) int {
+	return badgePaddingX*2 + iconSize + iconGap + font.MeasureString(f, s).Round()
+}
+
+func totalWidth(f font.Face, items []string) int {
+	total := 0
+	for _, s := range items {
+		total += badgeWidth(f, s)
+	}
+	total += badgeGap * (len(items) - 1)
+	return total
+}
+
+func truncateName(f font.Face, s string, maxW int) string {
+	if badgeWidth(f, s) <= maxW {
+		return s
+	}
+	runes := []rune(s)
+	for len(runes) > 0 {
+		cand := string(runes[:len(runes)-1]) + "…"
+		if badgeWidth(f, cand) <= maxW {
+			return cand
+		}
+		runes = runes[:len(runes)-1]
+	}
+	return "…"
+}
+
+func buildBadgeItems(tagNames []string, maxWidth int) ([]string, error) {
+	f, err := face()
+	if err != nil {
+		return nil, err
+	}
+	if len(tagNames) == 0 {
+		return []string{}, nil
+	}
+
+	names := tagNames
+	if len(names) > maxNamedBadges {
+		names = names[:maxNamedBadges]
+	}
+	more := len(tagNames) - len(names)
+
+	maxTotal := maxWidth - 2*badgeMargin
+
+	// Drop the last named badge (moving it into the overflow count) until
+	// the line fits. The overflow badge is tracked structurally via the
+	// `more` counter, never by matching "+" on the string, so a tag
+	// literally named "+x" cannot be confused with it. At least one named
+	// badge is always kept.
+	for len(names) > 1 {
+		width := totalWidth(f, names)
+		if more > 0 {
+			width += badgeGap + badgeWidth(f, fmt.Sprintf("+%d", more))
+		}
+		if width <= maxTotal {
+			break
+		}
+		names = names[:len(names)-1]
+		more++
+	}
+
+	// Reserve space for the overflow badge (short, must stay readable),
+	// then truncate the named badges to fit the space that remains.
+	reserved := 0
+	if more > 0 {
+		reserved = badgeGap + badgeWidth(f, fmt.Sprintf("+%d", more))
+	}
+	available := maxTotal - reserved
+	for i := range names {
+		if i > 0 {
+			available -= badgeGap
+		}
+		names[i] = truncateName(f, names[i], available)
+		available -= badgeWidth(f, names[i])
+	}
+
+	items := append([]string{}, names...)
+	if more > 0 {
+		items = append(items, fmt.Sprintf("+%d", more))
+	}
+	return items, nil
+}
+
+func fillCircle(img *image.NRGBA, cx, cy, r int, col color.RGBA) {
+	for dy := -r; dy <= r; dy++ {
+		for dx := -r; dx <= r; dx++ {
+			if dx*dx+dy*dy <= r*r {
+				img.Set(cx+dx, cy+dy, col)
+			}
+		}
+	}
+}
+
+func drawPill(img *image.NRGBA, x, y, w, h, r int, col color.RGBA) {
+	draw.Draw(img, image.Rect(x, y, x+w, y+h), image.NewUniform(col), image.Point{}, draw.Over)
+	fillCircle(img, x+r, y+r, r, col)
+	fillCircle(img, x+w-r, y+r, r, col)
+	fillCircle(img, x+r, y+h-r, r, col)
+	fillCircle(img, x+w-r, y+h-r, r, col)
+}
+
+// fillRightTriangle fills a right-pointing triangle: vertical edge at x=bx
+// from y0..y1, apex at (bx+tip, (y0+y1)/2).
+func fillRightTriangle(img *image.NRGBA, bx, y0, y1, tip int, col color.RGBA) {
+	cy := (y0 + y1) / 2
+	half := (y1 - y0) / 2
+	if half <= 0 || tip <= 0 {
+		return
+	}
+	for yy := y0; yy < y1; yy++ {
+		frac := float64(yy-cy) / float64(half)
+		if frac < 0 {
+			frac = -frac
+		}
+		w := int(float64(tip) * (1 - frac))
+		for xx := bx; xx < bx+w; xx++ {
+			img.Set(xx, yy, col)
+		}
+	}
+}
+
+// drawLabelIcon draws an MDI-style "label" icon: a rounded square body with a
+// triangular point on its right side, centered at cy, `size` px wide. The
+// body is 14/19 of the glyph width, matching the mdi-label proportions.
+func drawLabelIcon(img *image.NRGBA, x, cy, size int, col color.RGBA) {
+	body := size * 11 / 15
+	tip := size - body
+	y0 := cy - body/2
+	drawPill(img, x, y0, body, body, body/4, col)
+	fillRightTriangle(img, x+body, y0, y0+body, tip, col)
+}
+
+// DrawPromotedBadges draws one mauve pill badge per promoted tag name,
+// top-left on the canvas, capped at maxNamedBadges names plus a "+N"
+// overflow badge.
+func DrawPromotedBadges(canvas *image.NRGBA, tagNames []string) error {
+	f, err := face()
+	if err != nil {
+		return err
+	}
+	items, err := buildBadgeItems(tagNames, canvas.Bounds().Dx())
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	white := color.RGBA{255, 255, 255, 255}
+	mauve := color.RGBA{121, 87, 213, 255}
+
+	x := badgeMargin
+	y := badgeMargin
+	for _, s := range items {
+		w := badgeWidth(f, s)
+		drawPill(canvas, x, y, w, badgeHeight, badgeHeight/4, mauve)
+		drawLabelIcon(canvas, x+badgePaddingX, y+badgeHeight/2, iconSize, white)
+		d := &font.Drawer{Dst: canvas, Src: image.NewUniform(white), Face: f}
+		m := f.Metrics()
+		baseline := y + (badgeHeight-m.Ascent.Ceil()-m.Descent.Ceil())/2 + m.Ascent.Ceil()
+		d.Dot = fixed.P(x+badgePaddingX+iconSize+iconGap, baseline)
+		d.DrawString(s)
+		x += w + badgeGap
+	}
+	return nil
+}

--- a/pkg/imgbadge/imgbadge_test.go
+++ b/pkg/imgbadge/imgbadge_test.go
@@ -1,0 +1,185 @@
+package imgbadge
+
+import (
+	"image"
+	"image/color"
+	"image/draw"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func newCanvas() *image.NRGBA {
+	c := image.NewNRGBA(image.Rect(0, 0, 700, 420))
+	draw.Draw(c, c.Bounds(), image.NewUniform(color.Black), image.Point{}, draw.Src)
+	return c
+}
+
+func TestBuildBadgeItemsCapsAtThree(t *testing.T) {
+	items, err := buildBadgeItems([]string{"anal", "milf", "pov", "teen", "dp"}, 700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"anal", "milf", "pov", "+2"}
+	if len(items) != len(want) {
+		t.Fatalf("got %v, want %v", items, want)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Fatalf("got %v, want %v", items, want)
+		}
+	}
+}
+
+func TestBuildBadgeItemsNoOverflow(t *testing.T) {
+	items, err := buildBadgeItems([]string{"anal"}, 700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0] != "anal" {
+		t.Fatalf("got %v", items)
+	}
+}
+
+func TestBuildBadgeItemsEmpty(t *testing.T) {
+	items, err := buildBadgeItems(nil, 700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("got %v", items)
+	}
+}
+
+func TestBuildBadgeItemsTruncatesLongName(t *testing.T) {
+	long := strings.Repeat("x", 50)
+	items, err := buildBadgeItems([]string{long}, 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("got %v", items)
+	}
+	if !strings.HasSuffix(items[0], "…") {
+		t.Fatalf("expected ellipsis suffix, got %q", items[0])
+	}
+}
+
+func TestBuildBadgeItemsDropRecountsOverflow(t *testing.T) {
+	long := strings.Repeat("a", 30)
+	tags := []string{long, long, long, long, long}
+	items, err := buildBadgeItems(tags, 250)
+	if err != nil {
+		t.Fatal(err)
+	}
+	named := 0
+	overflow := 0
+	for _, it := range items {
+		if strings.HasPrefix(it, "+") {
+			n, err := strconv.Atoi(strings.TrimPrefix(it, "+"))
+			if err != nil {
+				t.Fatalf("bad overflow badge %q", it)
+			}
+			overflow = n
+		} else {
+			named++
+		}
+	}
+	if named+overflow != len(tags) {
+		t.Fatalf("named(%d)+overflow(%d)=%d, want %d", named, overflow, named+overflow, len(tags))
+	}
+}
+
+func TestBuildBadgeItemsPlusNamedTag(t *testing.T) {
+	count := func(tags, items []string) (named, overflow int) {
+		for _, it := range items {
+			isNamed := false
+			for _, tag := range tags {
+				if it == tag {
+					isNamed = true
+					break
+				}
+			}
+			if isNamed {
+				named++
+				continue
+			}
+			n, err := strconv.Atoi(strings.TrimPrefix(it, "+"))
+			if err != nil {
+				t.Fatalf("bad overflow badge %q", it)
+			}
+			overflow = n
+		}
+		return named, overflow
+	}
+
+	items, err := buildBadgeItems([]string{"+3", "anal"}, 700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"+3", "anal"}
+	if len(items) != len(want) {
+		t.Fatalf("got %v, want %v", items, want)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Fatalf("got %v, want %v", items, want)
+		}
+	}
+	named, overflow := count([]string{"+3", "anal"}, items)
+	if named != 2 || overflow != 0 {
+		t.Fatalf("literal \"+3\" must be drawn as a named badge, got %v", items)
+	}
+	if named+overflow != 2 {
+		t.Fatalf("named(%d)+overflow(%d)=%d, want %d", named, overflow, named+overflow, 2)
+	}
+
+	items, err = buildBadgeItems([]string{"+3", "anal", "pov", "milf"}, 700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []string{"+3", "anal", "pov", "+1"}
+	if len(items) != len(want) {
+		t.Fatalf("got %v, want %v", items, want)
+	}
+	for i := range want {
+		if items[i] != want[i] {
+			t.Fatalf("got %v, want %v", items, want)
+		}
+	}
+	named, overflow = count([]string{"+3", "anal", "pov", "milf"}, items)
+	if named != 3 || overflow != 1 {
+		t.Fatalf("got %v, want 3 named badges + a separate \"+1\" overflow badge", items)
+	}
+	if named+overflow != 4 {
+		t.Fatalf("named(%d)+overflow(%d)=%d, want %d", named, overflow, named+overflow, 4)
+	}
+}
+
+func TestDrawPromotedBadgesPaintsTopLeft(t *testing.T) {
+	c := newCanvas()
+	err := DrawPromotedBadges(c, []string{"anal"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	col := c.NRGBAAt(50, 12)
+	if col.R == 0 && col.G == 0 && col.B == 0 {
+		t.Fatal("expected non-black pixel in top-left badge area")
+	}
+	col = c.NRGBAAt(350, 415)
+	if col.R != 0 || col.G != 0 || col.B != 0 {
+		t.Fatal("expected bottom of canvas untouched")
+	}
+}
+
+func TestDrawPromotedBadgesNoTags(t *testing.T) {
+	c := newCanvas()
+	err := DrawPromotedBadges(c, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	col := c.NRGBAAt(50, 12)
+	if col.R != 0 || col.G != 0 || col.B != 0 {
+		t.Fatal("expected canvas untouched when no promoted tags")
+	}
+}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -847,6 +847,23 @@ func Migrate(migrateTo string) {
 				return tx.AutoMigrate(File{}).Error
 			},
 		},
+		{
+			ID: "0088-tag-is-promoted",
+			Migrate: func(tx *gorm.DB) error {
+				type Tag struct {
+					IsPromoted bool
+				}
+				return tx.AutoMigrate(Tag{}).Error
+			},
+		},
+		{
+			ID: "0089-add-scene-tags-tag-id-index",
+			Migrate: func(tx *gorm.DB) error {
+				// Add index on tag_id to improve tag scene count query performance
+				// This prevents timeout on Options Tags page for users with large databases
+				return tx.Table("scene_tags").AddIndex("idx_scene_tags_tag_id", "tag_id").Error
+			},
+		},
 
 		// ===============================================================================================
 		// Put DB Schema migrations above this line and migrations that rely on the updated schema below

--- a/pkg/models/model_scene.go
+++ b/pkg/models/model_scene.go
@@ -191,6 +191,15 @@ func (o *Scene) GetIfExistByPK(id uint) error {
 		Where(&Scene{ID: id}).First(o).Error
 }
 
+func (s *Scene) HasPromotedTags() bool {
+	for i := range s.Tags {
+		if s.Tags[i].IsPromoted {
+			return true
+		}
+	}
+	return false
+}
+
 func (o *Scene) GetIfExistURL(u string) error {
 	commonDb, _ := GetCommonDB()
 
@@ -979,6 +988,8 @@ func queryScenes(db *gorm.DB, r RequestSceneList) (*gorm.DB, *gorm.DB) {
 			where = "exists (select 1 from external_reference_links where external_source like 'alternate scene %' and internal_db_id = scenes.id)"
 		case "Multiple Scenes Available at an Alternate Site":
 			where = "exists (select 1 from external_reference_links where external_source like 'alternate scene %' and internal_db_id = scenes.id  group by external_source having count(*)>1)"
+		case "Has Promoted Tag":
+			where = "exists (select 1 from scene_tags join tags on tags.id = scene_tags.tag_id where scene_tags.scene_id = scenes.id and tags.is_promoted = 1)"
 		}
 
 		if negate {

--- a/pkg/models/model_tag.go
+++ b/pkg/models/model_tag.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Tag struct {
-	ID     uint    `gorm:"primary_key" json:"id" xbvrbackup:"-"`
-	Scenes []Scene `gorm:"many2many:scene_tags;" json:"scenes" xbvrbackup:"-"`
-	Name   string  `gorm:"index" json:"name" xbvrbackup:"name"`
-	Clean  string  `gorm:"index" json:"clean" xbvrbackup:"-"`
-	Count  int     `json:"count" xbvrbackup:"-"`
+	ID         uint    `gorm:"primary_key" json:"id" xbvrbackup:"-"`
+	Scenes     []Scene `gorm:"many2many:scene_tags;" json:"scenes" xbvrbackup:"-"`
+	Name       string  `gorm:"index" json:"name" xbvrbackup:"name"`
+	Clean      string  `gorm:"index" json:"clean" xbvrbackup:"-"`
+	Count      int     `json:"count" xbvrbackup:"-"`
+	IsPromoted bool    `json:"is_promoted" gorm:"default:false" xbvrbackup:"is_promoted"`
 }
 
 func (t *Tag) Save() error {

--- a/pkg/server/herespherethumbnailproxy.go
+++ b/pkg/server/herespherethumbnailproxy.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"image"
 	"image/draw"
 	"image/jpeg"
@@ -18,6 +19,7 @@ import (
 	"github.com/disintegration/imaging"
 	"github.com/xbapps/xbvr/pkg/common"
 	"github.com/xbapps/xbvr/pkg/config"
+	"github.com/xbapps/xbvr/pkg/imgbadge"
 	"github.com/xbapps/xbvr/pkg/models"
 	"willnorris.com/go/imageproxy"
 )
@@ -29,9 +31,8 @@ const heatmapMargin = 3
 const maximumHeatmaps = 20 // maximumHeatmaps*(heatmapHeight+heatmapMargin) needs to be lower than thumbnailHeight
 
 type BufferResponseWriter struct {
-	header     http.Header
-	statusCode int
-	buf        *bytes.Buffer
+	header http.Header
+	buf    *bytes.Buffer
 }
 
 func (myrw *BufferResponseWriter) Write(p []byte) (int, error) {
@@ -42,44 +43,19 @@ func (w *BufferResponseWriter) Header() http.Header {
 	return w.header
 }
 
-func (w *BufferResponseWriter) WriteHeader(statusCode int) {
-	w.statusCode = statusCode
-}
+func (w *BufferResponseWriter) WriteHeader(statusCode int) {}
 
-type HeatmapThumbnailProxy struct {
+type HereSphereThumbnailProxy struct {
 	ImageProxy *imageproxy.Proxy
 	Cache      imageproxy.Cache
 }
 
-func NewHeatmapThumbnailProxy(imageproxy *imageproxy.Proxy, cache imageproxy.Cache) *HeatmapThumbnailProxy {
-	proxy := &HeatmapThumbnailProxy{
+func NewHereSphereThumbnailProxy(imageproxy *imageproxy.Proxy, cache imageproxy.Cache) *HereSphereThumbnailProxy {
+	proxy := &HereSphereThumbnailProxy{
 		ImageProxy: imageproxy,
 		Cache:      cache,
 	}
 	return proxy
-}
-
-func getScriptFiles(urlpart string) ([]models.File, error) {
-	sceneId, err := strconv.Atoi(urlpart)
-	files := make([]models.File, 0)
-	if err != nil {
-		return files, err
-	}
-
-	var scene models.Scene
-	err = scene.GetIfExistByPK(uint(sceneId))
-	if err != nil {
-		return files, err
-	}
-
-	scriptfiles, err := scene.GetScriptFilesSorted(config.Config.Interfaces.Players.ScriptSortSeq)
-	if err != nil || len(scriptfiles) < 1 {
-		return files, fmt.Errorf("scene %d has no script files", sceneId)
-	}
-
-	files = append(files, scriptfiles...)
-
-	return files, nil
 }
 
 func getHeatmapImageForScene(fileId uint) (image.Image, error) {
@@ -99,7 +75,25 @@ func getHeatmapImageForScene(fileId uint) (image.Image, error) {
 	return heatmapImage, nil
 }
 
-func createHeatmapThumbnail(out *bytes.Buffer, r io.Reader, heatmapImages []image.Image) error {
+func promotedTagHash(tagNames []string) uint32 {
+	h := fnv.New32a()
+	for _, name := range tagNames {
+		h.Write([]byte(name))
+		h.Write([]byte{0})
+	}
+	return h.Sum32()
+}
+
+func fileIDHash(files []models.File) uint32 {
+	h := fnv.New32a()
+	for _, f := range files {
+		h.Write([]byte(strconv.FormatUint(uint64(f.ID), 10)))
+		h.Write([]byte{0})
+	}
+	return h.Sum32()
+}
+
+func createHereSphereThumbnail(out *bytes.Buffer, r io.Reader, heatmapImages []image.Image, promotedTagNames []string) error {
 	thumbnailImage, err := jpeg.Decode(r)
 
 	if err != nil {
@@ -107,6 +101,7 @@ func createHeatmapThumbnail(out *bytes.Buffer, r io.Reader, heatmapImages []imag
 	}
 
 	heatmapsHeight := len(heatmapImages) * (heatmapHeight + heatmapMargin)
+
 	rect := thumbnailImage.Bounds()
 	if rect.Dx() != thumbnailWidth || rect.Dy() != thumbnailHeight-heatmapsHeight {
 		thumbnailImage = imaging.Fill(thumbnailImage, thumbnailWidth, thumbnailHeight-heatmapsHeight, imaging.Center, imaging.Linear)
@@ -124,21 +119,33 @@ func createHeatmapThumbnail(out *bytes.Buffer, r io.Reader, heatmapImages []imag
 		draw.Draw(canvas, drawRect, heatmapImage, image.Point{}, draw.Over)
 	}
 
+	if len(promotedTagNames) > 0 {
+		if err := imgbadge.DrawPromotedBadges(canvas, promotedTagNames); err != nil {
+			return err
+		}
+	}
+
 	jpeg.Encode(out, canvas, &jpeg.Options{Quality: 90})
 	return nil
 }
 
-func (p *HeatmapThumbnailProxy) serveImageproxyResponse(w http.ResponseWriter, r *http.Request, imageURL string) {
-	proxyURL := "/700x/" + imageURL
+// requestWithPath returns a shallow copy of r whose URL.Path is replaced with
+// path, so the imageproxy can be handed a rewritten request without mutating
+// the original.
+func requestWithPath(r *http.Request, path string) *http.Request {
 	r2 := new(http.Request)
 	*r2 = *r
 	r2.URL = new(url.URL)
 	*r2.URL = *r.URL
-	r2.URL.Path = proxyURL
-	p.ImageProxy.ServeHTTP(w, r2)
+	r2.URL.Path = path
+	return r2
 }
 
-func (p *HeatmapThumbnailProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (p *HereSphereThumbnailProxy) serveImageproxyResponse(w http.ResponseWriter, r *http.Request, imageURL string) {
+	p.ImageProxy.ServeHTTP(w, requestWithPath(r, "/700x/"+imageURL))
+}
+
+func (p *HereSphereThumbnailProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	parts := strings.SplitN(r.URL.Path, "/", 3)
 	if len(parts) != 3 {
@@ -147,22 +154,57 @@ func (p *HeatmapThumbnailProxy) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	imageURL := parts[2]
-	files, err := getScriptFiles(parts[1])
+	sceneID, err := strconv.Atoi(parts[1])
 	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var scene models.Scene
+	if err := scene.GetIfExistByPK(uint(sceneID)); err != nil {
 		p.serveImageproxyResponse(w, r, imageURL)
 		return
 	}
 
+	promotedTagNames := make([]string, 0)
+	for i := range scene.Tags {
+		if scene.Tags[i].IsPromoted {
+			promotedTagNames = append(promotedTagNames, scene.Tags[i].Name)
+		}
+	}
+
+	scriptfiles, err := scene.GetScriptFilesSorted(config.Config.Interfaces.Players.ScriptSortSeq)
+	if err != nil {
+		scriptfiles = nil
+	}
+
+	heatmapImages := make([]image.Image, 0)
+
+	for i := range scriptfiles {
+		heatmapImage, err := getHeatmapImageForScene(scriptfiles[i].ID)
+		if err == nil {
+			heatmapImages = append(heatmapImages, heatmapImage)
+			if len(heatmapImages) == maximumHeatmaps {
+				break
+			}
+		}
+	}
+
+	if len(heatmapImages) == 0 && len(promotedTagNames) == 0 {
+		p.serveImageproxyResponse(w, r, imageURL)
+		return
+	}
+
+	cacheKey := fmt.Sprintf("%d:%x:%x:%s", scene.ID, promotedTagHash(promotedTagNames), fileIDHash(scriptfiles), imageURL)
+
 	loadFromCache := true
 
-	for i := range files {
-		if files[i].RefreshHeatmapCache {
+	for i := range scriptfiles {
+		if scriptfiles[i].RefreshHeatmapCache {
 			loadFromCache = false
 			break
 		}
 	}
-
-	cacheKey := fmt.Sprintf("%d:%s", files[0].ID, imageURL)
 
 	if loadFromCache {
 		cachedContent, ok := p.Cache.Get(cacheKey)
@@ -176,61 +218,37 @@ func (p *HeatmapThumbnailProxy) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	heatmapImages := make([]image.Image, 0)
-
-	for i := range files {
-		heatmapImage, err := getHeatmapImageForScene(files[i].ID)
-		if err == nil {
-			heatmapImages = append(heatmapImages, heatmapImage)
-			if len(heatmapImages) == maximumHeatmaps {
-				break
-			}
+	if len(heatmapImages) > 0 {
+		for i := range scriptfiles {
+			file := scriptfiles[i]
+			file.RefreshHeatmapCache = false
+			file.Save()
 		}
-	}
-
-	if len(heatmapImages) == 0 {
-		p.serveImageproxyResponse(w, r, imageURL)
-		return
-	}
-
-	for i := range files {
-		file := files[i]
-		file.RefreshHeatmapCache = false
-		file.Save()
 	}
 
 	heatmapsHeight := len(heatmapImages) * (heatmapHeight + heatmapMargin)
 	proxyURL := fmt.Sprintf("/%dx%d,jpeg/%s", thumbnailWidth, thumbnailHeight-heatmapsHeight, imageURL)
-	r2 := new(http.Request)
-	*r2 = *r
-	r2.URL = new(url.URL)
-	*r2.URL = *r.URL
-	r2.URL.Path = proxyURL
 	imageproxyResponseWriter := &BufferResponseWriter{
 		header: http.Header{},
 		buf:    &bytes.Buffer{},
 	}
-	p.ImageProxy.ServeHTTP(imageproxyResponseWriter, r2)
+	p.ImageProxy.ServeHTTP(imageproxyResponseWriter, requestWithPath(r, proxyURL))
 
-	respbody, err := io.ReadAll(imageproxyResponseWriter.buf)
-	if err == nil {
-		var output bytes.Buffer
-		err = createHeatmapThumbnail(&output, bytes.NewReader(respbody), heatmapImages)
-		if err == nil {
-			p.Cache.Set(cacheKey, output.Bytes())
-			w.Header().Add("Content-Type", "image/jpeg")
-			w.Header().Add("Content-Length", fmt.Sprint(len(output.Bytes())))
-			if _, err := io.Copy(w, bytes.NewReader(output.Bytes())); err != nil {
-				log.Printf("Failed to send out response: %v", err)
-			}
-			return
-		}
-	}
+	respbody := imageproxyResponseWriter.buf.Bytes()
+
+	var output bytes.Buffer
+	err = createHereSphereThumbnail(&output, bytes.NewReader(respbody), heatmapImages, promotedTagNames)
 	if err != nil {
 		log.Printf("%v", err)
-		// serve original response
 		if _, err := io.Copy(w, bytes.NewReader(respbody)); err != nil {
 			log.Printf("Failed to send out response: %v", err)
 		}
+		return
+	}
+	p.Cache.Set(cacheKey, output.Bytes())
+	w.Header().Add("Content-Type", "image/jpeg")
+	w.Header().Add("Content-Length", fmt.Sprint(len(output.Bytes())))
+	if _, err := io.Copy(w, bytes.NewReader(output.Bytes())); err != nil {
+		log.Printf("Failed to send out response: %v", err)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -94,6 +94,7 @@ func StartServer(version, commit, branch, date string) {
 	restful.Add(api.PlaylistResource{}.WebService())
 	restful.Add(api.AkaResource{}.WebService())
 	restful.Add(api.TagGroupResource{}.WebService())
+	restful.Add(api.TagResource{}.WebService())
 	restful.Add(api.ExternalReference{}.WebService())
 
 	restConfig := restfulspec.Config{
@@ -149,7 +150,8 @@ func StartServer(version, commit, branch, date string) {
 	u, _ := url.Parse("http://127.0.0.1:" + strconv.Itoa(config.Config.Server.Port))
 	p.DefaultBaseURL = u
 	r.PathPrefix("/img/").Handler(ForceShortCacheHandler(http.StripPrefix("/img", p)))
-	hmp := NewHeatmapThumbnailProxy(p, diskCache(filepath.Join(common.AppDir, "heatmapthumbnailproxy")))
+	hmp := NewHereSphereThumbnailProxy(p, diskCache(filepath.Join(common.AppDir, "herespherethumbnailproxy")))
+	r.PathPrefix("/imghs/").Handler(http.StripPrefix("/imghs", hmp))
 	r.PathPrefix("/imghm/").Handler(http.StripPrefix("/imghm", hmp))
 	downloadhandler := DownloadHandler{}
 	r.PathPrefix("/download/").Handler(http.StripPrefix("/download/", downloadhandler))

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -241,5 +241,12 @@
   "Go": "Go",
   "Limit scraping to newest scenes on the website. Turn off if you are missing scenes.": "Limit scraping to newest scenes on the website. Turn off if you are missing scenes.",
   "Highlights this studio in the scene view and includes scenes in the &quot;Has subscription&quot; attribute filter": "Highlights this studio in the scene view and includes scenes in the &quot;Has subscription&quot; attribute filter",
-  "Cookies/Headers":"Cookies/Headers"
+  "Cookies/Headers":"Cookies/Headers",
+  "Tags": "Tags",
+  "Tag": "Tag",
+  "Promoted": "Promoted",
+  "Promoted tags": "Promoted tags",
+  "Tags marked as promoted will be shown as a badge under the scene thumbnail.": "Tags marked as promoted will be shown as a badge under the scene thumbnail.",
+  "Search tags": "Search tags",
+  "Failed to update tag": "Failed to update tag"
 }

--- a/ui/src/views/options/Options.vue
+++ b/ui/src/views/options/Options.vue
@@ -20,6 +20,7 @@
                          @click="setActive('funscripts')"/>
             <b-menu-item :label="$t('Data import/export')" :active="active==='data-import-export'"
                          @click="setActive('data-import-export')"/>
+            <b-menu-item :label="$t('Tags')" :active="active==='data-tags'" @click="setActive('data-tags')"/>
           </b-menu-list>
           <b-menu-list :label="$t('Interfaces')">
             <b-menu-item :label="$t('Players')" :active="active==='interface_deovr'" @click="setActive('interface_deovr')"/>
@@ -40,6 +41,7 @@
           <SceneCreate v-show="active==='create-scene'"/>
           <Funscripts v-show="active==='funscripts'"/>
           <SceneDataImportExport v-show="active==='data-import-export'"/>
+          <OptionsSceneDataTags v-show="active==='data-tags'"/>
           <InterfaceWeb v-show="active==='interface_web'"/>
           <InterfaceDLNA v-show="active==='interface_dlna'"/>
           <InterfaceDeoVR v-show="active==='interface_deovr'"/>
@@ -59,6 +61,7 @@ import SceneDataScrapers from './sections/OptionsSceneDataScrapers'
 import SceneCreate from './sections/OptionsSceneCreate'
 import Funscripts from './sections/Funscripts'
 import SceneDataImportExport from './sections/OptionsSceneDataImportExport'
+import OptionsSceneDataTags from './sections/OptionsSceneDataTags'
 import InterfaceDLNA from './sections/InterfaceDLNA.vue'
 import Cache from './sections/Cache.vue'
 import Previews from './sections/Previews.vue'
@@ -68,7 +71,7 @@ import InterfaceAdvanced from './sections/InterfaceAdvanced.vue'
 import SceneMatchParams from './overlays/SceneMatchParams.vue'
 
 export default {
-  components: { Storage, SceneDataScrapers, SceneCreate, Funscripts, SceneDataImportExport, InterfaceWeb, InterfaceDLNA, InterfaceDeoVR, Cache, Previews, Schedules, InterfaceAdvanced,SceneMatchParams },
+  components: { Storage, SceneDataScrapers, SceneCreate, Funscripts, SceneDataImportExport, OptionsSceneDataTags, InterfaceWeb, InterfaceDLNA, InterfaceDeoVR, Cache, Previews, Schedules, InterfaceAdvanced,SceneMatchParams },
   data: function () {
     return {
       active: 'storage'

--- a/ui/src/views/options/sections/OptionsSceneDataTags.vue
+++ b/ui/src/views/options/sections/OptionsSceneDataTags.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="content">
+    <h3 class="title">{{ $t('Promoted tags') }}</h3>
+    <p>{{ $t('Tags marked as promoted will be shown as a badge under the scene thumbnail.') }}</p>
+    <b-field :label="$t('Search tags')">
+      <b-input v-model="search" icon="magnify"/>
+    </b-field>
+    <b-table :data="filteredTags" :per-page="50" paginated>
+      <b-table-column field="name" :label="$t('Tag')" sortable v-slot="props">
+        {{ props.row.name }}
+      </b-table-column>
+      <b-table-column field="count" :label="$t('Scenes')" numeric sortable v-slot="props">
+        {{ props.row.count }}
+      </b-table-column>
+      <b-table-column field="is_promoted" :label="$t('Promoted')" width="120" v-slot="props">
+        <b-switch v-model="props.row.is_promoted" @input="togglePromoted(props.row)"></b-switch>
+      </b-table-column>
+    </b-table>
+  </div>
+</template>
+
+<script>
+import ky from 'ky'
+
+export default {
+  name: 'OptionsSceneDataTags',
+  data () {
+    return {
+      tags: [],
+      search: ''
+    }
+  },
+  computed: {
+    filteredTags () {
+      if (!this.search) {
+        return this.tags
+      }
+      const q = this.search.toLowerCase()
+      return this.tags.filter(t => t.name.toLowerCase().includes(q))
+    }
+  },
+  mounted () {
+    this.loadTags()
+  },
+  methods: {
+    async loadTags () {
+      try {
+        const resp = await ky.get('/api/tag/list').json()
+        this.tags = resp.tags || []
+      } catch (error) {
+        this.tags = []
+        this.$buefy.toast.open({ message: this.$t('Failed to update tag'), type: 'is-danger' })
+      }
+    },
+    togglePromoted (row) {
+      ky.post('/api/tag/promote/' + row.id, { json: { is_promoted: row.is_promoted } }).catch(() => {
+        row.is_promoted = !row.is_promoted
+        this.$buefy.toast.open({ message: this.$t('Failed to update tag'), type: 'is-danger' })
+      })
+    }
+  }
+}
+</script>

--- a/ui/src/views/scenes/SceneCard.vue
+++ b/ui/src/views/scenes/SceneCard.vue
@@ -9,6 +9,10 @@
         <video v-if="preview && item.has_preview" :src="`/api/dms/preview/${item.scene_id}`" autoplay loop></video>
         <div class="overlay align-bottom-left">
           <div style="padding: 5px">
+            <span class="promoted-tags" :class="promotedSizeClass" ref="promotedTags">
+              <b-tag type="is-primary" v-for="(tag, idx) in promotedTags" :key="tag.id" class="promoted-tag" v-show="idx < visiblePromotedCount"><b-icon pack="mdi" icon="label" size="is-small" style="margin-right:0.3em"/>{{ tag.name }}</b-tag>
+              <b-tag v-if="morePromotedCount > 0" type="is-primary" class="promoted-tag promoted-more" :title="hiddenPromotedTags.map(t => t.name).join(', ')"><b-icon pack="mdi" icon="label" size="is-small" style="margin-right:0.3em"/>+{{morePromotedCount}}</b-tag>
+            </span>
             <b-tag v-if="item.is_watched && !this.$store.state.optionsWeb.web.sceneWatched">
               <b-icon pack="mdi" icon="eye" size="is-small"/>
             </b-tag>
@@ -109,6 +113,8 @@ export default {
       parseISO,
       alternateSources: [],
       stashLinkExists: false,
+      visiblePromotedCount: 999,
+      promotedResizeTimer: null,
     }
   },
   computed: {
@@ -174,6 +180,34 @@ export default {
         return "cover"
       }
     },
+    promotedTags () {
+      if (this.item.tags == null) { return [] }
+      return this.item.tags.filter(t => t.is_promoted)
+    },
+    promotedSizeClass () {
+      switch (this.$store.state.sceneList.filters.cardSize) {
+        case '1': return 'promoted-size-xs'
+        case '2': return 'promoted-size-s'
+        case '3': return 'promoted-size-m'
+        case '4': return 'promoted-size-l'
+        default:  return 'promoted-size-s'
+      }
+    },
+    promotedMaxWidth () {
+      switch (this.$store.state.sceneList.filters.cardSize) {
+        case '1': return 80
+        case '2': return 130
+        case '3': return 200
+        case '4': return 280
+        default:  return 130
+      }
+    },
+    morePromotedCount () {
+      return Math.max(0, this.promotedTags.length - this.visiblePromotedCount)
+    },
+    hiddenPromotedTags () {
+      return this.promotedTags.slice(this.visiblePromotedCount)
+    },
     async getAlternateSceneSourcesWithTitles() {
       this.stashLinkExists = false
       try {
@@ -208,7 +242,76 @@ export default {
       }
     }
   },
+  watch: {
+    promotedTags () {
+      this.measurePromotedTags()
+    },
+    '$store.state.sceneList.filters.cardSize' () {
+      this.measurePromotedTags()
+    }
+  },
+  mounted () {
+    this.measurePromotedTags()
+    window.addEventListener('resize', this.onPromotedResize)
+  },
+  beforeDestroy () {
+    window.removeEventListener('resize', this.onPromotedResize)
+  },
   methods: {
+    onPromotedResize () {
+      if (this.promotedResizeTimer) { clearTimeout(this.promotedResizeTimer) }
+      this.promotedResizeTimer = setTimeout(() => this.measurePromotedTags(), 100)
+    },
+    measurePromotedTags () {
+      this.$nextTick(() => this.measurePromotedPass(0))
+    },
+    measurePromotedPass (iteration) {
+      if (iteration > 5) { return }
+      const span = this.$refs.promotedTags
+      if (!span) { this.visiblePromotedCount = 0; return }
+      const tags = Array.from(span.querySelectorAll('.promoted-tag')).filter(el => !el.classList.contains('promoted-more'))
+      if (tags.length === 0) { this.visiblePromotedCount = 0; return }
+      const card = span.closest('.card-image')
+      if (!card) { return }
+      const available = Math.min(this.promotedMaxWidth, card.clientWidth - 10)
+      if (available <= 0) { return }
+      span.style.maxWidth = available + 'px'
+
+      const hidden = tags.map(t => t.style.display)
+      tags.forEach(t => { t.style.display = '' })
+      const widths = tags.map(t => t.getBoundingClientRect().width)
+      const gaps = []
+      for (let i = 0; i < tags.length - 1; i++) {
+        gaps.push(tags[i + 1].getBoundingClientRect().left - tags[i].getBoundingClientRect().right)
+      }
+      const more = span.querySelector('.promoted-more')
+      const moreW = more ? more.getBoundingClientRect().width : 47
+      const moreGap = more ? (more.getBoundingClientRect().left - tags[tags.length - 1].getBoundingClientRect().right) : 4
+      tags.forEach((t, i) => { t.style.display = hidden[i] })
+
+      const prefixW = [0]
+      for (const w of widths) { prefixW.push(prefixW[prefixW.length - 1] + w) }
+      const prefixG = [0]
+      for (const g of gaps) { prefixG.push(prefixG[prefixG.length - 1] + g) }
+      const totalW = prefixW[tags.length] + prefixG[tags.length - 1]
+      let count
+      if (totalW <= available) {
+        count = tags.length
+      } else {
+        count = 0
+        if (moreW <= available) {
+          for (let k = 1; k <= tags.length; k++) {
+            const required = prefixW[k] + (k >= 2 ? prefixG[k - 2] : 0) + moreGap + moreW
+            if (required > available) { break }
+            count = k
+          }
+        }
+      }
+      if (count !== this.visiblePromotedCount) {
+        this.visiblePromotedCount = count
+        this.$nextTick(() => this.measurePromotedPass(iteration + 1))
+      }
+    },
     getImageURL (u) {
         if (u.startsWith('http') == false) {
         return u
@@ -323,6 +426,28 @@ export default {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .promoted-tags {
+    display: inline-block;
+    vertical-align: middle;
+    white-space: nowrap;
+    pointer-events: auto;
+  }
+
+  .promoted-tags.promoted-size-xs { max-width: 80px; }
+  .promoted-tags.promoted-size-s  { max-width: 130px; }
+  .promoted-tags.promoted-size-m  { max-width: 200px; }
+  .promoted-tags.promoted-size-l  { max-width: 280px; }
+
+  .promoted-tag {
+    font-weight: bold;
+    margin-right: 0.2em;
+    margin-bottom: 0.2em;
+  }
+
+  .promoted-more {
+    opacity: 0.65;
   }
 
 .heatmapFunscript {


### PR DESCRIPTION
## Summary

Promoted tags let users mark tags that stand out across the library. 

Three subfeatures:

### 1. Promoted tags

- New `is_promoted` boolean column on tags (migrations
  `0088-tag-is-promoted` and `0089-add-scene-tags-tag-id-index`), included
  in tag backups

- New API: `GET /api/tag/list` (with per-tag scene counts) and
  `POST /api/tag/promote/{id}`

- New "Tags" management section under `Options > Scene data` (searchable,
  paginated) to toggle promotion per tag

- Scene cards render an `is-primary` badge with a label icon per promoted
  tag, capped per card size with a `+N` overflow badge (tooltip lists the
  hidden tag names)

### 2. Has Promoted Tag filter

- New "Has Promoted Tag" attribute in the scene Attributes dropdown,
  server-fed from `/api/scene/filters` so no frontend change was needed;
  mapped to an `exists()` subquery, so the `!` and `&` prefixes keep
  working

### 3. HereSphere thumbnails

- `HeatmapThumbnailProxy` renamed to `HereSphereThumbnailProxy`; a single
  `/imghs/` URL serves heatmaps and promoted-tag badges on the 700x420
  thumbnail (`/imghm/` kept for back-compat)

- New pure `pkg/imgbadge` package draws up to 3 mauve pill badges plus a
  `+N` overflow badge, dropping or truncating names to fit the canvas

- The cache key includes the promoted tag names and script-file identity,
  so unpromoting tags or replacing funscripts invalidates stale composites

- Proxy cache dir renamed to `herespherethumbnailproxy`

## Notes

- Purely additive; no changes to existing scene list queries, scraping
  flows, or backup format beyond the new field

- Tested: 8 unit tests for `pkg/imgbadge`, gofmt-clean
