### PR TITLE
Make missing actor restoration from scene edit history optional

### DIFF
--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -74,6 +74,7 @@ type RequestSaveOptionsAdvanced struct {
 	ScraperProxy                 string    `json:"scraperProxy"`
 	StashApiKey                  string    `json:"stashApiKey"`
 	ScrapeActorAfterScene        bool      `json:"scrapeActorAfterScene"`
+	RestoreMissingActors         bool      `json:"restoreMissingActorsFromSceneEdits"`
 	UseImperialEntry             bool      `json:"useImperialEntry"`
 	LinkScenesAfterSceneScraping bool      `json:"linkScenesAfterSceneScraping"`
 	UseAltSrcInFileMatching      bool      `json:"useAltSrcInFileMatching"`
@@ -547,6 +548,7 @@ func (i ConfigResource) saveOptionsAdvanced(req *restful.Request, resp *restful.
 	config.Config.Advanced.StashApiKey = r.StashApiKey
 	config.Config.Advanced.ScraperProxy = r.ScraperProxy
 	config.Config.Advanced.ScrapeActorAfterScene = r.ScrapeActorAfterScene
+	config.Config.Advanced.RestoreMissingActors = r.RestoreMissingActors
 	config.Config.Advanced.UseImperialEntry = r.UseImperialEntry
 	config.Config.Advanced.LinkScenesAfterSceneScraping = r.LinkScenesAfterSceneScraping
 	config.Config.Advanced.UseAltSrcInFileMatching = r.UseAltSrcInFileMatching

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ type ObjectConfig struct {
 		StashApiKey                  string    `default:"" json:"stashApiKey"`
 		ScraperProxy                 string    `default:"" json:"scraperProxy"`
 		ScrapeActorAfterScene        bool      `default:"true" json:"scrapeActorAfterScene"`
+		RestoreMissingActors         bool      `default:"true" json:"restoreMissingActorsFromSceneEdits"`
 		UseImperialEntry             bool      `default:"false" json:"useImperialEntry"`
 		ProgressTimeInterval         int       `default:"15" json:"progressTimeInterval"`
 		LinkScenesAfterSceneScraping bool      `default:"true" json:"linkScenesAfterSceneScraping"`

--- a/pkg/tasks/content.go
+++ b/pkg/tasks/content.go
@@ -254,8 +254,10 @@ func ReapplyEdits() {
 			}
 			// Reapply Cast edits
 			if a.ChangedColumn == "cast" {
-				var actor models.Actor
-				db.Where(&models.Actor{Name: strings.Replace(name, ".", "", -1)}).FirstOrCreate(&actor)
+				actor, found := findActorForEditReplay(db, strings.Replace(name, ".", "", -1))
+				if !found {
+					continue
+				}
 				if prefix == "-" {
 					db.Model(&scene).Association("Cast").Delete(&actor)
 				} else {
@@ -282,6 +284,19 @@ func ReapplyEdits() {
 		}
 	}
 	db.Model(&models.Scene{}).UpdateColumn("edits_applied", true)
+}
+
+func findActorForEditReplay(db *gorm.DB, name string) (models.Actor, bool) {
+	var actor models.Actor
+	query := db.Where(&models.Actor{Name: name})
+
+	if config.Config.Advanced.RestoreMissingActors {
+		query.FirstOrCreate(&actor)
+	} else if query.First(&actor).Error != nil {
+		return actor, false
+	}
+
+	return actor, actor.ID != 0
 }
 
 func ScrapeSingleScene(toScrape string, singleSceneURL string, singeScrapeAdditionalInfo string) models.Scene {

--- a/pkg/tasks/content_test.go
+++ b/pkg/tasks/content_test.go
@@ -1,0 +1,70 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/xbapps/xbvr/pkg/config"
+	"github.com/xbapps/xbvr/pkg/models"
+)
+
+func TestFindActorForEditReplay(t *testing.T) {
+	db, err := models.GetDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := db.AutoMigrate(&models.Actor{}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	originalSetting := config.Config.Advanced.RestoreMissingActors
+	if !originalSetting {
+		t.Fatal("expected missing actor restoration to default to enabled")
+	}
+	defer func() {
+		config.Config.Advanced.RestoreMissingActors = originalSetting
+	}()
+
+	t.Run("restores missing actors when enabled", func(t *testing.T) {
+		const name = "Hatsumi Saki enabled"
+		db.Unscoped().Where("name = ?", name).Delete(&models.Actor{})
+		config.Config.Advanced.RestoreMissingActors = true
+
+		actor, found := findActorForEditReplay(db, name)
+		if !found || actor.ID == 0 {
+			t.Fatal("expected missing actor to be restored")
+		}
+	})
+
+	t.Run("skips missing actors when disabled", func(t *testing.T) {
+		const name = "Hatsumi Saki disabled"
+		db.Unscoped().Where("name = ?", name).Delete(&models.Actor{})
+		config.Config.Advanced.RestoreMissingActors = false
+
+		if _, found := findActorForEditReplay(db, name); found {
+			t.Fatal("expected missing actor to remain deleted")
+		}
+
+		var count int
+		db.Model(&models.Actor{}).Where("name = ?", name).Count(&count)
+		if count != 0 {
+			t.Fatalf("expected no restored actor, found %d", count)
+		}
+	})
+
+	t.Run("finds existing localized actors when disabled", func(t *testing.T) {
+		const name = "初美沙希"
+		db.Unscoped().Where("name = ?", name).Delete(&models.Actor{})
+		existing := models.Actor{Name: name}
+		if err := db.Create(&existing).Error; err != nil {
+			t.Fatal(err)
+		}
+		config.Config.Advanced.RestoreMissingActors = false
+
+		actor, found := findActorForEditReplay(db, name)
+		if !found || actor.ID != existing.ID {
+			t.Fatal("expected existing localized actor to be found")
+		}
+	})
+}

--- a/ui/src/locales/en-GB.json
+++ b/ui/src/locales/en-GB.json
@@ -179,6 +179,8 @@
   "Add Cast to Aka Group. Select the Aka group and Actors to add in the Cast Filter":"Add Cast to Aka Group. Select the Aka group and Actors to add in the Cast Filter",
   "Links":"Links",
   "Actor Scrapers":"Actor Scrapers",
+  "Restore missing actors from scene edit history": "Restore missing actors from scene edit history",
+  "When reapplying saved scene edits after scraping, recreate actors referenced by Cast edit history if they no longer exist. Disable this if you intentionally delete Romaji actors and manage localized actor names yourself.": "When reapplying saved scene edits after scraping, recreate actors referenced by Cast edit history if they no longer exist. Disable this if you intentionally delete Romaji actors and manage localized actor names yourself.",
   "Age":"Age",
   "Active":"Active",
   "Nationality":"Nationality",

--- a/ui/src/store/optionsAdvanced.js
+++ b/ui/src/store/optionsAdvanced.js
@@ -8,6 +8,7 @@ const state = {
     showSceneSearchField: false,
     stashApiKey: '',
     scrapeActorAfterScene: 'true',
+    restoreMissingActorsFromSceneEdits: true,
     useImperialEntry: 'false',
     linkScenesAfterSceneScraping: true,
     useAltSrcInFileMatching: true,
@@ -37,6 +38,7 @@ const actions = {
         state.advanced.stashApiKey = data.config.advanced.stashApiKey
         state.advanced.scraperProxy = data.config.advanced.scraperProxy
         state.advanced.scrapeActorAfterScene = data.config.advanced.scrapeActorAfterScene
+        state.advanced.restoreMissingActorsFromSceneEdits = data.config.advanced.restoreMissingActorsFromSceneEdits
         state.advanced.useImperialEntry = data.config.advanced.useImperialEntry
         state.advanced.linkScenesAfterSceneScraping = data.config.advanced.linkScenesAfterSceneScraping
         state.advanced.useAltSrcInFileMatching = data.config.advanced.useAltSrcInFileMatching
@@ -57,6 +59,7 @@ const actions = {
         state.advanced.stashApiKey = data.stashApiKey
         state.advanced.scraperProxy = data.scraperProxy
         state.advanced.scrapeActorAfterScene = data.scrapeActorAfterScene
+        state.advanced.restoreMissingActorsFromSceneEdits = data.restoreMissingActorsFromSceneEdits
         state.advanced.useImperialEntry = data.useImperialEntry
         state.advanced.linkScenesAfterSceneScraping = data.linkScenesAfterSceneScraping
         state.advanced.useAltSrcInFileMatching = data.useAltSrcInFileMatching

--- a/ui/src/views/options/sections/InterfaceAdvanced.vue
+++ b/ui/src/views/options/sections/InterfaceAdvanced.vue
@@ -56,6 +56,13 @@
                 </b-switch>
               </b-tooltip>
             </b-field>
+            <b-field>
+              <b-tooltip :label="$t('When reapplying saved scene edits after scraping, recreate actors referenced by Cast edit history if they no longer exist. Disable this if you intentionally delete Romaji actors and manage localized actor names yourself.')" :delay="500" type="is-warning" multilined>
+                <b-switch v-model="restoreMissingActorsFromSceneEdits" type="is-default">
+                  {{ $t('Restore missing actors from scene edit history') }}
+                </b-switch>
+              </b-tooltip>
+            </b-field>
             <b-field :label="$t('Stashdb Api Key')" label-position="on-border">
               <b-input v-model="stashApiKey" placeholder="Visit https://discord.com/invite/2TsNFKt to sign up to Stashdb" type="password"></b-input>
             </b-field>
@@ -508,6 +515,14 @@ export default {
       set (value) {
         this.$store.state.optionsAdvanced.advanced.scrapeActorAfterScene = value
 
+      }
+    },
+    restoreMissingActorsFromSceneEdits: {
+      get () {
+        return this.$store.state.optionsAdvanced.advanced.restoreMissingActorsFromSceneEdits
+      },
+      set (value) {
+        this.$store.state.optionsAdvanced.advanced.restoreMissingActorsFromSceneEdits = value
       }
     },
     useAltSrcInFileMatching: {


### PR DESCRIPTION
## Summary

- Add an **Advanced > Actor Settings** toggle named **Restore missing actors from scene edit history**.
- Keep the option enabled by default to preserve the existing behavior.
- When disabled, `ReapplyEdits()` skips actors that no longer exist instead of recreating them with `FirstOrCreate`.
- Existing actors, including actors managed under localized names, continue to work normally.

## Motivation

Saved Cast edit history can recreate a Romaji actor record after a user intentionally deletes it and manages the performer under a localized name.

This may occur after an unrelated scrape because `ReapplyEdits()` replays historical Cast entries and previously used `FirstOrCreate`, recreating the deleted actor record.

The new option allows users to prevent that recreation without disabling the rest of the saved scene edit replay behavior.

## Backward compatibility

The option defaults to enabled, so existing installations retain the current behavior unless the user explicitly disables it.

## Testing

- Added Go tests covering:
  - the default enabled state;
  - restoring a missing actor when enabled;
  - leaving a deleted actor absent when disabled;
  - finding an existing localized actor when disabled.
- The `pkg/tasks` test binary passes.
- `pkg/api` and `pkg/config` compile checks pass.
- `npm run build` passes.

Related to #2212.

This addresses the actor resurrection portion of the issue only. It does not change scraper naming preferences or add alias-based actor resolution.
