### PR TITLE
test: add scraper integration tests, unblock go test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,19 @@ Ask your questions and suggest features on [Discord](https://discord.gg/wdCHXAG)
 
 Make sure you have following installed:
 
-- Go 1.24
+- Go 1.25 or newer (`go.mod` requires 1.25.0, CI builds with 1.26.x)
 - Node.js 22.x
-- Yarn 1.17.x
-- air (run `go install github.com/cosmtrek/air@latest` outside project directory)
+- Yarn 1.x
+- A C compiler — the SQLite driver is cgo-based. On Debian/Ubuntu `sudo apt install build-essential`, on macOS `xcode-select --install`, on Windows a MinGW-w64 toolchain.
+- air (run `go install github.com/air-verse/air@latest` outside project directory)
 
 Once all of the above is installed, running `yarn dev` from project directory launches file-watchers providing livereload for both Go and JavaScript.
+
+To build the binary by hand, cgo and the `json1` build tag are both required:
+
+```
+CGO_ENABLED=1 go build -tags=json1 -o dist/xbvr main.go
+```
 
 ## Development in Gitpod
 
@@ -100,6 +107,27 @@ Ready to get started?
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/xbapps/xbvr)
 
+## Tests
+
+```
+go test -tags=json1 -vet=off ./...
+```
+
+`-tags=json1` is needed for the SQLite driver. `-vet=off` is currently needed because `go test` runs `go vet` first, and several pre-existing vet findings fail the build before any test gets to run.
+
+Scraper tests live in `pkg/scrape`:
+
+- `registry_test.go` runs by default and needs no network. It checks that scraper registration is intact — unique IDs, populated fields, and that every site listed in the bundled `scrapers.json` actually registers a scraper. This catches a site silently disappearing from the UI.
+- `live_test.go` makes real requests to the sites, so it is excluded unless you build with `-tags=scrapelive`. It catches what a site redesign does: selectors stop matching, the scraper emits nothing, and no error is raised anywhere.
+
+```
+export XBVR_SCRAPE_TARGETS=~/xbvr-scrape-targets.json
+go test -tags='json1 scrapelive' -vet=off ./pkg/scrape/ -run TestLiveScrape -v
+```
+
+`XBVR_SCRAPE_TARGETS` points at a JSON file kept outside the repository, listing one `{"scraper": "<id>", "url": "<scene url>"}` object per scraper you want covered. It is deliberately not checked in — the URLs are user-specific, and saved page fixtures would carry scene and performer names into the repo.
+
+If you fix a scraper after a site change, adding a target entry for it is the cheapest way to find out when that site changes again.
 
 ### How To
 
@@ -139,15 +167,15 @@ esc - closes details pane
 #### using Command Line Arguments/Environment Variables
 | Command line parameter | Environment Variable | Type | Description |
 |------------------------|--------------|------|-------------|
-| `--enableLocalStorage` | | boolean | Use local folder to store application data|
+| `--localstorage` | | boolean | Use local folder to store application data|
 |	`--app_dir` | XBVR_APPDIR | String | path to the application directory|
 |	`--cache_dir` | XBVR_CACHEDIR | String | path to the temporary scraper cache directory|
 |	`--imgproxy_dir` | XBVR_IMAGEPROXYDIR | String | path to the imageproxy directory|
 |	`--search_dir` | XBVR_SEARCHDIR | String | path to the Search Index directory|
 |	`--preview_dir` | XBVR_VIDEOPREVIEWDIR | String | path to the Scraper Cache directory|
-|	`--scriptsheatmap_dir` | XBVR_SCRIPTHEATMAPDIR | String| path to the scripts_heatmap directory|
+|	`--scripts_heatmap_dir` | XBVR_SCRIPTHEATMAPDIR | String| path to the scripts_heatmap directory|
 |	`--myfiles_dir` | XBVR_MYFILESDIR | String | path to the myfiles directory for serving users own content (eg images|
-|	`--databaseurl` | DATABASE_URL | String | override default database path|
+|	`--database_url` | DATABASE_URL | String | override default database path|
 |	`--web_port` | XBVR_WEB_PORT | Int | override default Web Page port 9999|
 |	`--ws_addr` | XBVR_WS_ADDR | String | override default Websocket address from the default 0.0.0.0:9998|
 |	`--db_connection_pool_size` | DB_CONNECTION_POOL_SIZE | Int | sets the connection pool size for mariadb databases|

--- a/pkg/common/paths.go
+++ b/pkg/common/paths.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/ProtonMail/go-appdir"
 )
@@ -57,7 +58,14 @@ func InitPaths() {
 	db_connection_pool_size := flag.Int("db_connection_pool_size", 0, "Optional: sets a limit to the number of db connections while scraping")
 	concurrentSscrapers := flag.Int("concurrent_scrapers", 0, "Optional: sets a limit to the number of concurrent scrapers")
 
-	flag.Parse()
+	// InitPaths runs from models' package init, which means it also runs inside test
+	// binaries. `go test` passes -test.* flags that this flag set does not define, and
+	// flag.Parse would abort the process before any test runs - that is why no package
+	// importing pkg/models could be tested. Under test, skip parsing and fall back to
+	// the env vars and defaults handled below.
+	if !testing.Testing() {
+		flag.Parse()
+	}
 
 	if *app_dir == "" {
 		tmp := os.Getenv("XBVR_APPDIR")

--- a/pkg/scrape/live_test.go
+++ b/pkg/scrape/live_test.go
@@ -1,0 +1,180 @@
+//go:build scrapelive
+
+// Live scraper smoke tests. Excluded from every normal build and from `go test ./...`
+// unless -tags=scrapelive is passed, because they make real requests to the sites.
+//
+// Run:
+//
+//	export XBVR_SCRAPE_TARGETS=~/xbvr-scrape-targets.json
+//	go test -tags='json1 scrapelive' -vet=off ./pkg/scrape/ -run TestLiveScrape -v
+//
+// The targets file lives OUTSIDE this repository - it holds scene URLs, which must
+// never be committed. Format:
+//
+//	[
+//	  {"scraper": "virtualrealporn", "url": "https://.../vr-porn-video/<slug>/"},
+//	  {"scraper": "povr-single_scene", "url": "https://.../vr-porn/<slug>/", "skipCast": true}
+//	]
+//
+// What this catches is the failure mode a site redesign produces: every selector stops
+// matching, the scraper emits nothing, and no error is raised anywhere. Assertions stay
+// deliberately shape-based (non-empty, plausible range) rather than comparing to exact
+// titles or performer names, so the test does not encode that content and does not break
+// when a site legitimately edits its own metadata.
+
+package scrape
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+type liveTarget struct {
+	Scraper string `json:"scraper"`
+	URL     string `json:"url"`
+	// Opt-outs for sites that legitimately omit a field.
+	SkipCast    bool `json:"skipCast"`
+	SkipTags    bool `json:"skipTags"`
+	SkipCover   bool `json:"skipCover"`
+	SkipRelease bool `json:"skipRelease"`
+}
+
+const liveScrapeTimeout = 3 * time.Minute
+
+func loadLiveTargets(t *testing.T) []liveTarget {
+	t.Helper()
+
+	path := os.Getenv("XBVR_SCRAPE_TARGETS")
+	if path == "" {
+		t.Skip("XBVR_SCRAPE_TARGETS not set - see the comment at the top of live_test.go")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var targets []liveTarget
+	if err := json.Unmarshal(raw, &targets); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if len(targets) == 0 {
+		t.Fatalf("%s contains no targets", path)
+	}
+	return targets
+}
+
+func findScraper(t *testing.T, id string) models.Scraper {
+	t.Helper()
+	for _, s := range models.GetScrapers() {
+		if s.ID == id {
+			return s
+		}
+	}
+	t.Fatalf("no scraper registered with ID %q", id)
+	return models.Scraper{}
+}
+
+// runScraperOnce drives one scraper against one scene URL and returns everything it
+// emitted. A scraper that matches nothing returns an empty slice rather than an error,
+// which is exactly the silent failure we are testing for.
+func runScraperOnce(t *testing.T, s models.Scraper, url string) []models.ScrapedScene {
+	t.Helper()
+
+	out := make(chan models.ScrapedScene, 16)
+	errc := make(chan error, 1)
+
+	var wg models.ScrapeWG
+	wg.Add(1)
+	go func() {
+		// updateSite=false so the test never writes site.LastUpdate;
+		// limitScraping=true so a single-scene run cannot walk into pagination.
+		errc <- s.Scrape(&wg, false, []string{}, out, url, "", true)
+	}()
+
+	select {
+	case err := <-errc:
+		if err != nil {
+			t.Fatalf("scraper %q returned an error: %v", s.ID, err)
+		}
+	case <-time.After(liveScrapeTimeout):
+		t.Fatalf("scraper %q timed out after %s", s.ID, liveScrapeTimeout)
+	}
+
+	close(out)
+	var scenes []models.ScrapedScene
+	for sc := range out {
+		scenes = append(scenes, sc)
+	}
+	return scenes
+}
+
+func TestLiveScrape(t *testing.T) {
+	for _, target := range loadLiveTargets(t) {
+		t.Run(target.Scraper, func(t *testing.T) {
+			s := findScraper(t, target.Scraper)
+			scenes := runScraperOnce(t, s, target.URL)
+
+			if len(scenes) == 0 {
+				t.Fatalf("scraper %q emitted no scenes for the target URL - "+
+					"selectors have most likely stopped matching after a site change", s.ID)
+			}
+			sc := scenes[0]
+
+			if sc.SceneID == "" {
+				t.Error("SceneID is empty - the scene would be dropped before reaching the DB")
+			}
+			if sc.SiteID == "" {
+				t.Error("SiteID is empty")
+			}
+			if sc.Title == "" {
+				t.Error("Title is empty")
+			}
+			if sc.HomepageURL == "" {
+				t.Error("HomepageURL is empty")
+			}
+			if len(sc.Filenames) == 0 {
+				t.Error("Filenames is empty - nothing on disk could ever match this scene")
+			}
+			if sc.Duration <= 0 || sc.Duration > 600 {
+				t.Errorf("Duration %d min is outside the plausible range", sc.Duration)
+			}
+			if !target.SkipRelease && sc.Released == "" {
+				t.Error("Released is empty")
+			}
+			if !target.SkipCover && len(sc.Covers) == 0 {
+				t.Error("Covers is empty")
+			}
+			if !target.SkipTags && len(sc.Tags) == 0 {
+				t.Error("Tags is empty")
+			}
+			if !target.SkipCast {
+				if len(sc.Cast) == 0 {
+					t.Error("Cast is empty")
+				}
+				for _, name := range sc.Cast {
+					if _, ok := sc.ActorDetails[name]; !ok {
+						t.Errorf("cast member at index %d has no matching ActorDetails entry",
+							indexOf(sc.Cast, name))
+					}
+				}
+			}
+
+			// Log shapes, never values - see the no-names rule in CLAUDE.md.
+			t.Logf("ok: %d filenames, %d tags, %d cast, %d covers, %d gallery, %d min, trailer=%s",
+				len(sc.Filenames), len(sc.Tags), len(sc.Cast), len(sc.Covers),
+				len(sc.Gallery), sc.Duration, sc.TrailerType)
+		})
+	}
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, v := range haystack {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/scrape/registry_test.go
+++ b/pkg/scrape/registry_test.go
@@ -1,0 +1,118 @@
+package scrape
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/xbapps/xbvr/pkg/config"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+// These tests are hermetic - no network, no fixtures. They guard the registration
+// wiring in each scraper's init(), which is easy to break because it is spread
+// across ~45 files and only surfaces at runtime.
+
+func TestScraperIDsAreUnique(t *testing.T) {
+	seen := map[string]string{}
+	for _, s := range models.GetScrapers() {
+		if prev, dup := seen[s.ID]; dup {
+			t.Errorf("duplicate scraper ID %q registered by both %q and %q", s.ID, prev, s.Name)
+			continue
+		}
+		seen[s.ID] = s.Name
+	}
+}
+
+func TestScraperFieldsArePopulated(t *testing.T) {
+	scrapers := models.GetScrapers()
+	if len(scrapers) == 0 {
+		t.Fatal("no scrapers registered - init() wiring is broken")
+	}
+	for _, s := range scrapers {
+		if s.ID == "" {
+			t.Errorf("scraper %q has an empty ID", s.Name)
+		}
+		if s.Name == "" {
+			t.Errorf("scraper %q has an empty Name", s.ID)
+		}
+		if s.Domain == "" {
+			t.Errorf("scraper %q has an empty Domain", s.ID)
+		}
+		if s.Scrape == nil {
+			t.Errorf("scraper %q has a nil Scrape func", s.ID)
+		}
+	}
+}
+
+// A scraper whose Domain does not reduce to a usable core domain silently loses its
+// rate limit and its per-site header/cookie config in createCollector.
+func TestScraperDomainsReduceToCoreDomain(t *testing.T) {
+	for _, s := range models.GetScrapers() {
+		if s.Domain == "" {
+			continue
+		}
+		core := GetCoreDomain(s.Domain)
+		if core == "" {
+			t.Errorf("scraper %q: domain %q reduced to an empty core domain", s.ID, s.Domain)
+		}
+		if strings.Contains(core, "/") {
+			t.Errorf("scraper %q: core domain %q still contains a path separator", s.ID, core)
+		}
+	}
+}
+
+// Site-family scrapers (POVR, SLR, StashDB, RealVR, VRPorn, VRPHub) are registered by
+// looping over the embedded scrapers.json. If an entry stops registering - a renamed
+// JSON key, a changed ID rule - the site quietly disappears from the UI with no error.
+func TestOfficialScraperListIsFullyRegistered(t *testing.T) {
+	var list config.ScraperList
+	if err := list.Load(); err != nil {
+		t.Fatalf("loading scraper list: %v", err)
+	}
+
+	registered := map[string]bool{}
+	for _, s := range models.GetScrapers() {
+		registered[s.ID] = true
+	}
+
+	families := map[string][]config.ScraperConfig{
+		"povr":    list.XbvrScrapers.PovrScrapers,
+		"slr":     list.XbvrScrapers.SlrScrapers,
+		"stashdb": list.XbvrScrapers.StashDbScrapers,
+		"realvr":  list.XbvrScrapers.RealVRScrapers,
+		"vrporn":  list.XbvrScrapers.VrpornScrapers,
+		"vrphub":  list.XbvrScrapers.VrphubScrapers,
+	}
+
+	checked := 0
+	for family, entries := range families {
+		// Some families ship with no list-driven entries (their sites are registered
+		// directly in the scraper's init instead). That is a valid state, not a failure.
+		if len(entries) == 0 {
+			t.Logf("family %q has no list-driven entries - skipping", family)
+			continue
+		}
+		checked += len(entries)
+		missing := 0
+		for _, e := range entries {
+			if e.ID == "" {
+				t.Errorf("family %q: entry with URL %q has no ID assigned", family, e.URL)
+				continue
+			}
+			if !registered[e.ID] {
+				missing++
+				if missing <= 5 {
+					t.Errorf("family %q: scrapers.json entry %q is not registered", family, e.ID)
+				}
+			}
+		}
+		if missing > 5 {
+			t.Errorf("family %q: %d entries total are not registered", family, missing)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no scrapers.json entries were checked - the embedded list failed to load")
+	}
+	t.Logf("verified %d list-driven scraper entries are registered", checked)
+}


### PR DESCRIPTION
`go test ./...` does not currently build in this repo. This fixes that and adds scraper tests on top.

## The blocker

`common.InitPaths()` runs from `models`' package `init()`, so it also runs inside every test binary. It calls `flag.Parse()` on a flag set that does not define `go test`'s `-test.*` flags, so the binary exits with a flag usage dump before any test runs:

```
flag provided but not defined: -test.testlogfile
Usage of /tmp/go-build.../scrape.test:
  -app_dir string
  ...
```

That blocks tests in every package importing `pkg/models`: `scrape`, `api`, `tasks`, `config`, `migrations`, `server`, `session`. It also silently broke the three existing test files under `pkg/dms/dlna/dms`, which imports `models` transitively — those tests have not been running.

Guarded with `testing.Testing()`. `pkg/dms/dlna/dms` passes again after this change.

## Scraper tests

**`registry_test.go`** — hermetic, no network, runs by default. Scraper registration is spread across ~45 `init()` functions and only surfaces at runtime, so this checks IDs are unique, required fields are populated, domains reduce to a usable core domain, and every list-driven entry in the embedded `scrapers.json` actually registers (79 entries today). A site dropping out of that list currently vanishes from the UI with no error anywhere.

**`live_test.go`** — real requests, excluded unless built with `-tags=scrapelive`, so `go test ./...` never touches it. It catches what a site redesign produces: every selector stops matching, the scraper emits nothing, and no error is raised — the failure mode is silence.

Verified against a scraper broken by a live site change: it fails with

```
scraper "..." emitted no scenes for the target URL - selectors have most likely
stopped matching after a site change
```

and passes once fixed. On its first run it also caught a real latent bug — `pkg/scrape` calls `image.Decode` but registers no image decoder, working only because `pkg/server` happens to import `image/jpeg` (fixed separately).

Targets come from a JSON file outside the repo named by `XBVR_SCRAPE_TARGETS`. Checked-in page fixtures would carry scene and performer names into the repository, so assertions are shape-based and the test logs counts, not values.

```
export XBVR_SCRAPE_TARGETS=~/xbvr-scrape-targets.json
go test -tags='json1 scrapelive' -vet=off ./pkg/scrape/ -run TestLiveScrape -v
```

## Docs

The documented `air` install fails outright — the module renamed itself, so `go install github.com/cosmtrek/air@latest` aborts with a module path conflict. A new contributor following the README cannot get a dev environment running.

Three documented CLI flags are rejected by the binary, verified by running it:

| README | actual |
|---|---|
| `--enableLocalStorage` | `--localstorage` |
| `--databaseurl` | `--database_url` |
| `--scriptsheatmap_dir` | `--scripts_heatmap_dir` |

The stated Go version also contradicted `go.mod` (requires 1.25.0) and CI (1.26.x), and the cgo C compiler requirement was undocumented despite being needed for the SQLite driver.

## Note

`-vet=off` is currently required to run tests: nine pre-existing vet findings across `scrape`, `tasks`, `migrations` and `dms` fail the build first. Left alone here to keep this reviewable; happy to fix them in a follow-up.
